### PR TITLE
feat: story 3.10 implementation

### DIFF
--- a/_bmad-output/implementation-artifacts/3-10-character-removal.md
+++ b/_bmad-output/implementation-artifacts/3-10-character-removal.md
@@ -1,6 +1,6 @@
 # Story 3.10: Character Removal
 
-Status: ready-for-dev
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -25,35 +25,69 @@ so that the session state stays clean when a character is no longer needed.
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — API contract and backend** (AC: 1)
-  - [ ] Keep `DELETE /characters/:characterId` as the delete endpoint.
-  - [ ] Remove any restriction on deleting associated characters — all characters are deletable regardless of `userId`.
-  - [ ] Add/extend backend tests in `backend/character-service/src/app.test.ts` for:
-    - [ ] unassociated character delete succeeds (`204`)
-    - [ ] associated character delete also succeeds (`204`)
+- [x] **Task 1 — API contract and backend** (AC: 1)
+  - [x] Keep `DELETE /characters/:characterId` as the delete endpoint.
+  - [x] Remove any restriction on deleting associated characters — all characters are deletable regardless of `userId`.
+  - [x] Add/extend backend tests in `backend/character-service/src/app.test.ts` for:
+    - [x] unassociated character delete succeeds (`204`)
+    - [x] associated character delete also succeeds (`204`)
 
-- [ ] **Task 2 — Frontend delete API helper** (AC: 1)
-  - [ ] Add `deleteCharacter(characterId: string)` to `frontend/api/characters.ts`.
-  - [ ] Add tests in `frontend/api/characters.test.ts` for successful delete and non-2xx error propagation.
+- [x] **Task 2 — Frontend delete API helper** (AC: 1)
+  - [x] Add `deleteCharacter(characterId: string)` to `frontend/api/characters.ts`.
+  - [x] Add tests in `frontend/api/characters.test.ts` for successful delete and non-2xx error propagation.
 
-- [ ] **Task 3 — UI: Delete button in character change modal** (AC: 1, 2)
-  - [ ] Add a Delete button inside `ChangeCharacterModal` (`frontend/app/munchkin/modal-change-caracter.tsx`), positioned at the **bottom of the changeable characteristics section**.
-  - [ ] Style the button with the **Danger zone** color (destructive/red — use the same token or style as other destructive actions in the app).
-  - [ ] The Delete button must be rendered for **all** characters, regardless of `userId`.
-  - [ ] Add explicit confirmation dialog/sheet before executing delete.
-  - [ ] On confirmed delete: call `deleteCharacter`, close modal cleanly, keep Room View interactive.
-  - [ ] On cancel: dismiss confirmation, return user to the modal without side effects.
+- [x] **Task 3 — UI: Delete button in character change modal** (AC: 1, 2)
+  - [x] Add a Delete button inside `ChangeCharacterModal` (`frontend/app/munchkin/modal-change-caracter.tsx`), positioned at the **bottom of the changeable characteristics section**.
+  - [x] Style the button with the **Danger zone** color (destructive/red — use the same token or style as other destructive actions in the app).
+  - [x] The Delete button must be rendered for **all** characters, regardless of `userId`.
+  - [x] Add explicit confirmation dialog/sheet before executing delete.
+  - [x] On confirmed delete: call `deleteCharacter`, close modal cleanly, keep Room View interactive.
+  - [x] On cancel: dismiss confirmation, return user to the modal without side effects.
 
-- [ ] **Task 4 — Realtime/state consistency** (AC: 1)
-  - [ ] Ensure current websocket `character_deleted` handling in `useRoomCharacters` remains the source of truth for cross-client removal updates.
-  - [ ] Ensure no regressions in current character selection, footer rendering, and quick-edit flows after delete.
+- [x] **Task 4 — Realtime/state consistency** (AC: 1)
+  - [x] Ensure current websocket `character_deleted` handling in `useRoomCharacters` remains the source of truth for cross-client removal updates.
+  - [x] Ensure no regressions in current character selection, footer rendering, and quick-edit flows after delete.
 
-- [ ] **Task 5 — Regression tests + validation** (AC: 1, 2)
-  - [ ] Add UI tests for Delete button visibility (rendered for all characters).
-  - [ ] Add UI tests for confirmation flow and delete success/failure UX behavior.
-  - [ ] Run `cd backend && npm test`.
-  - [ ] Run `cd frontend && npm run test`.
-  - [ ] Run `cd frontend && npm run tsc -- --noEmit`.
+- [x] **Task 5 — Regression tests + validation** (AC: 1, 2)
+  - [x] Add UI tests for Delete button visibility (rendered for all characters).
+  - [x] Add UI tests for confirmation flow and delete success/failure UX behavior.
+  - [x] Run `cd backend && npm test`.
+- [x] Run `cd frontend && npm run test`.
+- [x] Run `cd frontend && npm run tsc -- --noEmit`.
+
+### Review Findings
+
+- [x] [Review][Patch] Switching characters during overlapping deletes can clear the active pending state and re-enable duplicate delete submissions [frontend/app/munchkin/modal-change-caracter.tsx:81]
+- [x] [Review][Patch] Delete failures are surfaced behind the modal instead of inside the active delete UI [frontend/app/munchkin/[roomNumber]/index.tsx:275]
+- [x] [Review][Patch] Deleting the current user's character triggers unintended auto-recreation [`frontend/hooks/useCharacters.ts:309`]
+- [x] [Review][Patch] Optimistic delete can close or clear a newer character selection after the user switches targets mid-request [`frontend/app/munchkin/[roomNumber]/index.tsx:260`]
+- [x] [Review][Patch] ChangeCharacterModal keeps stale local character state after the user switches selections during an in-flight delete [frontend/app/munchkin/modal-change-caracter.tsx:47]
+- [x] [Review][Patch] Late delete failures can surface on a newer character after the user switches selections mid-request [frontend/app/munchkin/[roomNumber]/index.tsx:281]
+- [x] [Review][Patch] Optimistic delete unmounts the active change modal before success or failure can be shown [frontend/app/munchkin/[roomNumber]/index.tsx:247]
+- [x] [Review][Patch] New modal test lives under Expo Router `app/`, violating the route-only test placement rule [frontend/app/munchkin/modal-change-caracter.test.tsx:1]
+- [x] [Review][Patch] Delete rollback restores a stale room snapshot and can discard newer local mutations [frontend/hooks/useCharacters.ts:243]
+- [x] [Review][Patch] Optimistic self-delete still exposes the global create action, so a replacement can be created before the delete settles and the failed-delete rollback can leave two self-owned characters competing for the singular current-character UI [frontend/hooks/useCharacters.ts:236]
+- [x] [Review] Cancel remains enabled while a delete is in flight, so the user can dismiss the modal and lose any surfaced delete failure because the route stores the rejection in hidden modal-only state instead of a visible room-level error [frontend/app/munchkin/modal-change-caracter.tsx:408] [frontend/app/munchkin/[roomNumber]/index.tsx:285]
+- [x] [Review][Patch] Save remains enabled while delete is in flight, so the same modal can still submit an update against a character that is already being removed [frontend/app/munchkin/modal-change-caracter.tsx:415]
+- [x] [Review] A remotely deleted selected character stays open in `ChangeCharacterModal` from `selectedCharacterSnapshot`, so other participants can still see and interact with a character that AC1 says should no longer be visible. The route now keeps the modal mounted whenever `selectedCharacter` disappears (`modalCharacter = selectedCharacter ?? selectedCharacterSnapshot`), but only clears that snapshot after the local delete/cancel path, not after websocket-driven removal from another client [frontend/app/munchkin/[roomNumber]/index.tsx:101] [frontend/app/munchkin/[roomNumber]/index.tsx:294]
+- [x] [Review][Patch] `deleteMutation.error` is included in the shared `errorMessage` computation, so a delete failure surfaces both inside `ChangeCharacterModal` (via `deleteError`) and in the room-level `RoomCharactersList` error display simultaneously — double-surfacing the same error [frontend/hooks/useCharacters.ts:418]
+- [x] [Review][Patch] `selectedCharacterIdRef` is synced via `useEffect`, introducing a one-render lag; a very fast delete completion (or test mock) can read a stale ref value before the effect runs, causing the staleness guard to pass incorrectly [frontend/app/munchkin/[roomNumber]/index.tsx:50]
+- [x] [Review][Patch] If `onMutate` throws (e.g. `queryClient.cancelQueries` rejects), `onSettled` receives `context = undefined` and skips the `pendingCurrentUserDeleteCountRef` decrement and `setIsCreateBlocked(false)` call, leaving `isCreateBlocked` permanently `true` for the rest of the room session [frontend/hooks/useCharacters.ts:285]
+- [x] [Review][Defer] `Alert.alert` confirmation callback can fire after `ChangeCharacterModal` is unmounted (e.g. remote delete closes the modal between Alert display and user tap), calling `setIsDeletePending` on an unmounted component — React handles this gracefully but logs a warning; native Alert lifecycle is platform-controlled and cannot be cancelled [frontend/app/munchkin/modal-change-caracter.tsx:95] — deferred, platform limitation
+- [x] [Review][Patch] `deleteMutation.error` still included in shared `errorMessage` — delete failure surfaces both in modal `deleteError` and room-level banner simultaneously [frontend/hooks/useCharacters.ts:418]
+- [x] [Review][Patch] `onMutate` throw leaves `context` undefined in `onSettled`, skipping `pendingCurrentUserDeleteCountRef` decrement and `setIsCreateBlocked(false)`, permanently blocking create for the session [frontend/hooks/useCharacters.ts:onSettled]
+- [x] [Review][Patch] `deletedCharacterIndex` of `-1` (character not found in cache) causes rollback re-insertion at index 0 instead of original position — `Math.max(0, Math.min(-1, len))` = 0 [frontend/hooks/useCharacters.ts:onError]
+- [x] [Review][Patch] `selectedCharacterIdRef` one-render lag still present — fast delete completion reads stale ref before `useEffect` syncs, staleness guard passes incorrectly [frontend/app/munchkin/[roomNumber]/index.tsx:50]
+- [x] [Review][Patch] `handleDeleteConfirm` closure captures `character.id` at definition time; if selection switches between Alert display and user tap, delete is issued for the wrong character id [frontend/app/munchkin/modal-change-caracter.tsx:95]
+- [x] [Review][Patch] `autoCreateSuppressedForCurrentUserRef=true` with `pendingCurrentUserDeleteCountRef=0` desync (possible after error path) permanently blocks create even after all deletes settle [frontend/hooks/useCharacters.ts:create guard]
+- [x] [Review][Patch] Remote-delete auto-close effect returns early when `selectedCharacterSnapshot` is null, so modal does not auto-close on remote delete if snapshot was never set [frontend/app/munchkin/[roomNumber]/index.tsx:remote-delete useEffect]
+- [x] [Review][Defer] `VioletButton` `disabled` prop may not suppress all interaction paths on Expo web (`TouchableOpacity` web behavior) [frontend/components/VioletButton.tsx] — deferred, web platform limitation
+- [x] [Review][Defer] Delete button text uses `AppTheme.colors.textPrimary` on `danger` background — contrast may be insufficient depending on theme values [frontend/app/munchkin/modal-change-caracter.tsx:styles] — deferred, visual/design concern
+- [x] [Review][Patch] Unconditional `setSelectedCharacterIdAndRef(null)` on delete success clears a different character's selection if the user switched targets while the delete was in flight [frontend/app/munchkin/[roomNumber]/index.tsx:~322]
+- [x] [Review][Patch] Snapshot guard inversion (`selectedCharacterSnapshot && ...` instead of `!selectedCharacterSnapshot || ...`) causes the remote-delete auto-close effect to fire unexpectedly when snapshot is null [frontend/app/munchkin/[roomNumber]/index.tsx:~139]
+- [x] [Review][Patch] `onSettled` context=undefined branch decrements `pendingCurrentUserDeleteCountRef` even when `onMutate` threw before incrementing it, prematurely unblocking create while a real delete is still in flight [frontend/hooks/useCharacters.ts:~278]
+- [x] [Review][Patch] `autoCreateSuppressedForCurrentUserRef` is set to true in `onMutate` but never reset when `onMutate` throws (only `onSettled` is called with context=undefined, which does not reset the ref), permanently suppressing auto-create for the session [frontend/hooks/useCharacters.ts:~278]
+- [x] [Review][Patch] `deleteMutation.error` removed from shared `errorMessage` — confirm `deleteError` prop path in the route covers all failure paths and no delete error is silently dropped [frontend/hooks/useCharacters.ts:~419]
 
 ## Dev Notes
 
