### PR TITLE
feat: implement Story 3.7 — QuickEditSheet for fast in-room stat editing

### DIFF
--- a/_bmad-output/implementation-artifacts/3-7-quick-character-stat-editing.md
+++ b/_bmad-output/implementation-artifacts/3-7-quick-character-stat-editing.md
@@ -73,6 +73,17 @@ so that I can update my stats mid-game without navigating away from the Room Vie
 - Reuse `useRoomCharacters().update(...)` as the persistence seam.
 - Do not introduce new data services or alternate mutation flows.
 
+### Development Clarifications
+
+- The final quick-edit flow is save-driven, not live-edit-driven: draft level/power values stay local to `QuickEditSheet` and Room View stats only change after `Save`.
+- `QuickEditSheet` uses an internal render lifecycle so the parent-owned `visible` prop controls intent while the component keeps itself mounted long enough to animate out cleanly.
+- Dismissal behavior must be based on the current window height rather than a fixed pixel offset, otherwise taller devices can leave the sheet partially visible during close.
+- The backdrop is part of the sheet animation contract: it must fade with the sheet during dismissal, render fully visible on every reopen, and avoid stale opacity state across repeated presentations.
+- The visible drag affordance at the top of the sheet is the expected gesture target. Pan responder handling must be attached to the drag region rather than relying on the whole sheet surface.
+- The entrance animation must begin off-screen and settle into place to avoid Android-specific overshoot/stretch artifacts on presentation.
+- `Edit more…` requires sequential modal handoff, never simultaneous modal stacking. The quick sheet must finish clearing before `ChangeCharacterModal` is opened, especially on iOS.
+- Repeated open/close cycles were a real implementation risk for this story. The working implementation must stay stable on second and third opens across iOS and Android.
+
 ### References
 
 - [Source: _bmad-output/planning-artifacts/epics/epic-3-character-management.md#Story 3.7]
@@ -94,6 +105,7 @@ gpt-5 (Codex)
 - `cd frontend && npm run test`
 - `cd frontend && npm run tsc`
 - `cd frontend && npm run test:unit -- QuickEditSheet.test.tsx`
+- `cd frontend && npm run test:room-route`
 
 ### Completion Notes List
 
@@ -108,6 +120,12 @@ gpt-5 (Codex)
 - Added a room-route regression test covering the save-only stat update flow.
 - Fixed the quick-edit dismissal flash by preserving the sheet's off-screen translation while the modal fade-out completes.
 - Added a unit regression test covering the close-path translation state so the dismissal flash does not return.
+- Reworked the quick-edit sheet into a parent-driven visibility model with internal exit rendering so repeated opens no longer get stuck on later attempts.
+- Corrected the drag affordance so the visible handle/header region is the actual responder target for downward dismissal gestures.
+- Changed dismissal distance to use window height and tied backdrop fade timing to the sheet so the overlay no longer lingers after the sheet is off-screen.
+- Added reopen safeguards so the overlay is restored correctly on iOS when the quick sheet is opened again after dismissal.
+- Adjusted the entrance animation so Android opens from an off-screen starting state without the temporary oversize/settling artifact.
+- Fixed the `Edit more…` transition so the quick sheet clears first and the full `ChangeCharacterModal` opens only after that handoff completes.
 
 ### File List
 
@@ -123,3 +141,5 @@ gpt-5 (Codex)
 - 2026-03-30: Created Story 3.7 implementation artifact and implemented QuickEditSheet with optimistic room stat editing flow, Undo dismiss toast, and save-failure rollback feedback.
 - 2026-03-30: Revised Story 3.7 quick-edit behavior so stats stay local until save, the sheet supports drag-down dismissal, the action buttons are larger and centered under the steppers, and the Undo toast renders above the footer.
 - 2026-03-30: Fixed a QuickEditSheet dismissal animation regression where the sheet briefly flashed back on screen during modal close, and added a unit regression test for the close path.
+- 2026-03-30: Iterated on QuickEditSheet animation behavior to fix partial-dismiss states, lingering backdrop visibility, drag-handle responsiveness, and repeated-open regressions across iOS and Android.
+- 2026-03-31: Clarified Story 3.7 implementation notes to record the final save-only editing model, internal sheet render lifecycle, platform-specific animation constraints, and sequential `Edit more…` modal handoff requirements.

--- a/_bmad-output/implementation-artifacts/3-7-quick-character-stat-editing.md
+++ b/_bmad-output/implementation-artifacts/3-7-quick-character-stat-editing.md
@@ -90,15 +90,24 @@ gpt-5 (Codex)
 
 - `cd frontend && npm run tsc`
 - `cd frontend && npm run test:unit -- QuickEditSheet.test.tsx`
+- `cd frontend && npm run test:room-route`
 - `cd frontend && npm run test`
+- `cd frontend && npm run tsc`
+- `cd frontend && npm run test:unit -- QuickEditSheet.test.tsx`
 
 ### Completion Notes List
 
 - Added `QuickEditSheet` as a reusable bottom-sheet modal with 60% height, level/power steppers, 44x44 tap targets, and haptics on every stepper interaction.
 - Wired Room View to route current-player edits to QuickEditSheet while preserving ChangeCharacterModal for other characters.
-- Added optimistic local stat overrides so Room View updates immediately while editing.
-- Added dismiss-with-Undo flow (1500ms toast) and failure rollback with danger border flash.
-- Added focused unit coverage for QuickEditSheet behavior.
+- Moved quick-edit stat drafting into the sheet so Room View only changes after the player taps `Save`.
+- Added undo-after-save feedback above the footer and preserved rollback feedback on save failure.
+- Added focused unit and room-route regression coverage for the corrected quick-edit behavior.
+- Corrected the quick-edit sheet layout so the larger `Edit more…` and `Save` actions sit centered directly beneath the stepper controls.
+- Moved stat draft state into `QuickEditSheet`, so Room View stats stay unchanged until the player taps `Save`.
+- Added drag-down dismissal for the sheet and moved the `Undo` toast above the footer with a slide-in animation so it stays visible.
+- Added a room-route regression test covering the save-only stat update flow.
+- Fixed the quick-edit dismissal flash by preserving the sheet's off-screen translation while the modal fade-out completes.
+- Added a unit regression test covering the close-path translation state so the dismissal flash does not return.
 
 ### File List
 
@@ -107,7 +116,10 @@ gpt-5 (Codex)
 - frontend/app/munchkin/[roomNumber]/index.tsx
 - frontend/components/munchkin/QuickEditSheet.tsx
 - frontend/components/munchkin/QuickEditSheet.test.tsx
+- frontend/__tests__/app/munchkin/[roomNumber].test.tsx
 
 ### Change Log
 
 - 2026-03-30: Created Story 3.7 implementation artifact and implemented QuickEditSheet with optimistic room stat editing flow, Undo dismiss toast, and save-failure rollback feedback.
+- 2026-03-30: Revised Story 3.7 quick-edit behavior so stats stay local until save, the sheet supports drag-down dismissal, the action buttons are larger and centered under the steppers, and the Undo toast renders above the footer.
+- 2026-03-30: Fixed a QuickEditSheet dismissal animation regression where the sheet briefly flashed back on screen during modal close, and added a unit regression test for the close path.

--- a/_bmad-output/implementation-artifacts/3-7-quick-character-stat-editing.md
+++ b/_bmad-output/implementation-artifacts/3-7-quick-character-stat-editing.md
@@ -1,0 +1,113 @@
+# Story 3.7: Quick Character Stat Editing
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a player,
+I want to tap my character card and quickly adjust my level and power from a bottom sheet,
+so that I can update my stats mid-game without navigating away from the Room View.
+
+## Acceptance Criteria
+
+1. **Given** I am viewing the Room View
+   **When** I tap my character card
+   **Then** a `QuickEditSheet` slides up from the bottom (~60% screen height) with level and power steppers
+   **And** each stepper has +/− buttons with minimum 44×44pt tap targets
+   **And** both level and power are floored at 0 with no upper ceiling
+   **And** `Haptics.ImpactFeedbackStyle.Light` fires on every tap before save
+   **And** stat values update optimistically in the UI immediately on tap
+
+2. **Given** I make changes in the QuickEditSheet
+   **When** I tap Save
+   **Then** changes are persisted to the server
+   **And** the sheet closes and the updated stats are visible in the Room View
+
+3. **Given** I make changes and then dismiss the sheet by tapping outside
+   **When** the sheet closes
+   **Then** an Undo toast appears for 1500ms — tapping it restores the previous state
+
+4. **Given** a save request fails
+   **When** the server returns an error
+   **Then** the stat value reverts quietly with a brief `danger` border flash — no toast
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add QuickEdit bottom-sheet component and interaction controls (AC: 1)
+  - [x] Create `frontend/components/munchkin/QuickEditSheet.tsx` as a bottom modal with ~60% screen height
+  - [x] Add level/power stepper controls with 44x44 button targets
+  - [x] Trigger `Haptics.ImpactFeedbackStyle.Light` on each +/− tap
+  - [x] Floor both values at zero on decrement
+
+- [x] Task 2: Integrate quick-edit flow into Room View for current player character (AC: 1, 2)
+  - [x] Update `frontend/app/munchkin/[roomNumber]/index.tsx` to open QuickEditSheet when the current player taps their character
+  - [x] Keep non-current-player edit path using existing `ChangeCharacterModal`
+  - [x] Persist level/power via existing `update` hook flow when Save is pressed
+
+- [x] Task 3: Implement optimistic stat updates, dismiss undo, and failure revert UX (AC: 1, 3, 4)
+  - [x] Add optimistic in-memory stat overrides for immediate UI updates in list/footer
+  - [x] Add 1500ms Undo toast when dismissing the sheet with unsaved changes
+  - [x] Revert to snapshot values and flash danger border on save failure
+
+- [x] Task 4: Add tests for quick-edit behavior (AC: 1)
+  - [x] Add unit test for sheet sizing, haptics trigger, and floor-at-zero stepper behavior in `frontend/components/munchkin/QuickEditSheet.test.tsx`
+
+- [x] Task 5: Run frontend validation
+  - [x] `cd frontend && npm run tsc`
+  - [x] `cd frontend && npm run test:unit -- QuickEditSheet.test.tsx`
+  - [x] `cd frontend && npm run test`
+
+## Dev Notes
+
+### Story Foundation
+
+- Story 3.7 introduces fast in-room stat editing via a bottom sheet to reduce context switching and support active gameplay updates.
+- This story depends on Story 3.6 tap-ready card interactions and Story 3.2 route structure continuity.
+
+### Architecture Guardrails
+
+- Keep room route orchestration in `frontend/app/munchkin/[roomNumber]/index.tsx`.
+- Keep reusable UI in `frontend/components/munchkin`.
+- Reuse `useRoomCharacters().update(...)` as the persistence seam.
+- Do not introduce new data services or alternate mutation flows.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics/epic-3-character-management.md#Story 3.7]
+- [Source: frontend/app/munchkin/[roomNumber]/index.tsx]
+- [Source: frontend/components/munchkin/QuickEditSheet.tsx]
+- [Source: frontend/hooks/useCharacters.ts]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+gpt-5 (Codex)
+
+### Debug Log References
+
+- `cd frontend && npm run tsc`
+- `cd frontend && npm run test:unit -- QuickEditSheet.test.tsx`
+- `cd frontend && npm run test`
+
+### Completion Notes List
+
+- Added `QuickEditSheet` as a reusable bottom-sheet modal with 60% height, level/power steppers, 44x44 tap targets, and haptics on every stepper interaction.
+- Wired Room View to route current-player edits to QuickEditSheet while preserving ChangeCharacterModal for other characters.
+- Added optimistic local stat overrides so Room View updates immediately while editing.
+- Added dismiss-with-Undo flow (1500ms toast) and failure rollback with danger border flash.
+- Added focused unit coverage for QuickEditSheet behavior.
+
+### File List
+
+- _bmad-output/implementation-artifacts/3-7-quick-character-stat-editing.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+- frontend/app/munchkin/[roomNumber]/index.tsx
+- frontend/components/munchkin/QuickEditSheet.tsx
+- frontend/components/munchkin/QuickEditSheet.test.tsx
+
+### Change Log
+
+- 2026-03-30: Created Story 3.7 implementation artifact and implemented QuickEditSheet with optimistic room stat editing flow, Undo dismiss toast, and save-failure rollback feedback.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-03-30T00:00:00Z
+last_updated: 2026-03-30T22:24:00Z
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-03-29T22:23:39Z
+last_updated: 2026-03-30T00:00:00Z
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -63,7 +63,7 @@ development_status:
   3-4-character-details-view: done
   3-5-room-character-list: done
   3-6-updated-character-card-styling: done
-  3-7-quick-character-stat-editing: backlog
+  3-7-quick-character-stat-editing: done
   3-8-realtime-update-signal-on-character-cards: backlog
   3-9-full-character-attribute-editing: done
   3-10-unassociated-character-removal: backlog

--- a/frontend/__tests__/app/munchkin/[roomNumber].test.tsx
+++ b/frontend/__tests__/app/munchkin/[roomNumber].test.tsx
@@ -3,9 +3,15 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { userProfileContext } from '@/context/UserContext';
+import type { Character } from '@/api/characters';
 
 const mockSetStringAsync = vi.hoisted(() => vi.fn());
 const mockRoomNumber = vi.hoisted(() => ({ current: 'ROOM42' as string | string[] | undefined }));
+const mockCreateCharacter = vi.hoisted(() => vi.fn());
+const mockUpdateCharacter = vi.hoisted(() => vi.fn());
+const mockCharactersState = vi.hoisted(() => ({
+  current: [] as Character[],
+}));
 vi.mock('expo-clipboard', () => ({
   setStringAsync: mockSetStringAsync,
 }));
@@ -42,20 +48,39 @@ vi.mock('expo-router', () => ({
 
 vi.mock('@/hooks/useCharacters', () => ({
   useRoomCharacters: () => ({
-    characters: [],
-    create: vi.fn(),
-    update: vi.fn(),
+    characters: mockCharactersState.current,
+    create: mockCreateCharacter,
+    update: mockUpdateCharacter,
     isLoading: false,
     errorMessage: null,
   }),
 }));
 
 vi.mock('../../../components/munchkin/RoomCharactersList', () => ({
-  default: () => null,
+  default: ({ characters }: { characters: Character[] }) => (
+    <div>
+      {characters.map((character) => (
+        <div key={character.id}>{`${character.nickname}: ${character.level} lvl / ${character.power} str`}</div>
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock('../../../components/munchkin/CurrentCharacterFooter', () => ({
-  default: () => null,
+  default: ({
+    character,
+    onChangePress,
+  }: {
+    character: Character;
+    onChangePress: (character: Character) => void;
+  }) => (
+    <div>
+      <div>{`Footer ${character.level} lvl / ${character.power} str`}</div>
+      <button type="button" onClick={() => onChangePress(character)}>
+        Open quick edit
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('../../../app/munchkin/modal-change-caracter', () => ({
@@ -66,11 +91,36 @@ vi.mock('../../../app/munchkin/modal-create-character', () => ({
   default: () => null,
 }));
 
+vi.mock('../../../components/munchkin/QuickEditSheet', () => ({
+  default: ({
+    visible,
+    character,
+    onSave,
+  }: {
+    visible: boolean;
+    character: Character | null;
+    onSave: (stats: { level: number; power: number }) => Promise<void>;
+  }) =>
+    visible && character ? (
+      <div>
+        <div>{`Quick edit for ${character.nickname}`}</div>
+        <button type="button" onClick={() => void onSave({ level: character.level + 2, power: character.power + 1 })}>
+          Save quick edit
+        </button>
+      </div>
+    ) : null,
+}));
+
 describe('Munchkin room header', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockSetStringAsync.mockReset();
     mockSetStringAsync.mockResolvedValue(true);
+    mockCreateCharacter.mockReset();
+    mockUpdateCharacter.mockReset();
+    mockCreateCharacter.mockResolvedValue(undefined);
+    mockUpdateCharacter.mockResolvedValue(undefined);
+    mockCharactersState.current = [];
     mockRoomNumber.current = 'ROOM42';
     latestHeaderOptions.current = undefined;
   });
@@ -164,5 +214,62 @@ describe('Munchkin room header', () => {
 
     expect(mockSetStringAsync).not.toHaveBeenCalled();
     expect(screen.getByText('Copy')).toBeTruthy();
+  });
+
+  it('keeps room stats unchanged until quick edit save is pressed', async () => {
+    mockCharactersState.current = [
+      {
+        id: 'char-1',
+        roomId: 'ROOM42',
+        userId: 'user-1',
+        nickname: 'Player One',
+        avatar: 1,
+        color: '#9966FF',
+        level: 1,
+        power: 0,
+        class: [],
+        race: ['Human'],
+        gender: ['male'],
+      },
+    ];
+
+    const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
+
+    await act(async () => {
+      render(
+        <userProfileContext.Provider
+          value={{
+            userProfile: {
+              id: 'user-1',
+              nickname: 'Player One',
+              avatar: 1,
+            },
+            setUserProfile: vi.fn(),
+          }}
+        >
+          <MunchkinIndexView />
+        </userProfileContext.Provider>
+      );
+    });
+
+    expect(screen.getByText('Player One: 1 lvl / 0 str')).toBeTruthy();
+    expect(screen.getByText('Footer 1 lvl / 0 str')).toBeTruthy();
+    expect(mockUpdateCharacter).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Open quick edit' }));
+    });
+
+    expect(screen.getByText('Quick edit for Player One')).toBeTruthy();
+    expect(screen.getByText('Footer 1 lvl / 0 str')).toBeTruthy();
+    expect(mockUpdateCharacter).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save quick edit' }));
+      await Promise.resolve();
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(mockUpdateCharacter).toHaveBeenCalledWith('char-1', { level: 3, power: 1 });
   });
 });

--- a/frontend/__tests__/app/munchkin/[roomNumber].test.tsx
+++ b/frontend/__tests__/app/munchkin/[roomNumber].test.tsx
@@ -10,6 +10,11 @@ vi.mock('expo-clipboard', () => ({
   setStringAsync: mockSetStringAsync,
 }));
 
+vi.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: { Light: 'light' },
+  impactAsync: vi.fn(() => Promise.resolve()),
+}));
+
 vi.mock('react-native-safe-area-context', async () => {
   const ReactRuntime = await import('react');
 

--- a/frontend/app/munchkin/[roomNumber]/index.tsx
+++ b/frontend/app/munchkin/[roomNumber]/index.tsx
@@ -5,7 +5,7 @@ import { useRoomCharacters } from '@/hooks/useCharacters';
 import { useRoomCodeClipboard } from '@/hooks/useRoomCodeClipboard';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { Platform, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Animated, Platform, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import CurrentCharacterFooter from '../../../components/munchkin/CurrentCharacterFooter';
 import QuickEditSheet from '../../../components/munchkin/QuickEditSheet';
@@ -31,18 +31,27 @@ const MunchkinIndexView: React.FC = () => {
   const [createCharacterModalVisible, setCreateCharacterModalVisible] = useState(false);
   const [changeCharacterModalVisible, setChangeCharacterModalVisible] = useState(false);
   const [quickEditVisible, setQuickEditVisible] = useState(false);
+  const [pendingFullEditOpen, setPendingFullEditOpen] = useState(false);
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-  const [optimisticOverrides, setOptimisticOverrides] = useState<Record<string, CharacterStatsOverride>>({});
-  const [quickEditSnapshot, setQuickEditSnapshot] = useState<{ characterId: string; stats: CharacterStatsOverride } | null>(null);
   const [undoState, setUndoState] = useState<UndoState | null>(null);
   const [showUndoToast, setShowUndoToast] = useState(false);
   const [dangerFlash, setDangerFlash] = useState(false);
+  const undoToastTranslateY = useMemo(() => new Animated.Value(24), []);
 
   useEffect(() => {
     if (!showUndoToast) {
+      undoToastTranslateY.setValue(24);
       return;
     }
+
+    Animated.spring(undoToastTranslateY, {
+      toValue: 0,
+      useNativeDriver: true,
+      damping: 14,
+      stiffness: 180,
+      mass: 0.9,
+    }).start();
 
     const timer = setTimeout(() => {
       setShowUndoToast(false);
@@ -50,7 +59,7 @@ const MunchkinIndexView: React.FC = () => {
     }, 1500);
 
     return () => clearTimeout(timer);
-  }, [showUndoToast]);
+  }, [showUndoToast, undoToastTranslateY]);
 
   useEffect(() => {
     if (!dangerFlash) {
@@ -64,31 +73,14 @@ const MunchkinIndexView: React.FC = () => {
     return () => clearTimeout(timer);
   }, [dangerFlash]);
 
-  const displayCharacters = useMemo(
-    () =>
-      characters.map((character) => {
-        const override = optimisticOverrides[character.id];
-        if (!override) {
-          return character;
-        }
-
-        return {
-          ...character,
-          level: override.level,
-          power: override.power,
-        };
-      }),
-    [characters, optimisticOverrides]
-  );
-
   const selectedCharacter = useMemo(
-    () => displayCharacters.find((character) => character.id === selectedCharacterId),
-    [displayCharacters, selectedCharacterId]
+    () => characters.find((character) => character.id === selectedCharacterId),
+    [characters, selectedCharacterId]
   );
 
   const currentCharacter = useMemo(
-    () => displayCharacters.find((character) => character.userId === userProfile.id),
-    [displayCharacters, userProfile.id]
+    () => characters.find((character) => character.userId === userProfile.id),
+    [characters, userProfile.id]
   );
 
   const handleChangePress = useCallback(
@@ -96,10 +88,8 @@ const MunchkinIndexView: React.FC = () => {
       setSelectedCharacterId(character.id);
 
       if (character.userId === userProfile.id) {
-        setQuickEditSnapshot({
-          characterId: character.id,
-          stats: { level: character.level, power: character.power },
-        });
+        setShowUndoToast(false);
+        setUndoState(null);
         setQuickEditVisible(true);
         return;
       }
@@ -109,48 +99,23 @@ const MunchkinIndexView: React.FC = () => {
     [userProfile.id]
   );
 
-  const handleQuickStatsChange = useCallback(
-    (stats: CharacterStatsOverride) => {
-      if (!selectedCharacterId) {
-        return;
-      }
-
-      setOptimisticOverrides((prev) => ({
-        ...prev,
-        [selectedCharacterId]: stats,
-      }));
-    },
-    [selectedCharacterId]
-  );
-
-  const closeQuickEditWithUndo = useCallback(() => {
-    if (!selectedCharacterId || !quickEditSnapshot) {
-      setQuickEditVisible(false);
-      return;
-    }
-
-    const latest = optimisticOverrides[selectedCharacterId] ?? quickEditSnapshot.stats;
-    const changed = latest.level !== quickEditSnapshot.stats.level || latest.power !== quickEditSnapshot.stats.power;
-
+  const closeQuickEditSheet = useCallback(() => {
     setQuickEditVisible(false);
+  }, []);
 
-    if (!changed) {
+  useEffect(() => {
+    if (!pendingFullEditOpen || quickEditVisible) {
       return;
     }
 
-    setUndoState({ characterId: selectedCharacterId, previous: quickEditSnapshot.stats });
-    setShowUndoToast(true);
-  }, [optimisticOverrides, quickEditSnapshot, selectedCharacterId]);
+    setPendingFullEditOpen(false);
+    setChangeCharacterModalVisible(true);
+  }, [pendingFullEditOpen, quickEditVisible]);
 
-  const handleQuickEditSave = useCallback(async () => {
-    if (!selectedCharacter || !selectedCharacterId || !quickEditSnapshot) {
+  const handleQuickEditSave = useCallback(async (stats: CharacterStatsOverride) => {
+    if (!selectedCharacter || !selectedCharacterId) {
       return;
     }
-
-    const stats = optimisticOverrides[selectedCharacterId] ?? {
-      level: selectedCharacter.level,
-      power: selectedCharacter.power,
-    };
 
     try {
       setActionError(null);
@@ -159,40 +124,37 @@ const MunchkinIndexView: React.FC = () => {
         power: stats.power,
       });
       setQuickEditVisible(false);
-      setQuickEditSnapshot(null);
-      setOptimisticOverrides((prev) => {
-        const next = { ...prev };
-        delete next[selectedCharacter.id];
-        return next;
+      setUndoState({
+        characterId: selectedCharacter.id,
+        previous: { level: selectedCharacter.level, power: selectedCharacter.power },
       });
-      setShowUndoToast(false);
-      setUndoState(null);
+      setShowUndoToast(true);
     } catch (error) {
       setDangerFlash(true);
       setActionError(error instanceof Error ? error.message : 'Failed to update character stats');
-      setOptimisticOverrides((prev) => ({
-        ...prev,
-        [selectedCharacter.id]: quickEditSnapshot.stats,
-      }));
+      setShowUndoToast(false);
+      setUndoState(null);
     }
-  }, [optimisticOverrides, quickEditSnapshot, selectedCharacter, selectedCharacterId, update]);
+  }, [selectedCharacter, selectedCharacterId, update]);
 
   const handleQuickEditUndo = useCallback(() => {
     if (!undoState) {
       return;
     }
-
-    setOptimisticOverrides((prev) => ({
-      ...prev,
-      [undoState.characterId]: undoState.previous,
-    }));
     setShowUndoToast(false);
     setUndoState(null);
-  }, [undoState]);
+
+    void update(undoState.characterId, {
+      level: undoState.previous.level,
+      power: undoState.previous.power,
+    }).catch((error) => {
+      setActionError(error instanceof Error ? error.message : 'Failed to undo character stats');
+    });
+  }, [undoState, update]);
 
   const handleOpenFullEdit = useCallback(() => {
+    setPendingFullEditOpen(true);
     setQuickEditVisible(false);
-    setChangeCharacterModalVisible(true);
   }, []);
 
   const handleCopyRoomCodePress = useCallback(() => {
@@ -228,7 +190,7 @@ const MunchkinIndexView: React.FC = () => {
           />
 
           <RoomCharactersList
-            characters={displayCharacters}
+            characters={characters}
             isLoading={isLoading}
             errorMessage={errorMessage}
             actionError={actionError}
@@ -301,19 +263,18 @@ const MunchkinIndexView: React.FC = () => {
           <QuickEditSheet
             visible={quickEditVisible}
             character={selectedCharacter ?? null}
-            onStatsChange={handleQuickStatsChange}
             onSave={handleQuickEditSave}
-            onClose={closeQuickEditWithUndo}
+            onClose={closeQuickEditSheet}
             onOpenFullEdit={handleOpenFullEdit}
             hasErrorFlash={dangerFlash}
           />
 
           {showUndoToast && undoState && (
-            <View style={styles.undoToastWrapper} pointerEvents="box-none">
+            <Animated.View style={[styles.undoToastWrapper, { transform: [{ translateY: undoToastTranslateY }] }]} pointerEvents="box-none">
               <Pressable style={styles.undoToast} onPress={handleQuickEditUndo}>
                 <Text style={styles.undoToastText}>Undo</Text>
               </Pressable>
-            </View>
+            </Animated.View>
           )}
         </View>
       </SafeAreaView>
@@ -402,7 +363,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     right: 0,
-    bottom: AppTheme.spacing.xl,
+    bottom: 96,
     alignItems: 'center',
   },
   undoToast: {

--- a/frontend/app/munchkin/[roomNumber]/index.tsx
+++ b/frontend/app/munchkin/[roomNumber]/index.tsx
@@ -4,13 +4,21 @@ import { userProfileContext } from '@/context/UserContext';
 import { useRoomCharacters } from '@/hooks/useCharacters';
 import { useRoomCodeClipboard } from '@/hooks/useRoomCodeClipboard';
 import { Stack, useLocalSearchParams } from 'expo-router';
-import React, { useCallback, useContext, useMemo, useState } from 'react';
-import { Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { Platform, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import CurrentCharacterFooter from '../../../components/munchkin/CurrentCharacterFooter';
+import QuickEditSheet from '../../../components/munchkin/QuickEditSheet';
 import RoomCharactersList from '../../../components/munchkin/RoomCharactersList';
 import ChangeCharacterModal from '../modal-change-caracter';
 import CreateCharacterModal from '../modal-create-character';
+
+type CharacterStatsOverride = { level: number; power: number };
+
+type UndoState = {
+  characterId: string;
+  previous: CharacterStatsOverride;
+};
 
 const MunchkinIndexView: React.FC = () => {
   const { roomNumber } = useLocalSearchParams<{ roomNumber: string }>();
@@ -20,17 +28,170 @@ const MunchkinIndexView: React.FC = () => {
   const { characters, create, update, isLoading, errorMessage } = useRoomCharacters(roomId, userProfile);
   const { buttonLabel, accessibilityLabel, copyRoomCode } = useRoomCodeClipboard(roomCode);
 
-  const currentCharacter = useMemo(
-    () => characters.find((character) => character.userId === userProfile.id),
-    [characters, userProfile.id]
-  );
   const [createCharacterModalVisible, setCreateCharacterModalVisible] = useState(false);
   const [changeCharacterModalVisible, setChangeCharacterModalVisible] = useState(false);
-  const [selectedCharacter, setSelectedCharacter] = useState<RoomCharacter | undefined>(undefined);
+  const [quickEditVisible, setQuickEditVisible] = useState(false);
+  const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [optimisticOverrides, setOptimisticOverrides] = useState<Record<string, CharacterStatsOverride>>({});
+  const [quickEditSnapshot, setQuickEditSnapshot] = useState<{ characterId: string; stats: CharacterStatsOverride } | null>(null);
+  const [undoState, setUndoState] = useState<UndoState | null>(null);
+  const [showUndoToast, setShowUndoToast] = useState(false);
+  const [dangerFlash, setDangerFlash] = useState(false);
 
-  const handleChangePress = useCallback((character: RoomCharacter) => {
-    setSelectedCharacter(character);
+  useEffect(() => {
+    if (!showUndoToast) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setShowUndoToast(false);
+      setUndoState(null);
+    }, 1500);
+
+    return () => clearTimeout(timer);
+  }, [showUndoToast]);
+
+  useEffect(() => {
+    if (!dangerFlash) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setDangerFlash(false);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [dangerFlash]);
+
+  const displayCharacters = useMemo(
+    () =>
+      characters.map((character) => {
+        const override = optimisticOverrides[character.id];
+        if (!override) {
+          return character;
+        }
+
+        return {
+          ...character,
+          level: override.level,
+          power: override.power,
+        };
+      }),
+    [characters, optimisticOverrides]
+  );
+
+  const selectedCharacter = useMemo(
+    () => displayCharacters.find((character) => character.id === selectedCharacterId),
+    [displayCharacters, selectedCharacterId]
+  );
+
+  const currentCharacter = useMemo(
+    () => displayCharacters.find((character) => character.userId === userProfile.id),
+    [displayCharacters, userProfile.id]
+  );
+
+  const handleChangePress = useCallback(
+    (character: RoomCharacter) => {
+      setSelectedCharacterId(character.id);
+
+      if (character.userId === userProfile.id) {
+        setQuickEditSnapshot({
+          characterId: character.id,
+          stats: { level: character.level, power: character.power },
+        });
+        setQuickEditVisible(true);
+        return;
+      }
+
+      setChangeCharacterModalVisible(true);
+    },
+    [userProfile.id]
+  );
+
+  const handleQuickStatsChange = useCallback(
+    (stats: CharacterStatsOverride) => {
+      if (!selectedCharacterId) {
+        return;
+      }
+
+      setOptimisticOverrides((prev) => ({
+        ...prev,
+        [selectedCharacterId]: stats,
+      }));
+    },
+    [selectedCharacterId]
+  );
+
+  const closeQuickEditWithUndo = useCallback(() => {
+    if (!selectedCharacterId || !quickEditSnapshot) {
+      setQuickEditVisible(false);
+      return;
+    }
+
+    const latest = optimisticOverrides[selectedCharacterId] ?? quickEditSnapshot.stats;
+    const changed = latest.level !== quickEditSnapshot.stats.level || latest.power !== quickEditSnapshot.stats.power;
+
+    setQuickEditVisible(false);
+
+    if (!changed) {
+      return;
+    }
+
+    setUndoState({ characterId: selectedCharacterId, previous: quickEditSnapshot.stats });
+    setShowUndoToast(true);
+  }, [optimisticOverrides, quickEditSnapshot, selectedCharacterId]);
+
+  const handleQuickEditSave = useCallback(async () => {
+    if (!selectedCharacter || !selectedCharacterId || !quickEditSnapshot) {
+      return;
+    }
+
+    const stats = optimisticOverrides[selectedCharacterId] ?? {
+      level: selectedCharacter.level,
+      power: selectedCharacter.power,
+    };
+
+    try {
+      setActionError(null);
+      await update(selectedCharacter.id, {
+        level: stats.level,
+        power: stats.power,
+      });
+      setQuickEditVisible(false);
+      setQuickEditSnapshot(null);
+      setOptimisticOverrides((prev) => {
+        const next = { ...prev };
+        delete next[selectedCharacter.id];
+        return next;
+      });
+      setShowUndoToast(false);
+      setUndoState(null);
+    } catch (error) {
+      setDangerFlash(true);
+      setActionError(error instanceof Error ? error.message : 'Failed to update character stats');
+      setOptimisticOverrides((prev) => ({
+        ...prev,
+        [selectedCharacter.id]: quickEditSnapshot.stats,
+      }));
+    }
+  }, [optimisticOverrides, quickEditSnapshot, selectedCharacter, selectedCharacterId, update]);
+
+  const handleQuickEditUndo = useCallback(() => {
+    if (!undoState) {
+      return;
+    }
+
+    setOptimisticOverrides((prev) => ({
+      ...prev,
+      [undoState.characterId]: undoState.previous,
+    }));
+    setShowUndoToast(false);
+    setUndoState(null);
+  }, [undoState]);
+
+  const handleOpenFullEdit = useCallback(() => {
+    setQuickEditVisible(false);
     setChangeCharacterModalVisible(true);
   }, []);
 
@@ -42,21 +203,14 @@ const MunchkinIndexView: React.FC = () => {
 
   return (
     <SafeAreaProvider key={`room-${roomNumber}`}>
-      <SafeAreaView style={{
-        flex: 1,
-        backgroundColor: AppTheme.colors.background,
-      }} edges={Platform.OS === "ios" ? [] : ["top", "bottom", "left", "right"]}>
+      <SafeAreaView style={styles.safeArea} edges={Platform.OS === 'ios' ? [] : ['top', 'bottom', 'left', 'right']}>
         <View style={styles.container}>
           <Stack.Screen
             options={{
               headerTitle: () => (
                 <View style={styles.headerTitleRow}>
                   <Text style={styles.headerRoomLabel}>Room</Text>
-                  <Text
-                    style={styles.headerRoomCode}
-                    numberOfLines={1}
-                    ellipsizeMode="middle"
-                  >
+                  <Text style={styles.headerRoomCode} numberOfLines={1} ellipsizeMode="middle">
                     {roomCode}
                   </Text>
                   <TouchableOpacity
@@ -74,7 +228,7 @@ const MunchkinIndexView: React.FC = () => {
           />
 
           <RoomCharactersList
-            characters={characters}
+            characters={displayCharacters}
             isLoading={isLoading}
             errorMessage={errorMessage}
             actionError={actionError}
@@ -82,9 +236,7 @@ const MunchkinIndexView: React.FC = () => {
             onChangePress={handleChangePress}
           />
 
-          {/* Bottom Action Buttons */}
           <View style={styles.actionButtons}>
-            {/* TODO: Not implemented yet */}
             <TouchableOpacity style={[styles.battleButton, { opacity: 0 }]}>
               <Text style={styles.battleButtonText}>Battle</Text>
             </TouchableOpacity>
@@ -93,13 +245,8 @@ const MunchkinIndexView: React.FC = () => {
             </TouchableOpacity>
           </View>
 
-          {/* Current Character Footer */}
           {currentCharacter && (
-            <CurrentCharacterFooter
-              key={`own-char-${currentCharacter.id}`}
-              character={currentCharacter}
-              onChangePress={handleChangePress}
-            />
+            <CurrentCharacterFooter key={`own-char-${currentCharacter.id}`} character={currentCharacter} onChangePress={handleChangePress} />
           )}
 
           <CreateCharacterModal
@@ -116,7 +263,7 @@ const MunchkinIndexView: React.FC = () => {
                   power: 0,
                   race: character.race,
                   gender: character.gender,
-                  class: character.class
+                  class: character.class,
                 });
                 setCreateCharacterModalVisible(false);
               } catch (error) {
@@ -126,7 +273,7 @@ const MunchkinIndexView: React.FC = () => {
             onCancel={() => setCreateCharacterModalVisible(false)}
           />
 
-          {changeCharacterModalVisible &&
+          {changeCharacterModalVisible && selectedCharacter && (
             <ChangeCharacterModal
               character={selectedCharacter}
               onConfirm={async (character) => {
@@ -140,7 +287,7 @@ const MunchkinIndexView: React.FC = () => {
                     power: character.power,
                     race: character.race,
                     gender: character.gender,
-                    class: character.class
+                    class: character.class,
                   });
                   setChangeCharacterModalVisible(false);
                 } catch (error) {
@@ -149,7 +296,25 @@ const MunchkinIndexView: React.FC = () => {
               }}
               onCancel={() => setChangeCharacterModalVisible(false)}
             />
-          }
+          )}
+
+          <QuickEditSheet
+            visible={quickEditVisible}
+            character={selectedCharacter ?? null}
+            onStatsChange={handleQuickStatsChange}
+            onSave={handleQuickEditSave}
+            onClose={closeQuickEditWithUndo}
+            onOpenFullEdit={handleOpenFullEdit}
+            hasErrorFlash={dangerFlash}
+          />
+
+          {showUndoToast && undoState && (
+            <View style={styles.undoToastWrapper} pointerEvents="box-none">
+              <Pressable style={styles.undoToast} onPress={handleQuickEditUndo}>
+                <Text style={styles.undoToastText}>Undo</Text>
+              </Pressable>
+            </View>
+          )}
         </View>
       </SafeAreaView>
     </SafeAreaProvider>
@@ -157,6 +322,10 @@ const MunchkinIndexView: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: AppTheme.colors.background,
+  },
   container: {
     flex: 1,
     backgroundColor: AppTheme.colors.elevated,
@@ -228,6 +397,25 @@ const styles = StyleSheet.create({
     fontSize: 32,
     fontWeight: '400',
     color: AppTheme.colors.textPrimary,
+  },
+  undoToastWrapper: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: AppTheme.spacing.xl,
+    alignItems: 'center',
+  },
+  undoToast: {
+    paddingHorizontal: AppTheme.spacing.lg,
+    paddingVertical: AppTheme.spacing.sm,
+    borderRadius: AppTheme.radius.pill,
+    backgroundColor: AppTheme.colors.surfaceSubtle,
+    borderWidth: 1,
+    borderColor: AppTheme.colors.accent,
+  },
+  undoToastText: {
+    color: AppTheme.colors.textPrimary,
+    ...AppTheme.typography.labelMd,
   },
 });
 

--- a/frontend/components/munchkin/AttributeList.tsx
+++ b/frontend/components/munchkin/AttributeList.tsx
@@ -3,7 +3,7 @@ import { AppTheme } from '@/constants/theme';
 import React, { memo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
-const ATTRIBUTES: Array<'race' | 'gender' | 'class'> = ['race', 'gender', 'class'];
+const ATTRIBUTES: ('race' | 'gender' | 'class')[] = ['race', 'gender', 'class'];
 
 interface AttributeListProps {
   character: RoomCharacter;

--- a/frontend/components/munchkin/NativePicker.ios.tsx
+++ b/frontend/components/munchkin/NativePicker.ios.tsx
@@ -1,0 +1,56 @@
+import { Host, Picker as SwiftUIPicker, Text as SwiftUIText } from '@expo/ui/swift-ui';
+import { aspectRatio, font, foregroundStyle, pickerStyle, tag } from '@expo/ui/swift-ui/modifiers';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+type NativePickerProps = {
+  selectedValue: string;
+  onValueChange: (value: string) => void;
+  options: string[];
+  pickerKey: string;
+};
+
+export default function NativePicker({
+  selectedValue,
+  onValueChange,
+  options,
+  pickerKey,
+}: NativePickerProps) {
+  return (
+    <Host matchContents={{ vertical: true, horizontal: false }} style={styles.swiftUIHost}>
+      <SwiftUIPicker modifiers={[pickerStyle('menu')]} selection={selectedValue} onSelectionChange={onValueChange}>
+        <SwiftUIText
+          modifiers={[
+            tag('<Select>'),
+            aspectRatio({ contentMode: 'fit', ratio: 1 }),
+            foregroundStyle('#000000'),
+            font({ size: 20 }),
+          ]}
+        >
+          {'<Select>'}
+        </SwiftUIText>
+        {options.map((option) => (
+          <SwiftUIText
+            key={`${pickerKey}-${option}`}
+            modifiers={[
+              tag(option),
+              aspectRatio({ contentMode: 'fit', ratio: 1 }),
+              foregroundStyle('#000000'),
+              font({ size: 20 }),
+            ]}
+          >
+            {option}
+          </SwiftUIText>
+        ))}
+      </SwiftUIPicker>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  swiftUIHost: {
+    width: '100%',
+    maxHeight: 40,
+    backgroundColor: '#DFDFDF',
+  },
+});

--- a/frontend/components/munchkin/NativePicker.tsx
+++ b/frontend/components/munchkin/NativePicker.tsx
@@ -1,6 +1,5 @@
 import { Picker } from '@react-native-picker/picker';
 import React from 'react';
-import { Platform, StyleSheet } from 'react-native';
 
 type NativePickerProps = {
   selectedValue: string;
@@ -15,54 +14,6 @@ export default function NativePicker({
   options,
   pickerKey,
 }: NativePickerProps) {
-  if (Platform.OS === 'ios') {
-    const { Host, Picker: SwiftUIPicker, Text: SwiftUIText } = require('@expo/ui/swift-ui');
-    const {
-      aspectRatio,
-      font,
-      foregroundStyle,
-      pickerStyle,
-      tag,
-    } = require('@expo/ui/swift-ui/modifiers');
-
-    return (
-      <Host
-        matchContents={{ vertical: true, horizontal: false }}
-        style={styles.swiftUIHost}
-      >
-        <SwiftUIPicker
-          modifiers={[pickerStyle('menu')]}
-          selection={selectedValue}
-          onSelectionChange={onValueChange}
-        >
-          <SwiftUIText
-            modifiers={[
-              tag('<Select>'),
-              aspectRatio({ contentMode: 'fit', ratio: 1 }),
-              foregroundStyle('#000000'),
-              font({ size: 20 }),
-            ]}
-          >
-            {'<Select>'}
-          </SwiftUIText>
-          {options.map((option) => (
-            <SwiftUIText
-              key={`${pickerKey}-${option}`}
-              modifiers={[
-                tag(option),
-                aspectRatio({ contentMode: 'fit', ratio: 1 }),
-                foregroundStyle('#000000'),
-                font({ size: 20 }),
-              ]}
-            >
-              {option}
-            </SwiftUIText>
-          ))}
-        </SwiftUIPicker>
-      </Host>
-    );
-  }
-
   return (
     <Picker selectedValue={selectedValue} onValueChange={onValueChange}>
       <Picker.Item label="<Select>" value="<Select>" />
@@ -72,11 +23,3 @@ export default function NativePicker({
     </Picker>
   );
 }
-
-const styles = StyleSheet.create({
-  swiftUIHost: {
-    width: '100%',
-    maxHeight: 40,
-    backgroundColor: '#DFDFDF',
-  },
-});

--- a/frontend/components/munchkin/QuickEditSheet.test.tsx
+++ b/frontend/components/munchkin/QuickEditSheet.test.tsx
@@ -1,0 +1,82 @@
+import { Character } from '@/api/characters';
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { TouchableOpacity } from 'react-native';
+import { describe, expect, it, vi } from 'vitest';
+
+import QuickEditSheet from './QuickEditSheet';
+
+const mockImpactAsync = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: {
+    Light: 'light',
+  },
+  impactAsync: mockImpactAsync,
+}));
+
+
+vi.mock('react-native', async () => {
+  const actual = await vi.importActual<typeof import('react-native')>('react-native');
+  return {
+    ...actual,
+    Modal: ({ children }: { children?: React.ReactNode }) => children,
+  };
+});
+const baseCharacter: Character = {
+  id: 'char-1',
+  roomId: 'room-1',
+  userId: 'user-1',
+  nickname: 'Rogue',
+  avatar: 0,
+  color: '#AABBCC',
+  level: 5,
+  power: 3,
+  class: ['Thief'],
+  race: ['Human'],
+  gender: ['Female'],
+};
+
+describe('QuickEditSheet', () => {
+  it('renders a 60% bottom sheet and applies floor zero on steppers', async () => {
+    const onStatsChange = vi.fn();
+
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onStatsChange={onStatsChange}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const sheet = renderer!.root.findByProps({ testID: 'quick-edit-sheet' });
+    expect(sheet.props.style[0].height).toBe('60%');
+
+    const buttons = renderer!.root.findAllByType(TouchableOpacity);
+
+    await act(async () => {
+      buttons[0].props.onPress();
+    });
+
+    expect(onStatsChange).toHaveBeenCalledWith({ level: 4, power: 3 });
+    expect(mockImpactAsync).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      buttons[0].props.onPress();
+      buttons[0].props.onPress();
+      buttons[0].props.onPress();
+      buttons[0].props.onPress();
+      buttons[0].props.onPress();
+    });
+
+    const updates = onStatsChange.mock.calls.map(([value]) => value.level);
+    expect(Math.min(...updates)).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/frontend/components/munchkin/QuickEditSheet.test.tsx
+++ b/frontend/components/munchkin/QuickEditSheet.test.tsx
@@ -1,12 +1,28 @@
 import { Character } from '@/api/characters';
 import React from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { TouchableOpacity } from 'react-native';
+import { Dimensions, TouchableOpacity } from 'react-native';
 import { describe, expect, it, vi } from 'vitest';
 
 import QuickEditSheet from './QuickEditSheet';
 
 const mockImpactAsync = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const mockAnimatedTiming = vi.hoisted(() =>
+  vi.fn((value: { setValue: (nextValue: number) => void }, config: { toValue: number }) => ({
+    start: (callback?: (result: { finished: boolean }) => void) => {
+      value.setValue(config.toValue);
+      callback?.({ finished: true });
+    },
+  }))
+);
+const mockAnimatedParallel = vi.hoisted(() =>
+  vi.fn((animations: Array<{ start: (callback?: (result: { finished: boolean }) => void) => void }>) => ({
+    start: (callback?: (result: { finished: boolean }) => void) => {
+      animations.forEach((animation) => animation.start());
+      callback?.({ finished: true });
+    },
+  }))
+);
 
 vi.mock('expo-haptics', () => ({
   ImpactFeedbackStyle: {
@@ -20,6 +36,11 @@ vi.mock('react-native', async () => {
   const actual = await vi.importActual<typeof import('react-native')>('react-native');
   return {
     ...actual,
+    Animated: {
+      ...actual.Animated,
+      parallel: mockAnimatedParallel,
+      timing: mockAnimatedTiming,
+    },
     Modal: ({ children }: { children?: React.ReactNode }) => children,
   };
 });
@@ -38,8 +59,136 @@ const baseCharacter: Character = {
 };
 
 describe('QuickEditSheet', () => {
-  it('renders a 60% bottom sheet and applies floor zero on steppers', async () => {
-    const onStatsChange = vi.fn();
+  it('exposes the top drag affordance as the movable gesture target', async () => {
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const dragArea = renderer!.root.findByProps({ testID: 'quick-edit-drag-area' });
+
+    expect(dragArea.props.onStartShouldSetResponder).toBeTypeOf('function');
+    expect(dragArea.props.onMoveShouldSetResponder).toBeTypeOf('function');
+    expect(dragArea.props.onResponderMove).toBeTypeOf('function');
+    expect(dragArea.props.onResponderRelease).toBeTypeOf('function');
+  });
+
+  it('keeps the sheet translated off-screen while the modal closes', async () => {
+    const onClose = vi.fn();
+    const dismissOffset = Dimensions.get('window').height;
+
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={onClose}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const overlay = renderer!.root.findByProps({ testID: 'quick-edit-overlay' });
+    await act(async () => {
+      overlay.props.onPress();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const overlayBackdropBeforeClose = renderer!.root.findByProps({ testID: 'quick-edit-overlay-backdrop' });
+    expect(overlayBackdropBeforeClose.props.style[1].opacity).toBeDefined();
+
+    const sheetBeforeClose = renderer!.root.findByProps({ testID: 'quick-edit-sheet' });
+    const translateYBeforeClose = sheetBeforeClose.props.style[2].transform[0].translateY;
+    expect(translateYBeforeClose.__getValue()).toBe(dismissOffset);
+
+    await act(async () => {
+      renderer!.update(
+        <QuickEditSheet
+          visible={false}
+          character={baseCharacter}
+          onClose={onClose}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const sheetAfterClose = renderer!.root.findByProps({ testID: 'quick-edit-sheet' });
+    const translateYAfterClose = sheetAfterClose.props.style[2].transform[0].translateY;
+    expect(translateYAfterClose.__getValue()).toBe(dismissOffset);
+
+    const overlayBackdropAfterClose = renderer!.root.findByProps({ testID: 'quick-edit-overlay-backdrop' });
+    expect(overlayBackdropAfterClose.props.style[1].opacity).toBeDefined();
+  });
+
+  it('shows the overlay immediately when reopening after a dismiss', async () => {
+    const onClose = vi.fn();
+
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={onClose}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const overlay = renderer!.root.findByProps({ testID: 'quick-edit-overlay' });
+    await act(async () => {
+      overlay.props.onPress();
+    });
+
+    await act(async () => {
+      renderer!.update(
+        <QuickEditSheet
+          visible={false}
+          character={baseCharacter}
+          onClose={onClose}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    await act(async () => {
+      renderer!.update(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={onClose}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const overlayBackdrop = renderer!.root.findByProps({ testID: 'quick-edit-overlay-backdrop' });
+    expect(overlayBackdrop.props.style[1].opacity).toBe(1);
+  });
+
+  it('dismisses the quick sheet before opening the full edit modal', async () => {
+    const onOpenFullEdit = vi.fn();
 
     let renderer: any;
     await act(async () => {
@@ -48,8 +197,34 @@ describe('QuickEditSheet', () => {
           visible
           character={baseCharacter}
           onClose={vi.fn()}
-          onStatsChange={onStatsChange}
           onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={onOpenFullEdit}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const buttons = renderer!.root.findAllByType(TouchableOpacity);
+    const editMoreButton = buttons[4];
+
+    await act(async () => {
+      editMoreButton.props.onPress();
+    });
+
+    expect(onOpenFullEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a 60% bottom sheet, keeps larger centered actions, and applies floor zero on steppers', async () => {
+    const onSave = vi.fn(async () => undefined);
+
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={onSave}
           onOpenFullEdit={vi.fn()}
           hasErrorFlash={false}
         />
@@ -60,12 +235,17 @@ describe('QuickEditSheet', () => {
     expect(sheet.props.style[0].height).toBe('60%');
 
     const buttons = renderer!.root.findAllByType(TouchableOpacity);
+    const editMoreButton = buttons[4];
+    const saveButton = buttons[5];
+
+    expect(editMoreButton.props.style.width).toBe('100%');
+    expect(editMoreButton.props.style.maxWidth).toBe(280);
+    expect(saveButton.props.style.minHeight).toBe(56);
 
     await act(async () => {
       buttons[0].props.onPress();
     });
 
-    expect(onStatsChange).toHaveBeenCalledWith({ level: 4, power: 3 });
     expect(mockImpactAsync).toHaveBeenCalledTimes(1);
 
     await act(async () => {
@@ -76,7 +256,10 @@ describe('QuickEditSheet', () => {
       buttons[0].props.onPress();
     });
 
-    const updates = onStatsChange.mock.calls.map(([value]) => value.level);
-    expect(Math.min(...updates)).toBeGreaterThanOrEqual(0);
+    await act(async () => {
+      saveButton.props.onPress();
+    });
+
+    expect(onSave).toHaveBeenCalledWith({ level: 0, power: 3 });
   });
 });

--- a/frontend/components/munchkin/QuickEditSheet.test.tsx
+++ b/frontend/components/munchkin/QuickEditSheet.test.tsx
@@ -16,7 +16,7 @@ const mockAnimatedTiming = vi.hoisted(() =>
   }))
 );
 const mockAnimatedParallel = vi.hoisted(() =>
-  vi.fn((animations: Array<{ start: (callback?: (result: { finished: boolean }) => void) => void }>) => ({
+  vi.fn((animations: { start: (callback?: (result: { finished: boolean }) => void) => void }[]) => ({
     start: (callback?: (result: { finished: boolean }) => void) => {
       animations.forEach((animation) => animation.start());
       callback?.({ finished: true });

--- a/frontend/components/munchkin/QuickEditSheet.tsx
+++ b/frontend/components/munchkin/QuickEditSheet.tsx
@@ -2,7 +2,7 @@ import { Character as RoomCharacter } from '@/api/characters';
 import { AppTheme } from '@/constants/theme';
 import * as Haptics from 'expo-haptics';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Modal, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Animated, Dimensions, Modal, PanResponder, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 type QuickEditStats = {
   level: number;
@@ -13,8 +13,7 @@ interface QuickEditSheetProps {
   visible: boolean;
   character: RoomCharacter | null;
   onClose: () => void;
-  onStatsChange: (stats: QuickEditStats) => void;
-  onSave: () => Promise<void>;
+  onSave: (stats: QuickEditStats) => Promise<void>;
   onOpenFullEdit: () => void;
   hasErrorFlash: boolean;
 }
@@ -27,26 +26,94 @@ export default function QuickEditSheet({
   visible,
   character,
   onClose,
-  onStatsChange,
   onSave,
   onOpenFullEdit,
   hasErrorFlash,
 }: QuickEditSheetProps) {
+  const [isRendered, setIsRendered] = useState(visible);
   const [isSaving, setIsSaving] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const [draftStats, setDraftStats] = useState<QuickEditStats>({ level: 0, power: 0 });
+  const translateY = useMemo(() => new Animated.Value(0), []);
+  const backdropOpacity = useMemo(() => new Animated.Value(1), []);
+  const dismissOffset = useMemo(() => Dimensions.get('window').height, []);
+  const shouldSetDragResponder = useCallback(
+    (dx: number, dy: number) => Math.abs(dy) > Math.abs(dx) && dy > 4,
+    []
+  );
+
+  useEffect(() => {
+    const nextStats = {
+      level: character?.level ?? 0,
+      power: character?.power ?? 0,
+    };
+
+    if (!visible) {
+      setIsSaving(false);
+      return;
+    }
+
+    setIsClosing(false);
+    setDraftStats(nextStats);
+  }, [character?.level, character?.power, visible]);
+
+  const animateSheetTo = useCallback(
+    (toValue: number, onFinished?: () => void) => {
+      Animated.parallel([
+        Animated.timing(translateY, {
+          toValue,
+          duration: 180,
+          useNativeDriver: true,
+        }),
+        Animated.timing(backdropOpacity, {
+          toValue: toValue === 0 ? 1 : 0,
+          duration: 120,
+          useNativeDriver: true,
+        }),
+      ]).start(({ finished }) => {
+        if (finished) {
+          onFinished?.();
+        }
+      });
+    },
+    [backdropOpacity, translateY]
+  );
 
   useEffect(() => {
     if (!visible) {
-      setIsSaving(false);
-    }
-  }, [visible]);
+      if (!isRendered) {
+        setIsSaving(false);
+        return;
+      }
 
-  const stats = useMemo(
-    () => ({
-      level: character?.level ?? 0,
-      power: character?.power ?? 0,
-    }),
-    [character?.level, character?.power]
-  );
+      setIsClosing(true);
+      animateSheetTo(dismissOffset, () => {
+        setIsClosing(false);
+        setIsSaving(false);
+        setIsRendered(false);
+      });
+      return;
+    }
+
+    setIsRendered(true);
+    setIsClosing(false);
+    translateY.setValue(dismissOffset);
+    backdropOpacity.setValue(0);
+    animateSheetTo(0);
+  }, [animateSheetTo, backdropOpacity, dismissOffset, isRendered, translateY, visible]);
+
+  const dismissWithSlide = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const handleOpenFullEdit = useCallback(() => {
+    setIsClosing(true);
+    animateSheetTo(dismissOffset, () => {
+      setIsClosing(false);
+      setIsRendered(false);
+      onOpenFullEdit();
+    });
+  }, [animateSheetTo, dismissOffset, onOpenFullEdit]);
 
   const applyStep = useCallback(
     (field: keyof QuickEditStats, delta: number) => {
@@ -55,15 +122,12 @@ export default function QuickEditSheet({
       }
 
       void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => undefined);
-
-      const nextStats: QuickEditStats = {
-        level: stats.level,
-        power: stats.power,
-      };
-      nextStats[field] = clampToFloorZero(nextStats[field] + delta);
-      onStatsChange(nextStats);
+      setDraftStats((current) => ({
+        ...current,
+        [field]: clampToFloorZero(current[field] + delta),
+      }));
     },
-    [character, onStatsChange, stats.level, stats.power]
+    [character]
   );
 
   const handleSave = useCallback(async () => {
@@ -72,16 +136,54 @@ export default function QuickEditSheet({
     }
 
     setIsSaving(true);
-    await onSave();
-  }, [character, isSaving, onSave]);
+    await onSave(draftStats);
+  }, [character, draftStats, isSaving, onSave]);
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onStartShouldSetPanResponderCapture: () => true,
+        onMoveShouldSetPanResponder: (_event, gestureState) => shouldSetDragResponder(gestureState.dx, gestureState.dy),
+        onMoveShouldSetPanResponderCapture: (_event, gestureState) => shouldSetDragResponder(gestureState.dx, gestureState.dy),
+        onPanResponderMove: (_event, gestureState) => {
+          const nextTranslateY = Math.max(0, gestureState.dy);
+          translateY.setValue(nextTranslateY);
+          backdropOpacity.setValue(Math.max(0, 1 - nextTranslateY / dismissOffset));
+        },
+        onPanResponderRelease: (_event, gestureState) => {
+          if (gestureState.dy > 120 || gestureState.vy > 1) {
+            dismissWithSlide();
+            return;
+          }
+
+          animateSheetTo(0);
+        },
+        onPanResponderTerminate: () => {
+          animateSheetTo(0);
+        },
+      }),
+    [animateSheetTo, backdropOpacity, dismissOffset, dismissWithSlide, shouldSetDragResponder, translateY]
+  );
 
   return (
-    <Modal transparent visible={visible} animationType="slide" onRequestClose={onClose}>
+    <Modal transparent visible={isRendered} animationType="none" onRequestClose={dismissWithSlide}>
       <View style={styles.root}>
-        <Pressable testID="quick-edit-overlay" style={styles.overlay} onPress={onClose} />
+        <Animated.View
+          testID="quick-edit-overlay-backdrop"
+          style={[styles.overlayBackdrop, { opacity: isClosing ? backdropOpacity : 1 }]}
+        >
+          <Pressable testID="quick-edit-overlay" style={styles.overlayPressable} onPress={dismissWithSlide} />
+        </Animated.View>
 
-        <View testID="quick-edit-sheet" style={[styles.sheet, hasErrorFlash && styles.sheetErrorFlash]}>
-          <Text style={styles.title}>Quick Edit</Text>
+        <Animated.View
+          testID="quick-edit-sheet"
+          style={[styles.sheet, hasErrorFlash && styles.sheetErrorFlash, { transform: [{ translateY }] }]}
+        >
+          <View testID="quick-edit-drag-area" style={styles.dragArea} {...panResponder.panHandlers}>
+            <View style={styles.dragHandle} />
+            <Text style={styles.title}>Quick Edit</Text>
+          </View>
 
           <View style={styles.stepperRow}>
             <Text style={styles.label}>Level</Text>
@@ -89,7 +191,7 @@ export default function QuickEditSheet({
               <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('level', -1)}>
                 <Text style={styles.stepperButtonText}>−</Text>
               </TouchableOpacity>
-              <Text style={styles.value}>{stats.level}</Text>
+              <Text style={styles.value}>{draftStats.level}</Text>
               <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('level', 1)}>
                 <Text style={styles.stepperButtonText}>+</Text>
               </TouchableOpacity>
@@ -102,7 +204,7 @@ export default function QuickEditSheet({
               <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('power', -1)}>
                 <Text style={styles.stepperButtonText}>−</Text>
               </TouchableOpacity>
-              <Text style={styles.value}>{stats.power}</Text>
+              <Text style={styles.value}>{draftStats.power}</Text>
               <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('power', 1)}>
                 <Text style={styles.stepperButtonText}>+</Text>
               </TouchableOpacity>
@@ -110,14 +212,14 @@ export default function QuickEditSheet({
           </View>
 
           <View style={styles.actions}>
-            <TouchableOpacity onPress={onOpenFullEdit} style={styles.secondaryAction}>
+            <TouchableOpacity onPress={handleOpenFullEdit} style={styles.secondaryAction}>
               <Text style={styles.secondaryActionText}>Edit more…</Text>
             </TouchableOpacity>
             <TouchableOpacity onPress={handleSave} style={styles.primaryAction} disabled={isSaving}>
               <Text style={styles.primaryActionText}>{isSaving ? 'Saving…' : 'Save'}</Text>
             </TouchableOpacity>
           </View>
-        </View>
+        </Animated.View>
       </View>
     </Modal>
   );
@@ -128,7 +230,10 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'flex-end',
   },
-  overlay: {
+  overlayBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  overlayPressable: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
@@ -143,6 +248,19 @@ const styles = StyleSheet.create({
     gap: AppTheme.spacing.md,
     borderWidth: 2,
     borderColor: 'transparent',
+    overflow: 'hidden',
+  },
+  dragArea: {
+    gap: AppTheme.spacing.md,
+    paddingBottom: AppTheme.spacing.xs,
+  },
+  dragHandle: {
+    alignSelf: 'center',
+    width: 52,
+    height: 5,
+    borderRadius: AppTheme.radius.pill,
+    backgroundColor: AppTheme.colors.textMuted,
+    opacity: 0.5,
   },
   sheetErrorFlash: {
     borderColor: AppTheme.colors.danger,
@@ -188,25 +306,36 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   actions: {
-    marginTop: 'auto',
-    flexDirection: 'row',
+    marginTop: AppTheme.spacing.md,
     alignItems: 'center',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     gap: AppTheme.spacing.md,
   },
   secondaryAction: {
-    paddingHorizontal: AppTheme.spacing.md,
-    paddingVertical: AppTheme.spacing.sm,
+    width: '100%',
+    maxWidth: 280,
+    minHeight: 52,
+    paddingHorizontal: AppTheme.spacing.xl,
+    paddingVertical: AppTheme.spacing.md,
+    borderRadius: AppTheme.radius.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: AppTheme.colors.surfaceSubtle,
   },
   secondaryActionText: {
-    color: AppTheme.colors.textMuted,
+    color: AppTheme.colors.textPrimary,
     ...AppTheme.typography.labelMd,
   },
   primaryAction: {
-    paddingHorizontal: AppTheme.spacing.lg,
-    paddingVertical: AppTheme.spacing.sm,
+    width: '100%',
+    maxWidth: 280,
+    minHeight: 56,
+    paddingHorizontal: AppTheme.spacing.xl,
+    paddingVertical: AppTheme.spacing.md,
     borderRadius: AppTheme.radius.pill,
     backgroundColor: AppTheme.colors.actionSecondary,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   primaryActionText: {
     color: AppTheme.colors.textPrimary,

--- a/frontend/components/munchkin/QuickEditSheet.tsx
+++ b/frontend/components/munchkin/QuickEditSheet.tsx
@@ -1,0 +1,215 @@
+import { Character as RoomCharacter } from '@/api/characters';
+import { AppTheme } from '@/constants/theme';
+import * as Haptics from 'expo-haptics';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+type QuickEditStats = {
+  level: number;
+  power: number;
+};
+
+interface QuickEditSheetProps {
+  visible: boolean;
+  character: RoomCharacter | null;
+  onClose: () => void;
+  onStatsChange: (stats: QuickEditStats) => void;
+  onSave: () => Promise<void>;
+  onOpenFullEdit: () => void;
+  hasErrorFlash: boolean;
+}
+
+function clampToFloorZero(value: number): number {
+  return Math.max(0, value);
+}
+
+export default function QuickEditSheet({
+  visible,
+  character,
+  onClose,
+  onStatsChange,
+  onSave,
+  onOpenFullEdit,
+  hasErrorFlash,
+}: QuickEditSheetProps) {
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      setIsSaving(false);
+    }
+  }, [visible]);
+
+  const stats = useMemo(
+    () => ({
+      level: character?.level ?? 0,
+      power: character?.power ?? 0,
+    }),
+    [character?.level, character?.power]
+  );
+
+  const applyStep = useCallback(
+    (field: keyof QuickEditStats, delta: number) => {
+      if (!character) {
+        return;
+      }
+
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => undefined);
+
+      const nextStats: QuickEditStats = {
+        level: stats.level,
+        power: stats.power,
+      };
+      nextStats[field] = clampToFloorZero(nextStats[field] + delta);
+      onStatsChange(nextStats);
+    },
+    [character, onStatsChange, stats.level, stats.power]
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!character || isSaving) {
+      return;
+    }
+
+    setIsSaving(true);
+    await onSave();
+  }, [character, isSaving, onSave]);
+
+  return (
+    <Modal transparent visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.root}>
+        <Pressable testID="quick-edit-overlay" style={styles.overlay} onPress={onClose} />
+
+        <View testID="quick-edit-sheet" style={[styles.sheet, hasErrorFlash && styles.sheetErrorFlash]}>
+          <Text style={styles.title}>Quick Edit</Text>
+
+          <View style={styles.stepperRow}>
+            <Text style={styles.label}>Level</Text>
+            <View style={styles.stepper}>
+              <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('level', -1)}>
+                <Text style={styles.stepperButtonText}>−</Text>
+              </TouchableOpacity>
+              <Text style={styles.value}>{stats.level}</Text>
+              <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('level', 1)}>
+                <Text style={styles.stepperButtonText}>+</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          <View style={styles.stepperRow}>
+            <Text style={styles.label}>Power</Text>
+            <View style={styles.stepper}>
+              <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('power', -1)}>
+                <Text style={styles.stepperButtonText}>−</Text>
+              </TouchableOpacity>
+              <Text style={styles.value}>{stats.power}</Text>
+              <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('power', 1)}>
+                <Text style={styles.stepperButtonText}>+</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          <View style={styles.actions}>
+            <TouchableOpacity onPress={onOpenFullEdit} style={styles.secondaryAction}>
+              <Text style={styles.secondaryActionText}>Edit more…</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={handleSave} style={styles.primaryAction} disabled={isSaving}>
+              <Text style={styles.primaryActionText}>{isSaving ? 'Saving…' : 'Save'}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  sheet: {
+    height: '60%',
+    borderTopLeftRadius: AppTheme.radius.lg,
+    borderTopRightRadius: AppTheme.radius.lg,
+    backgroundColor: AppTheme.colors.elevated,
+    paddingHorizontal: AppTheme.spacing.lg,
+    paddingTop: AppTheme.spacing.lg,
+    paddingBottom: AppTheme.spacing.xl,
+    gap: AppTheme.spacing.md,
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  sheetErrorFlash: {
+    borderColor: AppTheme.colors.danger,
+  },
+  title: {
+    color: AppTheme.colors.textPrimary,
+    fontSize: 26,
+    fontWeight: '700',
+  },
+  stepperRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: {
+    color: AppTheme.colors.textMuted,
+    ...AppTheme.typography.labelMd,
+  },
+  stepper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: AppTheme.spacing.md,
+  },
+  stepperButton: {
+    width: 44,
+    height: 44,
+    borderRadius: AppTheme.radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: AppTheme.colors.surfaceSubtle,
+  },
+  stepperButtonText: {
+    color: AppTheme.colors.textPrimary,
+    fontSize: 24,
+    fontWeight: '700',
+    lineHeight: 24,
+  },
+  value: {
+    width: 48,
+    textAlign: 'center',
+    color: AppTheme.colors.accent,
+    fontSize: 26,
+    fontWeight: '700',
+  },
+  actions: {
+    marginTop: 'auto',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: AppTheme.spacing.md,
+  },
+  secondaryAction: {
+    paddingHorizontal: AppTheme.spacing.md,
+    paddingVertical: AppTheme.spacing.sm,
+  },
+  secondaryActionText: {
+    color: AppTheme.colors.textMuted,
+    ...AppTheme.typography.labelMd,
+  },
+  primaryAction: {
+    paddingHorizontal: AppTheme.spacing.lg,
+    paddingVertical: AppTheme.spacing.sm,
+    borderRadius: AppTheme.radius.pill,
+    backgroundColor: AppTheme.colors.actionSecondary,
+  },
+  primaryActionText: {
+    color: AppTheme.colors.textPrimary,
+    ...AppTheme.typography.labelMd,
+  },
+});


### PR DESCRIPTION
### Motivation
- Provide a low-friction in-room flow for players to adjust level and power without leaving the Room View. 
- Deliver optimistic UI updates and a safe rollback/undo UX for edits to preserve game flow during intermittent failures. 
- Integrate the quick-edit interaction into existing route/component seams so the full-edit modal remains the authoritative persistence path for non-current-player edits. 

### Description
- Added a reusable `QuickEditSheet` component at `frontend/components/munchkin/QuickEditSheet.tsx` implementing a ~60% bottom sheet with 44×44 steppers, haptic feedback on taps, floor-at-zero semantics, and error-flash styling. 
- Integrated quick-edit orchestration into the room route at `frontend/app/munchkin/[roomNumber]/index.tsx` with optimistic in-memory stat overrides, dismiss-to-undo toast (1500ms), save persistence via existing `useRoomCharacters().update`, and fallback rollback on save failure. 
- Added focused unit tests at `frontend/components/munchkin/QuickEditSheet.test.tsx` and adjusted the room-route test to mock `expo-haptics` so route tests remain stable. 
- Created Story 3.7 implementation artifact `_bmad-output/implementation-artifacts/3-7-quick-character-stat-editing.md` and updated sprint tracking in `_bmad-output/implementation-artifacts/sprint-status.yaml` to mark the story done. 

### Testing
- Ran TypeScript validation with `cd frontend && npm run tsc` and it passed. 
- Ran focused unit tests with `cd frontend && npm run test:unit -- QuickEditSheet.test.tsx` and the test passed. 
- Ran the full frontend test suite with `cd frontend && npm run test` which completed successfully (unit and room-route suites passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9febcdd483208dc64c9cf0039f5d)