@@ -86,6 +120,15 @@ The Delete button must appear **inside `ChangeCharacterModal`**, at the **bottom
 - Do not introduce new websocket channels or polling loops.
 - Do not refactor room routing or unrelated modal flows.
 
+### Confirmation Dialog (Web Compatibility)
+
+`Alert.alert` is a no-op on Expo web. A reusable `ConfirmDialog` component (`frontend/components/ConfirmDialog.tsx`) was introduced to handle this:
+
+- **Native**: calls `Alert.alert` via `useEffect` when `visible` becomes `true` — renders nothing.
+- **Web**: renders an inline modal overlay with Cancel and confirm buttons, styled with `AppTheme` tokens.
+
+`ChangeCharacterModal` uses controlled state (`deleteConfirmVisible`, `pendingDeleteCharacterIdRef`) to drive `ConfirmDialog` instead of calling `Alert.alert` directly. This keeps the modal component platform-agnostic.
+
 ### File Structure Requirements
 
 - Backend (expected):
@@ -94,6 +137,7 @@ The Delete button must appear **inside `ChangeCharacterModal`**, at the **bottom
 - Frontend (expected):
   - `frontend/api/characters.ts`
   - `frontend/api/characters.test.ts`
+  - `frontend/components/ConfirmDialog.tsx`
   - `frontend/app/munchkin/[roomNumber]/index.tsx`
   - `frontend/app/munchkin/modal-change-caracter.tsx`
   - related tests under `frontend/__tests__/app/munchkin/` and/or component tests
@@ -124,20 +168,71 @@ The Delete button must appear **inside `ChangeCharacterModal`**, at the **bottom
 
 ### Agent Model Used
 
-claude-sonnet-4-6
+gpt-5
 
 ### Debug Log References
 
-_none_
+- `cd backend && npm test`
+- `cd frontend && npm run test`
+- `cd frontend && npm run tsc -- --noEmit`
 
 ### Completion Notes List
 
-- Updated Story 3.10: removed "unassociated" restriction — all characters are now removable.
-- Added explicit UI placement requirement: Delete button at the bottom of the changeable characteristics section inside ChangeCharacterModal.
-- Added Danger zone color requirement for the Delete button.
-- Removed AC2 (associated characters cannot be removed) and corresponding backend 409 rejection.
+- Added explicit backend coverage for both unassociated (`userId: null`) and associated (`userId` present) character deletion paths, both returning `204`.
+- Added `deleteCharacter(characterId)` API helper with tests for success path and non-2xx error propagation.
+- Added delete mutation support in `useRoomCharacters` with optimistic cache removal and rollback on error while preserving websocket `character_deleted` invalidation as source of truth.
+- Added delete orchestration in room route (`[roomNumber]/index.tsx`) to close modal cleanly and keep room interactions responsive.
+- Added Delete button to `ChangeCharacterModal` at the bottom of changeable characteristics, styled with `AppTheme.colors.danger`.
+- Added explicit confirmation dialog (`Alert.alert`) with cancel/no-side-effect behavior before delete execution.
+- Added room-route UI tests covering delete visibility/flow for own and other-user characters, explicit confirmation gating, and failure UX signaling.
+- Suppressed automatic self-character recreation after an intentional self-delete while still allowing explicit recreation flows.
+- Guarded delete completion so a late response cannot close or clear a newer character selection in the room screen.
+- Surfaced delete failures inside `ChangeCharacterModal` so the active destructive flow shows the error state directly within the edit UI.
+- Reset `ChangeCharacterModal` draft state whenever the selected character changes so stale edits and pending delete state cannot leak onto a newer selection.
+- Guarded delete failure handling in the room route so late rejections only surface if the failed request still belongs to the active selection.
+- Added modal- and route-level regression coverage for selection switching during in-flight deletes and late failure isolation.
+- Kept `ChangeCharacterModal` mounted against a selected-character snapshot so optimistic delete removal no longer unmounts the active destructive flow before success/failure feedback.
+- Moved modal draft-reset test from Expo Router `app/` into `frontend/__tests__/app/munchkin/` to comply with route-only test placement.
+- Replaced delete rollback snapshot restore with targeted re-insertion of the failed character so newer local mutations remain intact; added a hook-level regression covering in-flight delete failure plus later local updates.
+- Scoped modal delete pending-state cleanup to the active request so older delete completions cannot re-enable duplicate submissions after switching selections; added modal regression coverage for overlapping deletes.
+- Added a self-delete in-flight create guard in `useRoomCharacters` and surfaced `isCreateBlocked` to the room list so the global Create action is disabled until the current-user delete settles.
+- Added regressions for self-delete create blocking at the hook level and create-button disabled state at the room-route level.
+- Disabled `ChangeCharacterModal` cancel/dismiss interactions while delete is pending so late delete failures cannot be hidden by closing the modal; added regression coverage for pending-delete cancel lockout.
+- Disabled `ChangeCharacterModal` save interaction while delete is pending so updates cannot race against destructive removal; added modal regression coverage for pending-delete save lockout.
+- Closed the final remote-delete visibility gap by clearing stale selected-character snapshots when websocket updates remove the active character and no local delete is pending, so the edit modal closes immediately for remotely deleted characters.
+- Replaced `Alert.alert` confirmation with a reusable `ConfirmDialog` component that uses `Alert.alert` on native and renders an inline modal overlay on web; updated modal tests to interact with `ConfirmDialog` via `testID` instead of mocking `Alert.alert`.
 
 ### File List
 
+- frontend/components/ConfirmDialog.tsx
+- backend/character-service/src/app.test.ts
+- frontend/api/characters.ts
+- frontend/api/characters.test.ts
+- frontend/hooks/useCharacters.ts
+- frontend/hooks/useCharacters.test.ts
+- frontend/components/VioletButton.tsx
+- frontend/components/munchkin/RoomCharactersList.tsx
+- frontend/app/munchkin/modal-change-caracter.tsx
+- frontend/app/munchkin/[roomNumber]/index.tsx
+- frontend/__tests__/app/munchkin/[roomNumber].test.tsx
+- frontend/__tests__/app/munchkin/modal-change-caracter.test.tsx
 - _bmad-output/implementation-artifacts/3-10-character-removal.md
 - _bmad-output/implementation-artifacts/sprint-status.yaml
+
+### Change Log
+
+- 2026-04-04: Implemented Story 3.10 character removal end-to-end (backend deletion coverage, frontend delete API + mutation, modal danger delete UI with confirmation, room orchestration, and regression tests). Story marked `review`.
+- 2026-04-04: Fixed review findings for self-delete auto-recreation and stale delete completion clearing a newer selection; added regression tests for both cases.
+- 2026-04-04: Fixed the final review finding by surfacing delete failures inside the active character edit modal and revalidated the room-route/frontend regression suites.
+- 2026-04-04: Closed the remaining review findings by resetting modal draft state on selection changes and ignoring late delete failures for superseded selections; added targeted modal and room-route regressions and re-ran frontend tests plus TypeScript checks.
+- 2026-04-04: Resolved the last two review findings by preserving modal visibility through optimistic delete lifecycle and relocating modal tests to `frontend/__tests__/app/munchkin/`; re-ran frontend tests and TypeScript checks.
+- 2026-04-04: Resolved the remaining review finding by changing delete-error rollback to merge back only the failed character (instead of restoring a full stale snapshot), preserving newer local mutations; added a focused `useRoomCharacters` regression test and re-ran hook tests plus TypeScript checks.
+- 2026-04-04: Re-ran code review and found one remaining modal delete race: an earlier delete request can clear `isDeletePending` after the user switches targets, which re-enables duplicate delete submissions on the active character.
+- 2026-04-04: Fixed the final modal delete race by keying pending-state cleanup to the active delete request/character, preventing stale completion handlers from re-enabling duplicate deletes on a newly selected character; added modal regression and re-ran frontend tests + TypeScript checks.
+- 2026-04-04: Re-ran code review and found one remaining optimistic self-delete race: the room still exposes `Create a character` while the current user's delete is in flight, so a failed rollback can restore the old character after a replacement was already created.
+- 2026-04-04: Closed the remaining self-delete review finding by blocking current-user create while self-delete is in flight and disabling the global Create button through a new `isCreateBlocked` hook signal; added hook + room-route regressions and re-ran frontend tests + TypeScript checks.
+- 2026-04-04: Re-ran code review and found one remaining delete UX gap: the modal still allows cancel while delete is pending, which can hide a late delete failure instead of surfacing it in visible UI.
+- 2026-04-04: Closed the final delete UX finding by disabling modal cancel/close while delete is pending, added a modal regression for pending-delete cancel lockout, and re-ran frontend tests + TypeScript checks.
+- 2026-04-04: Re-ran code review and found one remaining modal concurrency gap: Save stays enabled during an in-flight delete, so the UI can still issue a conflicting update against a character already being removed.
+- 2026-04-04: Closed the final modal concurrency finding by disabling Save while delete is pending, added regression coverage, and re-ran frontend tests + TypeScript checks.
+- 2026-04-05: Replaced `Alert.alert` confirmation with cross-platform `ConfirmDialog` component (native: `Alert.alert` via `useEffect`; web: inline modal overlay); updated modal tests to use `testID`-based confirm button interaction.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-04-02T00:30:00Z
+last_updated: 2026-04-05T01:12:00Z
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -66,7 +66,7 @@ development_status:
   3-7-quick-character-stat-editing: done
   3-8-realtime-update-signal-on-character-cards: done
   3-9-full-character-attribute-editing: done
-  3-10-character-removal: ready-for-dev
+  3-10-character-removal: done
   epic-3-retrospective: optional
 
   epic-4: in-progress

--- a/backend/character-service/src/app.test.ts
+++ b/backend/character-service/src/app.test.ts
@@ -81,7 +81,7 @@ describe('character-service app', () => {
     expect(response.body.message).toContain('color');
   });
 
-  it('deletes character', async () => {
+  it('deletes unassociated character', async () => {
     const model = buildCharacterModel();
     const now = new Date();
     vi.mocked(model.findByIdAndDelete).mockResolvedValue({
@@ -102,6 +102,31 @@ describe('character-service app', () => {
 
     const app = createApp(model);
     const response = await request(app).delete('/characters/c3');
+
+    expect(response.status).toBe(204);
+  });
+
+  it('deletes associated character', async () => {
+    const model = buildCharacterModel();
+    const now = new Date();
+    vi.mocked(model.findByIdAndDelete).mockResolvedValue({
+      id: 'c4',
+      roomId: 'r4',
+      userId: 'u4',
+      name: 'Paladin',
+      avatarId: 5,
+      color: '#ABCDEF',
+      level: 2,
+      power: 3,
+      class: '',
+      race: '',
+      gender: '',
+      createdAt: now,
+      updatedAt: now
+    });
+
+    const app = createApp(model);
+    const response = await request(app).delete('/characters/c4');
 
     expect(response.status).toBe(204);
   });

--- a/frontend/__tests__/app/munchkin/[roomNumber].test.tsx
+++ b/frontend/__tests__/app/munchkin/[roomNumber].test.tsx
@@ -9,6 +9,8 @@ const mockSetStringAsync = vi.hoisted(() => vi.fn());
 const mockRoomNumber = vi.hoisted(() => ({ current: 'ROOM42' as string | string[] | undefined }));
 const mockCreateCharacter = vi.hoisted(() => vi.fn());
 const mockUpdateCharacter = vi.hoisted(() => vi.fn());
+const mockRemoveCharacter = vi.hoisted(() => vi.fn());
+const mockIsCreateBlocked = vi.hoisted(() => ({ current: false }));
 const mockCharactersState = vi.hoisted(() => ({
   current: [] as Character[],
 }));
@@ -51,16 +53,39 @@ vi.mock('@/hooks/useCharacters', () => ({
     characters: mockCharactersState.current,
     create: mockCreateCharacter,
     update: mockUpdateCharacter,
+    remove: mockRemoveCharacter,
+    isCreateBlocked: mockIsCreateBlocked.current,
     isLoading: false,
     errorMessage: null,
   }),
 }));
 
 vi.mock('../../../components/munchkin/RoomCharactersList', () => ({
-  default: ({ characters }: { characters: Character[] }) => (
+  default: ({
+    characters,
+    actionError,
+    isCreateBlocked,
+    onCreateCharacter,
+    onChangePress,
+  }: {
+    characters: Character[];
+    actionError?: string | null;
+    isCreateBlocked: boolean;
+    onCreateCharacter: () => void;
+    onChangePress: (character: Character) => void;
+  }) => (
     <div>
+      {actionError ? <div>{actionError}</div> : null}
+      <button type="button" disabled={isCreateBlocked} onClick={onCreateCharacter}>
+        Create a character
+      </button>
       {characters.map((character) => (
-        <div key={character.id}>{`${character.nickname}: ${character.level} lvl / ${character.power} str`}</div>
+        <div key={character.id}>
+          <div>{`${character.nickname}: ${character.level} lvl / ${character.power} str`}</div>
+          <button type="button" onClick={() => onChangePress(character)}>
+            {`Change ${character.nickname}`}
+          </button>
+        </div>
       ))}
     </div>
   ),
@@ -84,7 +109,45 @@ vi.mock('../../../components/munchkin/CurrentCharacterFooter', () => ({
 }));
 
 vi.mock('../../../app/munchkin/modal-change-caracter', () => ({
-  default: () => null,
+  default: ({
+    character,
+    deleteError,
+    onDelete,
+    onCancel,
+  }: {
+    character?: Character;
+    deleteError?: string | null;
+    onDelete: (characterId: string) => Promise<void>;
+    onCancel: () => void;
+  }) => {
+    const [confirmVisible, setConfirmVisible] = React.useState(false);
+    if (!character) {
+      return null;
+    }
+
+    return (
+      <div>
+        <div>{`Edit ${character.nickname}`}</div>
+        <button type="button" onClick={() => setConfirmVisible(true)}>
+          Delete character
+        </button>
+        {confirmVisible ? (
+          <div>
+            <button type="button" onClick={() => setConfirmVisible(false)}>
+              Cancel delete
+            </button>
+            <button type="button" onClick={() => void onDelete(character.id)}>
+              Confirm delete
+            </button>
+          </div>
+        ) : null}
+        {deleteError ? <div>{deleteError}</div> : null}
+        <button type="button" onClick={onCancel}>
+          Close edit
+        </button>
+      </div>
+    );
+  },
 }));
 
 vi.mock('../../../app/munchkin/modal-create-character', () => ({
@@ -96,16 +159,21 @@ vi.mock('../../../components/munchkin/QuickEditSheet', () => ({
     visible,
     character,
     onSave,
+    onOpenFullEdit,
   }: {
     visible: boolean;
     character: Character | null;
     onSave: (stats: { level: number; power: number }) => Promise<void>;
+    onOpenFullEdit: () => void;
   }) =>
     visible && character ? (
       <div>
         <div>{`Quick edit for ${character.nickname}`}</div>
         <button type="button" onClick={() => void onSave({ level: character.level + 2, power: character.power + 1 })}>
           Save quick edit
+        </button>
+        <button type="button" onClick={onOpenFullEdit}>
+          Open full edit
         </button>
       </div>
     ) : null,
@@ -118,8 +186,11 @@ describe('Munchkin room header', () => {
     mockSetStringAsync.mockResolvedValue(true);
     mockCreateCharacter.mockReset();
     mockUpdateCharacter.mockReset();
+    mockRemoveCharacter.mockReset();
+    mockIsCreateBlocked.current = false;
     mockCreateCharacter.mockResolvedValue(undefined);
     mockUpdateCharacter.mockResolvedValue(undefined);
+    mockRemoveCharacter.mockResolvedValue(undefined);
     mockCharactersState.current = [];
     mockRoomNumber.current = 'ROOM42';
     latestHeaderOptions.current = undefined;
@@ -271,5 +342,408 @@ describe('Munchkin room header', () => {
     });
 
     expect(mockUpdateCharacter).toHaveBeenCalledWith('char-1', { level: 3, power: 1 });
+  });
+
+  it('renders delete actions for own character full edit and requires explicit confirmation', async () => {
+    mockCharactersState.current = [
+      {
+        id: 'char-self',
+        roomId: 'ROOM42',
+        userId: 'user-1',
+        nickname: 'Player One',
+        avatar: 1,
+        color: '#9966FF',
+        level: 1,
+        power: 0,
+        class: [],
+        race: ['Human'],
+        gender: ['male'],
+      },
+    ];
+
+    const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
+
+    await act(async () => {
+      render(
+        <userProfileContext.Provider
+          value={{
+            userProfile: {
+              id: 'user-1',
+              nickname: 'Player One',
+              avatar: 1,
+            },
+            setUserProfile: vi.fn(),
+          }}
+        >
+          <MunchkinIndexView />
+        </userProfileContext.Provider>
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Open quick edit' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Open full edit' }));
+    });
+
+    expect(screen.getByText('Edit Player One')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Delete character' })).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete character' }));
+    });
+
+    expect(mockRemoveCharacter).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Cancel delete' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Confirm delete' })).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel delete' }));
+    });
+
+    expect(mockRemoveCharacter).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Confirm delete' })).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete character' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+      await Promise.resolve();
+    });
+
+    expect(mockRemoveCharacter).toHaveBeenCalledWith('char-self');
+  });
+
+  it('disables global create while current-user delete is still pending', async () => {
+    mockIsCreateBlocked.current = true;
+    mockCharactersState.current = [
+      {
+        id: 'char-self',
+        roomId: 'ROOM42',
+        userId: 'user-1',
+        nickname: 'Player One',
+        avatar: 1,
+        color: '#9966FF',
+        level: 1,
+        power: 0,
+        class: [],
+        race: ['Human'],
+        gender: ['male'],
+      },
+    ];
+
+    const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
+
+    await act(async () => {
+      render(
+        <userProfileContext.Provider
+          value={{
+            userProfile: {
+              id: 'user-1',
+              nickname: 'Player One',
+              avatar: 1,
+            },
+            setUserProfile: vi.fn(),
+          }}
+        >
+          <MunchkinIndexView />
+        </userProfileContext.Provider>
+      );
+    });
+
+    const createButton = screen.getByRole('button', { name: 'Create a character' });
+    expect(createButton.getAttribute('disabled')).toBe('');
+  });
+
+  it('renders delete actions for other users and shows failure errors after confirmed delete', async () => {
+    mockCharactersState.current = [
+      {
+        id: 'char-other',
+        roomId: 'ROOM42',
+        userId: 'user-2',
+        nickname: 'Rogue',
+        avatar: 2,
+        color: '#0088CC',
+        level: 4,
+        power: 1,
+        class: ['Thief'],
+        race: ['Elf'],
+        gender: ['female'],
+      },
+    ];
+    mockRemoveCharacter.mockRejectedValueOnce(new Error('Delete failed'));
+
+    const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
+
+    await act(async () => {
+      render(
+        <userProfileContext.Provider
+          value={{
+            userProfile: {
+              id: 'user-1',
+              nickname: 'Player One',
+              avatar: 1,
+            },
+            setUserProfile: vi.fn(),
+          }}
+        >
+          <MunchkinIndexView />
+        </userProfileContext.Provider>
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Change Rogue' }));
+    });
+
+    expect(screen.getByText('Edit Rogue')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Delete character' })).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete character' }));
+    });
+
+    expect(mockRemoveCharacter).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+      await Promise.resolve();
+    });
+
+    expect(mockRemoveCharacter).toHaveBeenCalledWith('char-other');
+    expect(screen.getByText('Edit Rogue')).toBeTruthy();
+    expect(screen.getByText('Delete failed')).toBeTruthy();
+  });
+
+  it('keeps a newer selection open when an earlier delete resolves late', async () => {
+    let resolveDelete!: () => void;
+    mockCharactersState.current = [
+      {
+        id: 'char-first',
+        roomId: 'ROOM42',
+        userId: 'user-2',
+        nickname: 'Rogue',
+        avatar: 2,
+        color: '#0088CC',
+        level: 4,
+        power: 1,
+        class: ['Thief'],
+        race: ['Elf'],
+        gender: ['female'],
+      },
+      {
+        id: 'char-second',
+        roomId: 'ROOM42',
+        userId: 'user-3',
+        nickname: 'Mage',
+        avatar: 3,
+        color: '#BB44DD',
+        level: 5,
+        power: 6,
+        class: ['Wizard'],
+        race: ['Human'],
+        gender: ['female'],
+      },
+    ];
+    mockRemoveCharacter.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        })
+    );
+
+    const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
+
+    await act(async () => {
+      render(
+        <userProfileContext.Provider
+          value={{
+            userProfile: {
+              id: 'user-1',
+              nickname: 'Player One',
+              avatar: 1,
+            },
+            setUserProfile: vi.fn(),
+          }}
+        >
+          <MunchkinIndexView />
+        </userProfileContext.Provider>
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Change Rogue' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete character' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Edit Rogue')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Change Mage' }));
+    });
+
+    expect(screen.getByText('Edit Mage')).toBeTruthy();
+
+    await act(async () => {
+      resolveDelete();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Edit Mage')).toBeTruthy();
+    expect(screen.queryByText('Edit Rogue')).toBeNull();
+  });
+
+  it('does not surface a late delete failure on a newer selection', async () => {
+    let rejectDelete!: (error?: unknown) => void;
+    mockCharactersState.current = [
+      {
+        id: 'char-first',
+        roomId: 'ROOM42',
+        userId: 'user-2',
+        nickname: 'Rogue',
+        avatar: 2,
+        color: '#0088CC',
+        level: 4,
+        power: 1,
+        class: ['Thief'],
+        race: ['Elf'],
+        gender: ['female'],
+      },
+      {
+        id: 'char-second',
+        roomId: 'ROOM42',
+        userId: 'user-3',
+        nickname: 'Mage',
+        avatar: 3,
+        color: '#BB44DD',
+        level: 5,
+        power: 6,
+        class: ['Wizard'],
+        race: ['Human'],
+        gender: ['female'],
+      },
+    ];
+    mockRemoveCharacter.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectDelete = reject;
+        })
+    );
+
+    const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
+
+    await act(async () => {
+      render(
+        <userProfileContext.Provider
+          value={{
+            userProfile: {
+              id: 'user-1',
+              nickname: 'Player One',
+              avatar: 1,
+            },
+            setUserProfile: vi.fn(),
+          }}
+        >
+          <MunchkinIndexView />
+        </userProfileContext.Provider>
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Change Rogue' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Delete character' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Edit Rogue')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Change Mage' }));
+    });
+
+    expect(screen.getByText('Edit Mage')).toBeTruthy();
+
+    await act(async () => {
+      rejectDelete(new Error('Delete failed'));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Edit Mage')).toBeTruthy();
+    expect(screen.queryByText('Delete failed')).toBeNull();
+  });
+
+  it('closes the change modal when the selected character is deleted remotely', async () => {
+    mockCharactersState.current = [
+      {
+        id: 'char-remote',
+        roomId: 'ROOM42',
+        userId: 'user-2',
+        nickname: 'Rogue',
+        avatar: 2,
+        color: '#0088CC',
+        level: 4,
+        power: 1,
+        class: ['Thief'],
+        race: ['Elf'],
+        gender: ['female'],
+      },
+    ];
+
+    const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
+
+    const view = render(
+      <userProfileContext.Provider
+        value={{
+          userProfile: {
+            id: 'user-1',
+            nickname: 'Player One',
+            avatar: 1,
+          },
+          setUserProfile: vi.fn(),
+        }}
+      >
+        <MunchkinIndexView />
+      </userProfileContext.Provider>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Change Rogue' }));
+    });
+
+    expect(screen.getByText('Edit Rogue')).toBeTruthy();
+
+    mockCharactersState.current = [];
+
+    await act(async () => {
+      view.rerender(
+        <userProfileContext.Provider
+          value={{
+            userProfile: {
+              id: 'user-1',
+              nickname: 'Player One',
+              avatar: 1,
+            },
+            setUserProfile: vi.fn(),
+          }}
+        >
+          <MunchkinIndexView />
+        </userProfileContext.Provider>
+      );
+    });
+
+    expect(screen.queryByText('Edit Rogue')).toBeNull();
   });
 });

--- a/frontend/__tests__/app/munchkin/modal-change-caracter.test.tsx
+++ b/frontend/__tests__/app/munchkin/modal-change-caracter.test.tsx
@@ -1,0 +1,343 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { Text, TextInput, TouchableOpacity } from 'react-native';
+import { describe, expect, it, vi } from 'vitest';
+
+import ChangeCharacterModal from '../../../app/munchkin/modal-change-caracter';
+
+vi.mock('expo-image', () => ({
+  Image: 'Image',
+}));
+
+vi.mock('@/constants/avatars', () => ({
+  default: Array.from({ length: 10 }, () => 1),
+}));
+
+vi.mock('@/components/munchkin/NativePicker', () => ({
+  default: () => null,
+}));
+
+vi.mock('reanimated-color-picker', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => children,
+  Panel5: () => null,
+}));
+
+vi.mock('react-native', async () => {
+  const actual = await vi.importActual<typeof import('react-native')>('react-native');
+  return {
+    ...actual,
+    Modal: ({ children }: { children?: React.ReactNode }) => children,
+  };
+});
+
+/** Find a TouchableOpacity whose direct Text child matches the given label. */
+function findButtonByLabel(renderer: ReturnType<typeof TestRenderer.create>, label: string) {
+  return renderer.root
+    .findAllByType(TouchableOpacity)
+    .find((btn: any) =>
+      btn.findAllByType(Text).some((t: any) => t.props.children === label)
+    );
+}
+
+/** Find the ConfirmDialog confirm button by testID. */
+function findConfirmButton(renderer: ReturnType<typeof TestRenderer.create>) {
+  return renderer.root
+    .findAllByType(TouchableOpacity)
+    .find((btn: any) => btn.props.testID === 'confirm-dialog-confirm');
+}
+
+describe('ChangeCharacterModal', () => {
+  it('resets its local draft when the selected character changes mid-session', async () => {
+    const firstCharacter = {
+      id: 'char-first',
+      nickname: 'Rogue',
+      color: '#0088CC',
+      gender: ['female'],
+      race: ['Elf'],
+      class: ['Thief'],
+      level: 4,
+      power: 1,
+      avatar: 2,
+    };
+    const secondCharacter = {
+      id: 'char-second',
+      nickname: 'Mage',
+      color: '#BB44DD',
+      gender: ['female'],
+      race: ['Human'],
+      class: ['Wizard'],
+      level: 5,
+      power: 6,
+      avatar: 3,
+    };
+
+    let renderer: ReturnType<typeof TestRenderer.create>;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <ChangeCharacterModal
+          character={firstCharacter}
+          deleteError={null}
+          onConfirm={vi.fn()}
+          onDelete={vi.fn(async () => undefined)}
+          onCancel={vi.fn()}
+        />
+      );
+    });
+
+    const nameInput = renderer!.root.findAllByType(TextInput)[0];
+
+    await act(async () => {
+      nameInput.props.onChangeText('Edited Rogue');
+    });
+
+    expect(renderer!.root.findAllByType(TextInput)[0].props.value).toBe('Edited Rogue');
+
+    await act(async () => {
+      renderer!.update(
+        <ChangeCharacterModal
+          character={secondCharacter}
+          deleteError={null}
+          onConfirm={vi.fn()}
+          onDelete={vi.fn(async () => undefined)}
+          onCancel={vi.fn()}
+        />
+      );
+    });
+
+    expect(renderer!.root.findAllByType(TextInput)[0].props.value).toBe('Mage');
+  });
+
+  it('keeps delete pending state scoped to the active character during overlapping deletes', async () => {
+    const firstCharacter = {
+      id: 'char-first',
+      nickname: 'Rogue',
+      color: '#0088CC',
+      gender: ['female'],
+      race: ['Elf'],
+      class: ['Thief'],
+      level: 4,
+      power: 1,
+      avatar: 2,
+    };
+    const secondCharacter = {
+      id: 'char-second',
+      nickname: 'Mage',
+      color: '#BB44DD',
+      gender: ['female'],
+      race: ['Human'],
+      class: ['Wizard'],
+      level: 5,
+      power: 6,
+      avatar: 3,
+    };
+
+    let resolveFirstDelete!: () => void;
+    let resolveSecondDelete!: () => void;
+    const onDelete = vi
+      .fn<(characterId: string) => Promise<void>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirstDelete = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSecondDelete = resolve;
+          })
+      );
+
+    let renderer: ReturnType<typeof TestRenderer.create>;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <ChangeCharacterModal
+          character={firstCharacter}
+          deleteError={null}
+          onConfirm={vi.fn()}
+          onDelete={onDelete}
+          onCancel={vi.fn()}
+        />
+      );
+    });
+
+    const pressDeleteAndConfirm = async () => {
+      const deleteButton = findButtonByLabel(renderer!, 'Delete');
+      expect(deleteButton).toBeTruthy();
+
+      await act(async () => {
+        deleteButton!.props.onPress();
+      });
+
+      // ConfirmDialog is now visible — find the confirm button by testID
+      const confirmButton = findConfirmButton(renderer!);
+      expect(confirmButton).toBeTruthy();
+
+      await act(async () => {
+        confirmButton!.props.onPress();
+        await Promise.resolve();
+      });
+    };
+
+    await pressDeleteAndConfirm();
+    expect(onDelete).toHaveBeenCalledWith('char-first');
+
+    await act(async () => {
+      renderer!.update(
+        <ChangeCharacterModal
+          character={secondCharacter}
+          deleteError={null}
+          onConfirm={vi.fn()}
+          onDelete={onDelete}
+          onCancel={vi.fn()}
+        />
+      );
+    });
+
+    await pressDeleteAndConfirm();
+    expect(onDelete).toHaveBeenCalledWith('char-second');
+
+    await act(async () => {
+      resolveFirstDelete();
+      await Promise.resolve();
+    });
+
+    const deletingLabelStillVisible = renderer!.root
+      .findAllByType(Text)
+      .some((textNode: any) => textNode.props.children === 'Deleting...');
+    expect(deletingLabelStillVisible).toBe(true);
+
+    await act(async () => {
+      resolveSecondDelete();
+      await Promise.resolve();
+    });
+
+    const deleteLabelVisible = renderer!.root
+      .findAllByType(Text)
+      .some((textNode: any) => textNode.props.children === 'Delete');
+    expect(deleteLabelVisible).toBe(true);
+  });
+
+  it('keeps cancel disabled while delete is in flight', async () => {
+    const character = {
+      id: 'char-first',
+      nickname: 'Rogue',
+      color: '#0088CC',
+      gender: ['female'],
+      race: ['Elf'],
+      class: ['Thief'],
+      level: 4,
+      power: 1,
+      avatar: 2,
+    };
+
+    let resolveDelete!: () => void;
+    const onDelete = vi.fn<(characterId: string) => Promise<void>>().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        })
+    );
+    const onCancel = vi.fn();
+
+    let renderer: ReturnType<typeof TestRenderer.create>;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <ChangeCharacterModal
+          character={character}
+          deleteError={null}
+          onConfirm={vi.fn()}
+          onDelete={onDelete}
+          onCancel={onCancel}
+        />
+      );
+    });
+
+    await act(async () => {
+      findButtonByLabel(renderer!, 'Delete')!.props.onPress();
+    });
+
+    // Confirm via ConfirmDialog
+    await act(async () => {
+      findConfirmButton(renderer!)!.props.onPress();
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const cancelButton = findButtonByLabel(renderer!, 'Cancel');
+    expect(cancelButton?.props.disabled).toBe(true);
+
+    await act(async () => {
+      cancelButton!.props.onPress();
+    });
+    expect(onCancel).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveDelete();
+      await Promise.resolve();
+    });
+
+    expect(findButtonByLabel(renderer!, 'Cancel')?.props.disabled).toBe(false);
+  });
+
+  it('keeps save disabled while delete is in flight', async () => {
+    const character = {
+      id: 'char-first',
+      nickname: 'Rogue',
+      color: '#0088CC',
+      gender: ['female'],
+      race: ['Elf'],
+      class: ['Thief'],
+      level: 4,
+      power: 1,
+      avatar: 2,
+    };
+
+    let resolveDelete!: () => void;
+    const onDelete = vi.fn<(characterId: string) => Promise<void>>().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        })
+    );
+    const onConfirm = vi.fn();
+
+    let renderer: ReturnType<typeof TestRenderer.create>;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <ChangeCharacterModal
+          character={character}
+          deleteError={null}
+          onConfirm={onConfirm}
+          onDelete={onDelete}
+          onCancel={vi.fn()}
+        />
+      );
+    });
+
+    await act(async () => {
+      findButtonByLabel(renderer!, 'Delete')!.props.onPress();
+    });
+
+    // Confirm via ConfirmDialog
+    await act(async () => {
+      findConfirmButton(renderer!)!.props.onPress();
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const saveButton = findButtonByLabel(renderer!, 'Save');
+    expect(saveButton?.props.disabled).toBe(true);
+
+    await act(async () => {
+      saveButton!.props.onPress();
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveDelete();
+      await Promise.resolve();
+    });
+
+    expect(findButtonByLabel(renderer!, 'Save')?.props.disabled).toBe(false);
+  });
+});

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'click.helpamunch.mobileapp'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.1.0"
+        versionCode 2
+        versionName "1.0.0"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'click.helpamunch.mobileapp'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
-        versionName "1.0.0"
+        versionCode 1
+        versionName "1.1.0"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/frontend/api/characters.test.ts
+++ b/frontend/api/characters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createCharacter, getCharactersByRoom, updateCharacter } from '@/api/characters';
+import { createCharacter, deleteCharacter, getCharactersByRoom, updateCharacter } from '@/api/characters';
 import { apiRequest } from '@/api/http';
 
 vi.mock('@/api/http', () => ({
@@ -137,5 +137,22 @@ describe('characters api', () => {
     });
     expect(response.nickname).toBe('Warrior+');
     expect(response.class).toEqual(['Warrior']);
+  });
+
+  it('deletes character successfully', async () => {
+    mockApiRequest.mockResolvedValueOnce(undefined);
+
+    await deleteCharacter('char/4');
+
+    expect(mockApiRequest).toHaveBeenCalledWith('/characters/char%2F4', {
+      method: 'DELETE',
+    });
+  });
+
+  it('propagates delete errors', async () => {
+    const deleteError = new Error('Delete failed');
+    mockApiRequest.mockRejectedValueOnce(deleteError);
+
+    await expect(deleteCharacter('char-5')).rejects.toThrow('Delete failed');
   });
 });

--- a/frontend/api/characters.ts
+++ b/frontend/api/characters.ts
@@ -204,3 +204,9 @@ export async function updateCharacter(characterId: string, payload: CharacterUpd
 
   return toFrontendCharacter(updated);
 }
+
+export async function deleteCharacter(characterId: string): Promise<void> {
+  await apiRequest<void>(`/characters/${encodeURIComponent(characterId)}`, {
+    method: 'DELETE',
+  });
+}

--- a/frontend/app/munchkin/[roomNumber]/index.tsx
+++ b/frontend/app/munchkin/[roomNumber]/index.tsx
@@ -4,7 +4,7 @@ import { userProfileContext } from '@/context/UserContext';
 import { useRoomCharacters } from '@/hooks/useCharacters';
 import { useRoomCodeClipboard } from '@/hooks/useRoomCodeClipboard';
 import { Stack, useLocalSearchParams } from 'expo-router';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Platform, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import CurrentCharacterFooter from '../../../components/munchkin/CurrentCharacterFooter';
@@ -25,7 +25,16 @@ const MunchkinIndexView: React.FC = () => {
   const roomId = Array.isArray(roomNumber) ? roomNumber[0] : roomNumber;
   const roomCode = roomId ?? '';
   const { userProfile } = useContext(userProfileContext);
-  const { characters, create, update, realtimeUpdateSignals, isLoading, errorMessage } = useRoomCharacters(roomId, userProfile);
+  const {
+    characters,
+    create,
+    update,
+    remove,
+    realtimeUpdateSignals,
+    isLoading,
+    errorMessage,
+    isCreateBlocked,
+  } = useRoomCharacters(roomId, userProfile);
   const { buttonLabel, accessibilityLabel, copyRoomCode } = useRoomCodeClipboard(roomCode);
 
   const [createCharacterModalVisible, setCreateCharacterModalVisible] = useState(false);
@@ -33,11 +42,20 @@ const MunchkinIndexView: React.FC = () => {
   const [quickEditVisible, setQuickEditVisible] = useState(false);
   const [pendingFullEditOpen, setPendingFullEditOpen] = useState(false);
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(null);
+  const [selectedCharacterSnapshot, setSelectedCharacterSnapshot] = useState<RoomCharacter | null>(null);
+  const [pendingDeleteCharacterId, setPendingDeleteCharacterId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [undoState, setUndoState] = useState<UndoState | null>(null);
   const [showUndoToast, setShowUndoToast] = useState(false);
   const [dangerFlash, setDangerFlash] = useState(false);
   const undoToastTranslateY = useMemo(() => new Animated.Value(24), []);
+  const selectedCharacterIdRef = useRef<string | null>(null);
+
+  const setSelectedCharacterIdAndRef = useCallback((id: string | null) => {
+    selectedCharacterIdRef.current = id;
+    setSelectedCharacterId(id);
+  }, []);
 
   useEffect(() => {
     if (!showUndoToast) {
@@ -82,10 +100,13 @@ const MunchkinIndexView: React.FC = () => {
     () => characters.find((character) => character.userId === userProfile.id),
     [characters, userProfile.id]
   );
+  const modalCharacter = selectedCharacter ?? selectedCharacterSnapshot;
 
   const handleChangePress = useCallback(
     (character: RoomCharacter) => {
-      setSelectedCharacterId(character.id);
+      setSelectedCharacterIdAndRef(character.id);
+      setSelectedCharacterSnapshot(character);
+      setDeleteError(null);
 
       if (character.userId === userProfile.id) {
         setShowUndoToast(false);
@@ -96,7 +117,7 @@ const MunchkinIndexView: React.FC = () => {
 
       setChangeCharacterModalVisible(true);
     },
-    [userProfile.id]
+    [userProfile.id, setSelectedCharacterIdAndRef]
   );
 
   const closeQuickEditSheet = useCallback(() => {
@@ -109,8 +130,35 @@ const MunchkinIndexView: React.FC = () => {
     }
 
     setPendingFullEditOpen(false);
+    setSelectedCharacterSnapshot(selectedCharacter ?? null);
     setChangeCharacterModalVisible(true);
-  }, [pendingFullEditOpen, quickEditVisible]);
+  }, [pendingFullEditOpen, quickEditVisible, selectedCharacter]);
+
+  useEffect(() => {
+    if (!changeCharacterModalVisible || !selectedCharacterId || selectedCharacter) {
+      return;
+    }
+
+    if (!selectedCharacterSnapshot || selectedCharacterSnapshot.id !== selectedCharacterId) {
+      return;
+    }
+
+    if (pendingDeleteCharacterId === selectedCharacterId) {
+      return;
+    }
+
+    setDeleteError(null);
+    setChangeCharacterModalVisible(false);
+    setSelectedCharacterSnapshot(null);
+    setSelectedCharacterIdAndRef(null);
+  }, [
+    changeCharacterModalVisible,
+    pendingDeleteCharacterId,
+    selectedCharacter,
+    selectedCharacterId,
+    selectedCharacterSnapshot,
+    setSelectedCharacterIdAndRef,
+  ]);
 
   const handleQuickEditSave = useCallback(async (stats: CharacterStatsOverride) => {
     if (!selectedCharacter || !selectedCharacterId) {
@@ -153,9 +201,11 @@ const MunchkinIndexView: React.FC = () => {
   }, [undoState, update]);
 
   const handleOpenFullEdit = useCallback(() => {
+    setDeleteError(null);
+    setSelectedCharacterSnapshot(selectedCharacter ?? null);
     setPendingFullEditOpen(true);
     setQuickEditVisible(false);
-  }, []);
+  }, [selectedCharacter]);
 
   const handleCopyRoomCodePress = useCallback(() => {
     void copyRoomCode().catch((error) => {
@@ -195,6 +245,7 @@ const MunchkinIndexView: React.FC = () => {
             errorMessage={errorMessage}
             actionError={actionError}
             realtimeUpdateSignals={realtimeUpdateSignals}
+            isCreateBlocked={isCreateBlocked}
             onCreateCharacter={() => setCreateCharacterModalVisible(true)}
             onChangePress={handleChangePress}
           />
@@ -236,12 +287,14 @@ const MunchkinIndexView: React.FC = () => {
             onCancel={() => setCreateCharacterModalVisible(false)}
           />
 
-          {changeCharacterModalVisible && selectedCharacter && (
+          {changeCharacterModalVisible && modalCharacter && (
             <ChangeCharacterModal
-              character={selectedCharacter}
+              character={modalCharacter}
+              deleteError={deleteError}
               onConfirm={async (character) => {
                 try {
                   setActionError(null);
+                  setDeleteError(null);
                   await update(character.id, {
                     nickname: character.nickname,
                     avatar: character.avatar,
@@ -257,7 +310,34 @@ const MunchkinIndexView: React.FC = () => {
                   setActionError(error instanceof Error ? error.message : 'Failed to update character');
                 }
               }}
-              onCancel={() => setChangeCharacterModalVisible(false)}
+              onDelete={async (characterId) => {
+                setPendingDeleteCharacterId(characterId);
+                try {
+                  setActionError(null);
+                  setDeleteError(null);
+                  await remove(characterId);
+                  if (selectedCharacterIdRef.current !== characterId) {
+                    return;
+                  }
+
+                  setChangeCharacterModalVisible(false);
+                  setSelectedCharacterSnapshot(null);
+                  setSelectedCharacterIdAndRef(null);
+                } catch (error) {
+                  if (selectedCharacterIdRef.current !== characterId) {
+                    return;
+                  }
+
+                  setDeleteError(error instanceof Error ? error.message : 'Failed to delete character');
+                } finally {
+                  setPendingDeleteCharacterId((current) => (current === characterId ? null : current));
+                }
+              }}
+              onCancel={() => {
+                setDeleteError(null);
+                setChangeCharacterModalVisible(false);
+                setSelectedCharacterSnapshot(null);
+              }}
             />
           )}
 

--- a/frontend/app/munchkin/modal-change-caracter.tsx
+++ b/frontend/app/munchkin/modal-change-caracter.tsx
@@ -1,6 +1,7 @@
 import { Image } from 'expo-image';
 import { AppTheme } from '@/constants/theme';
-import React, { useState } from 'react';
+import ConfirmDialog from '@/components/ConfirmDialog';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Modal,
   Pressable,
@@ -31,12 +32,16 @@ interface Character {
 interface ChangeCharacterModalProps {
   character?: Character;
   onConfirm: (character: Character) => void;
+  onDelete: (characterId: string) => Promise<void>;
+  deleteError?: string | null;
   onCancel: () => void;
 }
 
 export default function ChangeCharacterModal({
   character: initialCharacter,
   onConfirm,
+  onDelete,
+  deleteError = null,
   onCancel,
 }: ChangeCharacterModalProps) {
   const [character, setCharacter] = useState<Character>(
@@ -55,9 +60,79 @@ export default function ChangeCharacterModal({
   let [newRace, setNewRace] = useState("<Select>");
   let [newClass, setNewClass] = useState("<Select>");
   const [colorModalVisible, setColorModalVisible] = useState(false);
+  const [isDeletePending, setIsDeletePending] = useState(false);
+  const [deleteConfirmVisible, setDeleteConfirmVisible] = useState(false);
+  const pendingDeleteCharacterIdRef = useRef<string | null>(null);
+  const deleteRequestIdRef = useRef(0);
+  const activeDeleteRef = useRef<{ requestId: number; characterId: string } | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!initialCharacter) {
+      return;
+    }
+
+    setCharacter(initialCharacter);
+    setNewRace('<Select>');
+    setNewClass('<Select>');
+    setColorModalVisible(false);
+    setDeleteConfirmVisible(false);
+    setIsDeletePending(false);
+    activeDeleteRef.current = null;
+    pendingDeleteCharacterIdRef.current = null;
+  }, [initialCharacter?.id]);
 
   const handleSave = () => {
+    if (isDeletePending) {
+      return;
+    }
     onConfirm(character);
+  };
+
+  const handleDeleteConfirm = (characterId: string) => {
+    if (isDeletePending) {
+      return;
+    }
+
+    const requestId = deleteRequestIdRef.current + 1;
+    deleteRequestIdRef.current = requestId;
+    activeDeleteRef.current = { requestId, characterId };
+    setIsDeletePending(true);
+    void onDelete(characterId).finally(() => {
+      if (
+        activeDeleteRef.current?.requestId === requestId &&
+        activeDeleteRef.current.characterId === characterId
+      ) {
+        activeDeleteRef.current = null;
+        setIsDeletePending(false);
+      }
+    });
+  };
+
+  const handleDeletePress = () => {
+    pendingDeleteCharacterIdRef.current = character.id;
+    setDeleteConfirmVisible(true);
+  };
+
+  const handleDeleteConfirmAccept = () => {
+    setDeleteConfirmVisible(false);
+    const characterId = pendingDeleteCharacterIdRef.current;
+    if (characterId) {
+      handleDeleteConfirm(characterId);
+    }
+  };
+
+  const handleDeleteConfirmCancel = () => {
+    setDeleteConfirmVisible(false);
+    pendingDeleteCharacterIdRef.current = null;
+  };
+
+  const handleCancel = () => {
+    if (isDeletePending) {
+      return;
+    }
+    onCancel();
   };
 
   const races = ['Human', 'Elf', 'Dwarf', 'Halfling', 'Orc', 'Gnome'];
@@ -80,10 +155,18 @@ export default function ChangeCharacterModal({
     <Modal
       transparent={true}
       animationType="fade"
-      onRequestClose={onCancel}
+      onRequestClose={handleCancel}
     >
       <View style={styles.overlay}>
         <View style={styles.container}>
+          <ConfirmDialog
+            visible={deleteConfirmVisible}
+            title="Delete character?"
+            message="This action cannot be undone."
+            confirmLabel="Delete"
+            onConfirm={handleDeleteConfirmAccept}
+            onCancel={handleDeleteConfirmCancel}
+          />
           <ScrollView
             style={styles.content}
             contentContainerStyle={styles.contentContainer}
@@ -333,22 +416,37 @@ export default function ChangeCharacterModal({
                 </Pressable>
               </Modal>
             </View>
+
+            {deleteError ? (
+              <Text style={styles.deleteErrorText}>{deleteError}</Text>
+            ) : null}
+
+            <TouchableOpacity
+              style={[styles.deleteButton, isDeletePending && styles.deleteButtonDisabled]}
+              onPress={handleDeletePress}
+              activeOpacity={0.8}
+              disabled={isDeletePending}
+            >
+              <Text style={styles.deleteButtonText}>{isDeletePending ? 'Deleting...' : 'Delete'}</Text>
+            </TouchableOpacity>
           </ScrollView>
 
           {/* Buttons */}
           <View style={styles.buttonContainer}>
             <TouchableOpacity
-              style={styles.button}
+              style={[styles.button, isDeletePending && styles.buttonDisabled]}
               onPress={handleSave}
               activeOpacity={0.7}
+              disabled={isDeletePending}
             >
               <Text style={styles.buttonText}>Save</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
-              style={styles.button}
-              onPress={onCancel}
+              style={[styles.button, isDeletePending && styles.buttonDisabled]}
+              onPress={handleCancel}
               activeOpacity={0.7}
+              disabled={isDeletePending}
             >
               <Text style={styles.buttonText}>Cancel</Text>
             </TouchableOpacity>
@@ -653,6 +751,9 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
   buttonText: {
     color: '#CEB464',
     fontSize: 22,
@@ -663,5 +764,29 @@ const styles = StyleSheet.create({
     textShadowColor: '#796834',
     textShadowOffset: { width: 1, height: 1 },
     textShadowRadius: 1,
+  },
+  deleteButton: {
+    marginTop: 4,
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: AppTheme.colors.danger,
+  },
+  deleteButtonDisabled: {
+    opacity: 0.7,
+  },
+  deleteErrorText: {
+    color: AppTheme.colors.danger,
+    fontSize: 14,
+    fontWeight: '600',
+    textAlign: 'center',
+    fontFamily: 'Roboto',
+  },
+  deleteButtonText: {
+    color: AppTheme.colors.textPrimary,
+    fontSize: 16,
+    fontWeight: '600',
+    fontFamily: 'Roboto',
   },
 });

--- a/frontend/components/ConfirmDialog.tsx
+++ b/frontend/components/ConfirmDialog.tsx
@@ -1,0 +1,122 @@
+import { AppTheme } from '@/constants/theme';
+import React, { useEffect } from 'react';
+import { Alert, Modal, Platform, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+interface ConfirmDialogProps {
+  visible: boolean;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Cross-platform confirmation dialog.
+ * Native: delegates to Alert.alert (system sheet).
+ * Web: renders an inline modal overlay (Alert.alert is a no-op on web).
+ */
+export default function ConfirmDialog({
+  visible,
+  title,
+  message,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  useEffect(() => {
+    if (Platform.OS === 'web' || !visible) {
+      return;
+    }
+
+    Alert.alert(
+      title,
+      message,
+      [
+        { text: 'Cancel', style: 'cancel', onPress: onCancel },
+        { text: confirmLabel, style: 'destructive', onPress: onConfirm },
+      ],
+      { cancelable: true, onDismiss: onCancel }
+    );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
+
+  if (Platform.OS !== 'web') {
+    return null;
+  }
+
+  return (
+    <Modal transparent animationType="fade" visible={visible} onRequestClose={onCancel}>
+      {visible && (
+        <Pressable style={styles.overlay} onPress={onCancel}>
+          <Pressable style={styles.dialog} onPress={() => {}}>
+            <Text style={styles.title}>{title}</Text>
+            <Text style={styles.message}>{message}</Text>
+            <View style={styles.buttons}>
+              <TouchableOpacity style={[styles.button, styles.cancelButton]} onPress={onCancel}>
+                <Text style={styles.cancelText}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.button, styles.confirmButton]} onPress={onConfirm} testID="confirm-dialog-confirm">
+                <Text style={styles.confirmText}>{confirmLabel}</Text>
+              </TouchableOpacity>
+            </View>
+          </Pressable>
+        </Pressable>
+      )}
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  dialog: {
+    backgroundColor: AppTheme.colors.elevated,
+    borderRadius: AppTheme.radius.lg,
+    padding: AppTheme.spacing.xl,
+    width: 300,
+    gap: AppTheme.spacing.md,
+  },
+  title: {
+    color: AppTheme.colors.textPrimary,
+    fontSize: 17,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  message: {
+    color: AppTheme.colors.textMuted,
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: AppTheme.spacing.sm,
+    marginTop: AppTheme.spacing.sm,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: AppTheme.spacing.sm,
+    borderRadius: AppTheme.radius.md,
+    alignItems: 'center',
+  },
+  cancelButton: {
+    backgroundColor: AppTheme.colors.surfaceSubtle,
+  },
+  confirmButton: {
+    backgroundColor: AppTheme.colors.danger,
+  },
+  cancelText: {
+    color: AppTheme.colors.textPrimary,
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  confirmText: {
+    color: AppTheme.colors.textPrimary,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/frontend/components/VioletButton.tsx
+++ b/frontend/components/VioletButton.tsx
@@ -5,10 +5,11 @@ import { AppTheme } from '@/constants/theme';
 type VioletButtonProps = {
   title: string;
   onPress: () => void;
+  disabled?: boolean;
 };
 
-const VioletButton: React.FC<VioletButtonProps> = ({ title, onPress }) => (
-  <TouchableOpacity style={styles.violetButton} onPress={onPress}>
+const VioletButton: React.FC<VioletButtonProps> = ({ title, onPress, disabled = false }) => (
+  <TouchableOpacity style={[styles.violetButton, disabled && styles.violetButtonDisabled]} onPress={onPress} disabled={disabled}>
     <Text style={styles.violetButtonText}>{title}</Text>
   </TouchableOpacity>
 );
@@ -21,6 +22,9 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  violetButtonDisabled: {
+    opacity: 0.55,
   },
   violetButtonText: {
     fontSize: 16,

--- a/frontend/components/munchkin/RoomCharactersList.tsx
+++ b/frontend/components/munchkin/RoomCharactersList.tsx
@@ -11,6 +11,7 @@ interface RoomCharactersListProps {
   errorMessage: string | null;
   actionError: string | null;
   realtimeUpdateSignals: Record<string, number>;
+  isCreateBlocked: boolean;
   onCreateCharacter: () => void;
   onChangePress: (character: RoomCharacter) => void;
 }
@@ -21,6 +22,7 @@ const RoomCharactersList = memo(function RoomCharactersList({
   errorMessage,
   actionError,
   realtimeUpdateSignals,
+  isCreateBlocked,
   onCreateCharacter,
   onChangePress,
 }: RoomCharactersListProps) {
@@ -76,7 +78,7 @@ const RoomCharactersList = memo(function RoomCharactersList({
       ListEmptyComponent={listEmpty}
       ListFooterComponent={
         <View style={styles.createCharacterButtonContainer}>
-          <VioletButton title="Create a character" onPress={onCreateCharacter} />
+          <VioletButton title="Create a character" onPress={onCreateCharacter} disabled={isCreateBlocked} />
         </View>
       }
       removeClippedSubviews

--- a/frontend/hooks/useCharacters.test.ts
+++ b/frontend/hooks/useCharacters.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type Character,
   createCharacter,
+  deleteCharacter,
   getCharactersByRoom,
   updateCharacter,
 } from '@/api/characters';
@@ -18,6 +19,7 @@ const mockSubscribe = vi.fn<(listener: (event: { event: string; event_body: { ch
 
 vi.mock('@/api/characters', () => ({
   createCharacter: vi.fn(),
+  deleteCharacter: vi.fn(),
   getCharactersByRoom: vi.fn(),
   updateCharacter: vi.fn(),
 }));
@@ -31,6 +33,7 @@ vi.mock('@/hooks/useRoomWebSocket', () => ({
 
 const mockGetCharactersByRoom = vi.mocked(getCharactersByRoom);
 const mockCreateCharacter = vi.mocked(createCharacter);
+const mockDeleteCharacter = vi.mocked(deleteCharacter);
 const mockUpdateCharacter = vi.mocked(updateCharacter);
 
 describe('useRoomCharacters', () => {
@@ -57,6 +60,7 @@ describe('useRoomCharacters', () => {
 
     mockGetCharactersByRoom.mockReset();
     mockCreateCharacter.mockReset();
+    mockDeleteCharacter.mockReset();
     mockUpdateCharacter.mockReset();
     mockSubscribe.mockReset();
     mockSubscribe.mockImplementation(() => () => undefined);
@@ -167,6 +171,328 @@ describe('useRoomCharacters', () => {
         power: 5,
       })
     );
+  });
+
+  it('removes characters and keeps query state in sync', async () => {
+    const initialCharacters = [
+      {
+        id: 'char-self',
+        roomId,
+        userId: userProfile.id,
+        nickname: 'Hero',
+        avatar: 1,
+        color: '#AA5500',
+        level: 2,
+        power: 3,
+        race: ['Human'],
+        gender: ['male'],
+        class: ['Warrior'],
+      },
+      {
+        id: 'char-other',
+        roomId,
+        userId: 'user-2',
+        nickname: 'Rogue',
+        avatar: 2,
+        color: '#0088CC',
+        level: 4,
+        power: 1,
+        race: ['Elf'],
+        gender: ['female'],
+        class: ['Thief'],
+      },
+    ];
+
+    mockGetCharactersByRoom
+      .mockResolvedValueOnce(initialCharacters)
+      .mockResolvedValue([initialCharacters[0]]);
+    mockDeleteCharacter.mockResolvedValue(undefined);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useRoomCharacters(roomId, userProfile), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.characters).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await result.current.remove('char-other');
+    });
+
+    await waitFor(() => {
+      expect(result.current.characters).toHaveLength(1);
+      expect(result.current.characters[0]?.id).toBe('char-self');
+    });
+
+    expect(mockDeleteCharacter).toHaveBeenCalledWith('char-other');
+  });
+
+  it('does not auto-recreate the current user character after an intentional self-delete', async () => {
+    const initialCharacters = [
+      {
+        id: 'char-self',
+        roomId,
+        userId: userProfile.id,
+        nickname: 'Hero',
+        avatar: 1,
+        color: '#AA5500',
+        level: 2,
+        power: 3,
+        race: ['Human'],
+        gender: ['male'],
+        class: ['Warrior'],
+      },
+      {
+        id: 'char-other',
+        roomId,
+        userId: 'user-2',
+        nickname: 'Rogue',
+        avatar: 2,
+        color: '#0088CC',
+        level: 4,
+        power: 1,
+        race: ['Elf'],
+        gender: ['female'],
+        class: ['Thief'],
+      },
+    ];
+
+    mockGetCharactersByRoom
+      .mockResolvedValueOnce(initialCharacters)
+      .mockResolvedValue([initialCharacters[1]]);
+    mockDeleteCharacter.mockResolvedValue(undefined);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useRoomCharacters(roomId, userProfile), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.characters).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await result.current.remove('char-self');
+    });
+
+    await waitFor(() => {
+      expect(result.current.characters).toHaveLength(1);
+      expect(result.current.characters[0]?.id).toBe('char-other');
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteCharacter).toHaveBeenCalledWith('char-self');
+    });
+
+    expect(mockCreateCharacter).not.toHaveBeenCalled();
+  });
+
+  it('blocks creating a replacement current-user character while self-delete is still in flight', async () => {
+    const selfCharacter: Character = {
+      id: 'char-self',
+      roomId,
+      userId: userProfile.id,
+      nickname: 'Hero',
+      avatar: 1,
+      color: '#AA5500',
+      level: 2,
+      power: 3,
+      race: ['Human'],
+      gender: ['male'],
+      class: ['Warrior'],
+    };
+    const otherCharacter: Character = {
+      id: 'char-other',
+      roomId,
+      userId: 'user-2',
+      nickname: 'Rogue',
+      avatar: 2,
+      color: '#0088CC',
+      level: 4,
+      power: 1,
+      race: ['Elf'],
+      gender: ['female'],
+      class: ['Thief'],
+    };
+    const replacementCharacter: Character = {
+      id: 'char-replacement',
+      roomId,
+      userId: userProfile.id,
+      nickname: 'Replacement',
+      avatar: 3,
+      color: '#11AA77',
+      level: 1,
+      power: 0,
+      race: ['Human'],
+      gender: ['female'],
+      class: [],
+    };
+
+    let resolveDelete!: () => void;
+    mockGetCharactersByRoom
+      .mockResolvedValueOnce([selfCharacter, otherCharacter])
+      .mockResolvedValue([otherCharacter]);
+    mockDeleteCharacter.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        })
+    );
+    mockCreateCharacter.mockResolvedValue(replacementCharacter);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useRoomCharacters(roomId, userProfile), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.characters).toHaveLength(2);
+    });
+
+    let pendingDelete!: Promise<void>;
+    await act(async () => {
+      pendingDelete = result.current.remove('char-self');
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isCreateBlocked).toBe(true);
+      expect(result.current.characters.some((character) => character.id === 'char-self')).toBe(false);
+    });
+
+    await expect(
+      result.current.create({
+        userId: userProfile.id,
+        nickname: 'Replacement',
+        avatar: 3,
+        color: '#11AA77',
+        level: 1,
+        power: 0,
+        race: ['Human'],
+        gender: ['female'],
+        class: [],
+      })
+    ).rejects.toThrow('Please wait for character removal to finish before creating a new one');
+    expect(mockCreateCharacter).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveDelete();
+      await pendingDelete;
+    });
+
+    await waitFor(() => {
+      expect(result.current.isCreateBlocked).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.create({
+        userId: userProfile.id,
+        nickname: 'Replacement',
+        avatar: 3,
+        color: '#11AA77',
+        level: 1,
+        power: 0,
+        race: ['Human'],
+        gender: ['female'],
+        class: [],
+      });
+    });
+
+    expect(mockCreateCharacter).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves newer local mutations when a delete rollback restores the removed character', async () => {
+    const selfCharacter: Character = {
+      id: 'char-self',
+      roomId,
+      userId: userProfile.id,
+      nickname: 'Hero',
+      avatar: 1,
+      color: '#AA5500',
+      level: 2,
+      power: 3,
+      race: ['Human'],
+      gender: ['male'],
+      class: ['Warrior'],
+    };
+    const otherCharacter: Character = {
+      id: 'char-other',
+      roomId,
+      userId: 'user-2',
+      nickname: 'Rogue',
+      avatar: 2,
+      color: '#0088CC',
+      level: 4,
+      power: 1,
+      race: ['Elf'],
+      gender: ['female'],
+      class: ['Thief'],
+    };
+
+    let rejectDelete!: (reason?: unknown) => void;
+    mockGetCharactersByRoom.mockResolvedValueOnce([selfCharacter, otherCharacter]);
+    mockDeleteCharacter.mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectDelete = reject;
+        })
+    );
+    mockUpdateCharacter.mockResolvedValue({
+      ...selfCharacter,
+      power: 9,
+    });
+
+    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useRoomCharacters(roomId, userProfile), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.characters).toHaveLength(2);
+    });
+
+    let pendingDelete: Promise<void> | undefined;
+    await act(async () => {
+      pendingDelete = result.current.remove('char-other').catch(() => undefined);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.characters.map((character) => character.id)).toEqual(['char-self']);
+    });
+
+    await act(async () => {
+      await result.current.update('char-self', { power: 9 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.characters.find((character) => character.id === 'char-self')?.power).toBe(9);
+    });
+
+    await act(async () => {
+      rejectDelete(new Error('delete failed'));
+      await pendingDelete;
+    });
+
+    await waitFor(() => {
+      expect(result.current.characters).toHaveLength(2);
+      expect(result.current.characters.find((character) => character.id === 'char-self')?.power).toBe(9);
+      expect(result.current.characters.some((character) => character.id === 'char-other')).toBe(true);
+    });
+
+    invalidateQueriesSpy.mockRestore();
   });
 
   it('raises realtime update signals for websocket character updates, including the current user card', async () => {

--- a/frontend/hooks/useCharacters.ts
+++ b/frontend/hooks/useCharacters.ts
@@ -3,6 +3,7 @@ import {
   CharacterUpdatePayload,
   CharacterWritePayload,
   createCharacter,
+  deleteCharacter,
   getCharactersByRoom,
   updateCharacter,
 } from '@/api/characters';
@@ -16,9 +17,11 @@ interface UseRoomCharactersResult {
   realtimeUpdateSignals: Record<string, number>;
   isLoading: boolean;
   errorMessage: string | null;
+  isCreateBlocked: boolean;
   refresh: () => Promise<void>;
   create: (payload: Omit<CharacterWritePayload, 'roomId'>) => Promise<Character>;
   update: (characterId: string, payload: CharacterUpdatePayload) => Promise<Character>;
+  remove: (characterId: string) => Promise<void>;
 }
 
 const ENSURE_CHARACTER_COOLDOWN_MS = 5000;
@@ -27,6 +30,9 @@ const getCharactersQueryKey = (roomId: string | undefined): readonly ['character
 
 type CharactersMutationContext = {
   previousCharacters: Character[];
+  deletedCharacter?: Character;
+  deletedCharacterIndex?: number;
+  previousAutoCreateSuppressedForCurrentUser?: boolean;
 };
 
 type PendingLocalUpdateMarker = {
@@ -94,8 +100,11 @@ export function useRoomCharacters(roomId: string | undefined, userProfile: UserP
   const queryClient = useQueryClient();
   const isEnsuringCurrentCharacterRef = useRef(false);
   const lastEnsureAttemptAtRef = useRef(0);
+  const autoCreateSuppressedForCurrentUserRef = useRef(false);
+  const pendingCurrentUserDeleteCountRef = useRef(0);
   const recentLocalUpdateByCharacterRef = useRef<Map<string, PendingLocalUpdateMarker>>(new Map());
   const [realtimeUpdateSignals, setRealtimeUpdateSignals] = useState<Record<string, number>>({});
+  const [isCreateBlocked, setIsCreateBlocked] = useState(false);
 
   // Set up WebSocket connection for real-time updates
   const { isConnected, subscribe } = useRoomWebSocket(
@@ -153,6 +162,10 @@ export function useRoomCharacters(roomId: string | undefined, userProfile: UserP
       }
     },
     onSuccess: (createdCharacter) => {
+      if (createdCharacter.userId === userProfile.id) {
+        autoCreateSuppressedForCurrentUserRef.current = false;
+      }
+
       queryClient.setQueryData<Character[]>(getCharactersQueryKey(roomId), (currentCharacters = []) => {
         const nonOptimisticCharacters = currentCharacters.filter((character) => !character.id.startsWith('temp-'));
         return [...nonOptimisticCharacters, createdCharacter];
@@ -211,6 +224,74 @@ export function useRoomCharacters(roomId: string | undefined, userProfile: UserP
     },
   });
 
+  const deleteMutation = useMutation<void, Error, { characterId: string }, CharactersMutationContext>({
+    mutationFn: async ({ characterId }) => {
+      await deleteCharacter(characterId);
+    },
+    onMutate: async ({ characterId }) => {
+      const queryKey = getCharactersQueryKey(roomId);
+      await queryClient.cancelQueries({ queryKey });
+      const previousCharacters = queryClient.getQueryData<Character[]>(queryKey) ?? [];
+      const deletedCharacter = previousCharacters.find((character) => character.id === characterId);
+      const deletedCharacterIndex = previousCharacters.findIndex((character) => character.id === characterId);
+      const previousAutoCreateSuppressedForCurrentUser = autoCreateSuppressedForCurrentUserRef.current;
+
+      if (deletedCharacter?.userId === userProfile.id) {
+        autoCreateSuppressedForCurrentUserRef.current = true;
+        pendingCurrentUserDeleteCountRef.current += 1;
+        setIsCreateBlocked(true);
+      }
+
+      queryClient.setQueryData<Character[]>(queryKey, (currentCharacters = []) =>
+        currentCharacters.filter((character) => character.id !== characterId)
+      );
+
+      return { previousCharacters, deletedCharacter, deletedCharacterIndex, previousAutoCreateSuppressedForCurrentUser };
+    },
+    onError: (_error, _variables, context) => {
+      autoCreateSuppressedForCurrentUserRef.current = context?.previousAutoCreateSuppressedForCurrentUser ?? false;
+
+      if (context?.deletedCharacter) {
+        const deletedCharacter = context.deletedCharacter;
+        queryClient.setQueryData<Character[]>(getCharactersQueryKey(roomId), (currentCharacters = []) => {
+          const alreadyPresent = currentCharacters.some((character) => character.id === deletedCharacter.id);
+
+          if (alreadyPresent) {
+            return currentCharacters;
+          }
+
+          const insertionIndex = (context.deletedCharacterIndex ?? -1) >= 0
+            ? Math.min(context.deletedCharacterIndex!, currentCharacters.length)
+            : currentCharacters.length;
+
+          return [
+            ...currentCharacters.slice(0, insertionIndex),
+            deletedCharacter,
+            ...currentCharacters.slice(insertionIndex),
+          ];
+        });
+        return;
+      }
+
+      if (context?.previousCharacters) {
+        queryClient.setQueryData(getCharactersQueryKey(roomId), context.previousCharacters);
+      }
+    },
+    onSettled: (_data, _error, _variables, context) => {
+      if (context?.deletedCharacter?.userId === userProfile.id) {
+        pendingCurrentUserDeleteCountRef.current = Math.max(0, pendingCurrentUserDeleteCountRef.current - 1);
+        setIsCreateBlocked(pendingCurrentUserDeleteCountRef.current > 0);
+      } else if (context === undefined) {
+        // onMutate threw — refs may be in an inconsistent state; reset to safe defaults
+        autoCreateSuppressedForCurrentUserRef.current = false;
+        pendingCurrentUserDeleteCountRef.current = 0;
+        setIsCreateBlocked(false);
+      }
+
+      void queryClient.invalidateQueries({ queryKey: getCharactersQueryKey(roomId) });
+    },
+  });
+
   // Subscribe to WebSocket events for real-time character updates
   useEffect(() => {
     if (!isConnected) {
@@ -258,25 +339,43 @@ export function useRoomCharacters(roomId: string | undefined, userProfile: UserP
 
   useEffect(() => {
     setRealtimeUpdateSignals({});
+    autoCreateSuppressedForCurrentUserRef.current = false;
+    pendingCurrentUserDeleteCountRef.current = 0;
     recentLocalUpdateByCharacterRef.current.clear();
+    setIsCreateBlocked(false);
   }, [roomId]);
 
   const create = useCallback(
     async (payload: Omit<CharacterWritePayload, 'roomId'>) => {
+      if (
+        payload.userId === userProfile.id &&
+        pendingCurrentUserDeleteCountRef.current > 0
+      ) {
+        throw new Error('Please wait for character removal to finish before creating a new one');
+      }
+
       return createMutation.mutateAsync(payload);
     },
-    [createMutation]
+    [createMutation, userProfile.id]
   );
 
   const update = useCallback(async (characterId: string, payload: CharacterUpdatePayload) => {
     return updateMutation.mutateAsync({ characterId, payload });
   }, [updateMutation]);
 
+  const remove = useCallback(async (characterId: string) => {
+    await deleteMutation.mutateAsync({ characterId });
+  }, [deleteMutation]);
+
   const characters = charactersQuery.data ?? [];
   const hasCompletedInitialFetch = charactersQuery.isFetchedAfterMount && !charactersQuery.isFetching;
 
   useEffect(() => {
     if (!roomId || !userProfile.id || !hasCompletedInitialFetch) {
+      return;
+    }
+
+    if (autoCreateSuppressedForCurrentUserRef.current) {
       return;
     }
 
@@ -337,10 +436,12 @@ export function useRoomCharacters(roomId: string | undefined, userProfile: UserP
       realtimeUpdateSignals,
       isLoading,
       errorMessage,
+      isCreateBlocked,
       refresh,
       create,
       update,
+      remove,
     }),
-    [characters, create, errorMessage, isLoading, realtimeUpdateSignals, refresh, update]
+    [characters, create, errorMessage, isCreateBlocked, isLoading, realtimeUpdateSignals, refresh, remove, update]
   );
 }


### PR DESCRIPTION
## Summary

Implements **Story 3.10 — Character Removal**: allows any player in a Munchkin room to delete any character, regardless of ownership, with an explicit confirmation step to prevent accidental deletions.

---

## What Changed

### 🗑️ Backend — `character-service`
- Removed the `userId` ownership restriction on `DELETE /characters/:characterId` — all characters are now deletable by any room participant.
- Added two new integration tests covering both unassociated and associated character deletion (both must return `204 No Content`).

### 🔌 Frontend API — `api/characters.ts`
- Added `deleteCharacter(characterId: string): Promise<void>` helper that calls `DELETE /characters/:characterId` with proper `encodeURIComponent` encoding.
- Added unit tests for successful deletion and error propagation.

### 🪝 Hook — `useCharacters.ts`
- Added `remove(characterId)` async method backed by a React Query `useMutation` with **optimistic updates**: the character is removed from the local cache immediately, then rolled back on error.
- Added `isCreateBlocked` state that temporarily blocks auto-creation of a new character for the current user while their own character delete is in-flight, preventing a race condition.
- Tracked `pendingCurrentUserDeleteCount` to coordinate the block correctly across concurrent mutations.
- Extended the hook's return type with `remove` and `isCreateBlocked`.

### 🎭 Modal — `modal-change-caracter.tsx`
- Added a **Delete** button (destructive/red styling) at the bottom of the characteristics section, visible for all characters.
- Added `onDelete(characterId)` and `deleteError` props.
- Gated deletion behind a `ConfirmDialog`; on confirm → calls `onDelete`, closes modal cleanly; on cancel → dismisses dialog, returns user to modal with no side effects.
- Added `isDeletePending` state to disable the Delete button while a request is in-flight.
- Fixed a stale-closure issue with `initialCharacter` reset using a `useEffect` keyed on the character's `id`.

### 🆕 Component — `ConfirmDialog.tsx`
- New cross-platform confirmation dialog component.
  - **Native (iOS/Android)**: delegates to `Alert.alert` for a system-native sheet.
  - **Web**: renders a custom inline modal overlay (because `Alert.alert` is a no-op on web).
- Props: `visible`, `title`, `message`, `confirmLabel`, `onConfirm`, `onCancel`.

### 🖥️ Room Screen — `[roomNumber]/index.tsx`
- Wired `remove` and `isCreateBlocked` from `useRoomCharacters`.
- Added `selectedCharacterSnapshot` state to keep the modal mounted with the last-known character data while the async delete completes, then clears both selection and snapshot together.
- Added `pendingDeleteCharacterId` and `deleteError` state for coordinating the delete lifecycle with the modal.
- Passed `onDelete` and `deleteError` down to `ChangeCharacterModal`.

### 🔘 Component — `VioletButton.tsx`
- Added optional `disabled` prop (defaults to `false`) with 55% opacity visual feedback when disabled.

### 📋 Component — `RoomCharactersList.tsx`
- Passes `isCreateBlocked` to `VioletButton` for the "Create a character" button, disabling it during a self-character deletion.

---

## Tests Added / Updated

| File | Coverage added |
|---|---|
| `backend/character-service/src/app.test.ts` | Delete unassociated + associated character |
| `frontend/api/characters.test.ts` | `deleteCharacter` success & error propagation |
| `frontend/hooks/useCharacters.test.ts` | `remove` mutation, optimistic rollback, `isCreateBlocked` logic (326 lines) |
| `frontend/__tests__/app/munchkin/[roomNumber].test.tsx` | Delete flow from room view, snapshot preservation, error display |
| `frontend/__tests__/app/munchkin/modal-change-caracter.test.tsx` | *(new)* Delete button rendering, confirm/cancel flows, pending state (343 lines) |

---

## Acceptance Criteria

- [x] Any character in a room can be deleted regardless of `userId`
- [x] User sees an explicit confirmation dialog before deletion executes
- [x] On cancel: modal remains open, no side effects
- [x] On confirm: character removed, modal closes, room view stays interactive
- [x] Realtime `character_deleted` WebSocket events remain the source of truth for cross-client removal
- [x] No regressions in character selection, footer rendering, or quick-edit flows
- [x] "Create a character" button is blocked during own-character deletion to avoid race conditions
