### PR TITLE
chore: Sync BMAD stories to GitHub Project

### DIFF
--- a/.github/workflows/story-project-sync.yml
+++ b/.github/workflows/story-project-sync.yml
@@ -1,0 +1,65 @@
+name: Story Project Sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "_bmad-output/planning-artifacts/**"
+      - "_bmad-output/implementation-artifacts/**"
+      - "scripts/story-project-sync.mjs"
+      - ".github/workflows/story-project-sync.yml"
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - closed
+    paths:
+      - "_bmad-output/implementation-artifacts/**"
+      - "scripts/story-project-sync.mjs"
+      - ".github/workflows/story-project-sync.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: story-project-sync-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  sync_story_project:
+    name: Sync Story Project
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+      PROJECT_OWNER: REW1L
+      PROJECT_NUMBER: "1"
+      PROJECT_TITLE: Munch Helper project
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate Required Inputs
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "Missing required secret: GH_PROJECT_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Verify GitHub CLI Auth
+        run: gh auth status
+
+      - name: Sync Story Issues and Project Status
+        run: node scripts/story-project-sync.mjs

--- a/.github/workflows/story-project-sync.yml
+++ b/.github/workflows/story-project-sync.yml
@@ -10,10 +10,6 @@ on:
       - "scripts/story-project-sync.mjs"
       - ".github/workflows/story-project-sync.yml"
   pull_request:
-    types:
-      - opened
-      - reopened
-      - closed
     paths:
       - "_bmad-output/implementation-artifacts/**"
       - "scripts/story-project-sync.mjs"

--- a/README.md
+++ b/README.md
@@ -174,6 +174,30 @@ How to keep BMAD artifacts useful:
 2. Update affected artifacts when scope or implementation changes.
 3. Keep `docs/` aligned with shipped architecture/runtime behavior so future BMAD runs stay grounded.
 
+## Story Project Automation
+
+This repository includes `.github/workflows/story-project-sync.yml` to keep BMAD stories aligned with repository issues and the GitHub Project at `https://github.com/users/REW1L/projects/1`.
+
+Required repository secret:
+
+- `GH_PROJECT_TOKEN`: classic PAT with `repo` and `project` scope. The workflow uses this token for `gh issue` and `gh project` commands because the target project is user-owned.
+
+Current project assumptions:
+
+- Project owner: `REW1L`
+- Project number: `1`
+- Project title: `Munch Helper project`
+- Status field name: `Status`
+- Required status options: `Ready for Dev`, `Review`, `Done`
+
+Supported lifecycle sync:
+
+- A story mentioned in `_bmad-output/planning-artifacts/**` on `main` creates or reuses a matching repository issue and adds it to the project.
+- A story file added under `_bmad-output/implementation-artifacts/` creates the issue and project item if missing, then sets project status to `Ready for Dev`.
+- A pull request that touches exactly one story implementation artifact and whose artifact status is no longer `ready-for-dev` sets the project status to `Review`.
+- A merged `main` change that moves an implementation artifact status to `done` sets the project status to `Done`.
+- A pull request for a story that is closed without merge moves the project status from `Review` back to `Ready for Dev`.
+
 ## Documentation
 
 - Project docs index: `docs/index.md`

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ How to keep BMAD artifacts useful:
 
 ## Story Project Automation
 
-This repository includes `.github/workflows/story-project-sync.yml` to keep BMAD stories aligned with repository issues and the GitHub Project at `https://github.com/users/REW1L/projects/1`.
+This repository includes `.github/workflows/story-project-sync.yml` to keep BMAD stories and implementation specs aligned with repository issues and the GitHub Project at `https://github.com/users/REW1L/projects/1`.
 
 Required repository secret:
 
@@ -193,10 +193,10 @@ Current project assumptions:
 Supported lifecycle sync:
 
 - A story mentioned in `_bmad-output/planning-artifacts/**` on `main` creates or reuses a matching repository issue and adds it to the project.
-- A story file added under `_bmad-output/implementation-artifacts/` creates the issue and project item if missing, then sets project status to `Ready for Dev`.
-- A pull request that touches exactly one story implementation artifact and whose artifact status is no longer `ready-for-dev` sets the project status to `Review`.
-- A merged `main` change that moves an implementation artifact status to `done` sets the project status to `Done`.
-- A pull request for a story that is closed without merge moves the project status from `Review` back to `Ready for Dev`.
+- A story or approved `spec-*.md` file added under `_bmad-output/implementation-artifacts/` creates the issue and project item if missing, then sets project status to `Ready for Dev`.
+- A pull request that touches exactly one tracked implementation artifact and whose artifact status is no longer `ready-for-dev` sets the project status to `Review`.
+- A merged `main` change that moves a tracked implementation artifact status to `done` sets the project status to `Done`.
+- A pull request for a tracked implementation artifact that is closed without merge moves the project status from `Review` back to `Ready for Dev`.
 
 ## Documentation
 

--- a/_bmad-output/implementation-artifacts/spec-story-project-status-sync.md
+++ b/_bmad-output/implementation-artifacts/spec-story-project-status-sync.md
@@ -1,0 +1,118 @@
+---
+title: 'Story Project Status Sync'
+type: 'feature'
+created: '2026-04-10'
+status: 'done'
+baseline_commit: '6826790'
+context:
+  - '_bmad-output/project-context.md'
+  - '_bmad-output/planning-artifacts/epics/index.md'
+  - 'README.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** BMAD story state currently lives only in markdown artifacts and pull-request flow, so the GitHub Project at `users/REW1L/projects/1` and the repository issue tracker drift from the real implementation lifecycle. That forces manual issue creation and manual status movement for stories.
+
+**Approach:** Add repository automation that watches merged `main` changes and pull-request lifecycle events, derives a canonical story identity from BMAD artifact files, creates or reuses a matching repository issue for each story, adds that issue to the GitHub Project when needed, and uses `gh project` commands from GitHub Actions to keep the project `Status` field aligned with the story lifecycle (`Ready for Dev`, `Review`, `Done`).
+
+## Boundaries & Constraints
+
+**Always:** Use BMAD story headings and implementation artifact filenames as the source of truth for story identity; create a repository issue as the canonical ticket record before managing its project item; keep automation idempotent so reruns do not create duplicate issues or duplicate project items or regress completed states; use a repository secret-backed token for project writes because the target is a user-owned GitHub Project; target project number `1`, project title `Munch Helper project`, and the existing `Status` field options `Ready for Dev`, `Review`, and `Done`; handle only the explicit lifecycle transitions requested by the user.
+
+**Ask First:** If the target GitHub Project no longer exposes a `Status` single-select field with the expected option labels, or if repository issue creation needs additional metadata beyond the story title and a minimal BMAD reference body, stop and ask before inventing a fallback.
+
+**Never:** Do not infer story identity from PR titles alone when the artifact file is absent or ambiguous; do not create draft project items when a repository issue can be used; do not mutate unrelated project fields; do not replace `gh project` or `gh issue` with bespoke GraphQL or REST mutation code unless the CLI proves insufficient for a required transition.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| STORY_DISCOVERED | A push to `main` adds or updates a planning artifact that now mentions `Story X.Y: Name`, and no matching repository issue exists yet | A repository issue titled `Story X.Y: Name` is created and added to the project | Log and fail the run if issue/project access or story parsing fails |
+| ARTIFACT_CREATED | A push to `main` adds `_bmad-output/implementation-artifacts/<story-slug>.md` for a story | The workflow ensures the matching repository issue exists, adds it to the project if needed, then sets project status to `Ready for Dev` | Skip status mutation when the story item cannot be resolved uniquely |
+| PR_OPENED_FOR_STORY | A pull request touches exactly one story implementation artifact whose markdown `Status:` is not `ready-for-dev` | Matching project item status becomes `Review` | Ignore PRs that do not map cleanly to one story artifact |
+| STORY_DONE_ON_MAIN | A push to `main` changes a story implementation artifact status to `done` | Matching project item status becomes `Done` | Preserve current project item when the artifact status is not parseable |
+| PR_CLOSED_UNMERGED | A pull request closes with `merged = false` and still maps to a story currently in `Review` | Matching project item status returns to `Ready for Dev` | Ignore the event when the project item or review status cannot be confirmed |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `.github/workflows/story-project-sync.yml` -- Event wiring for `push` and `pull_request` story lifecycle sync.
+- `scripts/story-project-sync.mjs` -- Shared Node-based sync engine for event parsing, story resolution, change detection, repository issue lookup/creation, and `gh project` command orchestration.
+- `scripts/story-project-sync.test.mjs` -- Regression coverage for story parsing, transition decisions, issue deduplication, and duplicate-protection logic around the CLI command plan.
+- `README.md` -- Operator setup for required project secret and workflow behavior.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `scripts/story-project-sync.mjs` -- Implement reusable sync logic that loads event context, reads changed BMAD files from the checked-out repo, resolves story number/title/status, finds or creates the matching repository issue via `gh issue`, adds that issue to project `1` when needed, and emits deterministic `gh project item-edit` commands for the requested transition path -- keeps story logic centralized while delegating issue/project mutations to the GitHub CLI.
+- [x] `.github/workflows/story-project-sync.yml` -- Add a workflow that runs on pushes to `main` and PR opened/reopened/closed events, checks out enough history for change detection, ensures `gh` is authenticated with the required token secret, resolves the project and field metadata through `gh project list`, `gh project field-list`, and `gh project item-list`, and invokes the sync script -- wires the automation into GitHub without duplicating logic.
+- [x] `scripts/story-project-sync.test.mjs` -- Add targeted tests for story heading parsing, artifact-status parsing, transition selection, repository issue deduplication, and duplicate project-item avoidance, including the generated `gh issue` and `gh project` command plan -- protects the non-trivial lifecycle mapping rules.
+- [x] `README.md` -- Document the required PAT secret, the dependency on repository issues as the created ticket type, project number `1`, expected `Status` field labels, and the five supported lifecycle transitions -- makes the automation operable by humans after merge.
+
+**Acceptance Criteria:**
+- Given a story appears in merged BMAD planning artifacts on `main`, when no matching repository issue exists yet, then the workflow creates exactly one issue titled with the full story number and name and adds it to the project.
+- Given a merged `main` change adds a story implementation artifact, when the workflow processes the story, then it creates the matching repository issue and project item if either is missing and sets project `Status` to `Ready for Dev`.
+- Given a pull request maps cleanly to a story implementation artifact whose markdown status is no longer `ready-for-dev`, when the PR is opened or reopened, then the matching project item `Status` becomes `Review`.
+- Given a merged `main` change updates a story implementation artifact status to `done`, when the workflow processes the push, then the matching project item `Status` becomes `Done`.
+- Given a pull request mapped to a story is closed without merge while the project item is in `Review`, when the close event is processed, then the matching project item `Status` returns to `Ready for Dev`.
+- Given the same story is encountered again by later workflow runs, when the repository issue or project item already exists, then the automation reuses them and does not create duplicates.
+
+## Spec Change Log
+
+## Design Notes
+
+Use one script for all event types so the story-identification rules, issue lookup, project-item lookup, and status mapping stay consistent across `push` and `pull_request` flows. Prefer deterministic repository-derived data over PR metadata because the BMAD artifacts already encode the canonical story number, title, and current state. The script should compute what `gh issue` and `gh project` operations are needed, then execute only those commands, keeping GitHub-specific behavior thin and observable.
+
+## Verification
+
+**Commands:**
+- `node --test scripts/story-project-sync.test.mjs` -- expected: story parsing and transition tests pass
+- `node scripts/story-project-sync.mjs --help` -- expected: script prints usage/config summary without throwing
+- `GH_TOKEN=dummy node scripts/story-project-sync.mjs --dry-run` -- expected: script prints the planned `gh issue` and `gh project` commands without executing them
+
+**Manual checks (if no CLI):**
+- Create a dry-run-friendly workflow invocation or inspect logs from a test branch to confirm the script reports the intended story/item/status mapping before live project mutations are enabled.
+
+## Suggested Review Order
+
+**Workflow Entry**
+
+- Start at the event wiring and checkout strategy for push and PR lifecycle handling.
+  [`story-project-sync.yml:1`](../../.github/workflows/story-project-sync.yml#L1)
+
+- Verify the PR head checkout fix so closed and reopened PRs diff correctly.
+  [`story-project-sync.yml:42`](../../.github/workflows/story-project-sync.yml#L42)
+
+**Story Detection**
+
+- Review how push events collapse planning mentions and artifact transitions into one action set.
+  [`story-project-sync.mjs:278`](../../scripts/story-project-sync.mjs#L278)
+
+- Review the PR rule that only one implementation artifact can drive review transitions.
+  [`story-project-sync.mjs:336`](../../scripts/story-project-sync.mjs#L336)
+
+**GitHub CLI Orchestration**
+
+- Check project metadata loading and strict status-option validation against the live board.
+  [`story-project-sync.mjs:445`](../../scripts/story-project-sync.mjs#L445)
+
+- Check issue reuse and canonical-title correction to avoid story-number duplicates.
+  [`story-project-sync.mjs:593`](../../scripts/story-project-sync.mjs#L593)
+
+- Check project-item creation and status mutation through `gh project`.
+  [`story-project-sync.mjs:652`](../../scripts/story-project-sync.mjs#L652)
+
+- Finish at the main execution path that binds event payloads to CLI operations.
+  [`story-project-sync.mjs:730`](../../scripts/story-project-sync.mjs#L730)
+
+**Support**
+
+- Confirm the parser and transition tests cover the non-trivial BMAD status cases.
+  [`story-project-sync.test.mjs:1`](../../scripts/story-project-sync.test.mjs#L1)
+
+- Review the operator notes for secrets, project assumptions, and supported transitions.
+  [`README.md:177`](../../README.md#L177)

--- a/scripts/story-project-sync.mjs
+++ b/scripts/story-project-sync.mjs
@@ -25,6 +25,14 @@ const DEFAULT_CONFIG = {
   issueLabel: process.env.STORY_ISSUE_LABEL ?? "",
 };
 
+function logInfo(message) {
+  console.log(`[story-project-sync] ${message}`);
+}
+
+function logSkip(diagnostics, message) {
+  diagnostics.push(message);
+}
+
 function shellQuote(value) {
   if (/^[A-Za-z0-9_./:-]+$/.test(value)) {
     return value;
@@ -275,7 +283,13 @@ function getChangedFilesForPullRequest(payload) {
   return parseNameStatus(gitCommand(["diff", "--name-status", baseSha, headSha]));
 }
 
-export function buildPushOperations({ changedFiles, payload, loadCurrent, loadPrevious }) {
+export function buildPushOperations({
+  changedFiles,
+  payload,
+  loadCurrent,
+  loadPrevious,
+  diagnostics = [],
+}) {
   const operations = new Map();
   const beforeSha = payload.before ?? ZERO_SHA;
 
@@ -283,6 +297,12 @@ export function buildPushOperations({ changedFiles, payload, loadCurrent, loadPr
     if (isPlanningArtifact(changedFile.path) && changedFile.status !== "D") {
       const markdown = loadCurrent(changedFile.path);
       const stories = markdown ? extractStoryRefsFromMarkdown(markdown) : [];
+
+      if (!markdown) {
+        logSkip(diagnostics, `Planning artifact ${changedFile.path} could not be read from the checkout.`);
+      } else if (stories.length === 0) {
+        logSkip(diagnostics, `Planning artifact ${changedFile.path} changed but no story headings were found.`);
+      }
 
       for (const story of stories) {
         mergeStoryAction(operations, story, {
@@ -294,12 +314,22 @@ export function buildPushOperations({ changedFiles, payload, loadCurrent, loadPr
     }
 
     if (!isImplementationArtifact(changedFile.path) || changedFile.status === "D") {
+      if (changedFile.status !== "D") {
+        logSkip(
+          diagnostics,
+          `Changed file ${changedFile.path} does not qualify as a tracked implementation artifact.`
+        );
+      }
       continue;
     }
 
     const currentMarkdown = loadCurrent(changedFile.path);
     const currentStory = currentMarkdown ? parseImplementationArtifact(currentMarkdown) : null;
     if (!currentStory) {
+      logSkip(
+        diagnostics,
+        `Implementation artifact ${changedFile.path} changed but its story heading or status could not be parsed.`
+      );
       continue;
     }
 
@@ -324,6 +354,11 @@ export function buildPushOperations({ changedFiles, payload, loadCurrent, loadPr
         targetStatus: "done",
         sourcePaths: [changedFile.path],
       });
+    } else if (changedFile.status !== "A") {
+      logSkip(
+        diagnostics,
+        `Implementation artifact ${changedFile.path} did not trigger a lifecycle change (status ${previousStatus ?? "unknown"} -> ${currentStory.status ?? "unknown"}).`
+      );
     }
   }
 
@@ -333,12 +368,16 @@ export function buildPushOperations({ changedFiles, payload, loadCurrent, loadPr
   }));
 }
 
-export function buildPullRequestOperations({ changedFiles, payload, loadCurrent }) {
+export function buildPullRequestOperations({ changedFiles, payload, loadCurrent, diagnostics = [] }) {
   const actionableFiles = changedFiles.filter(
     (changedFile) => changedFile.status !== "D" && isImplementationArtifact(changedFile.path)
   );
 
   if (actionableFiles.length !== 1) {
+    logSkip(
+      diagnostics,
+      `Pull request event requires exactly one changed implementation artifact, found ${actionableFiles.length}.`
+    );
     return [];
   }
 
@@ -347,12 +386,20 @@ export function buildPullRequestOperations({ changedFiles, payload, loadCurrent 
   const story = markdown ? parseImplementationArtifact(markdown) : null;
 
   if (!story) {
+    logSkip(
+      diagnostics,
+      `Pull request artifact ${changedFile.path} could not be parsed into a story title and status.`
+    );
     return [];
   }
 
   const action = payload.action;
   if (action === "opened" || action === "reopened") {
     if (story.status === "ready-for-dev") {
+      logSkip(
+        diagnostics,
+        `Pull request action ${action} ignored because ${changedFile.path} is still ready-for-dev.`
+      );
       return [];
     }
 
@@ -385,18 +432,31 @@ export function buildPullRequestOperations({ changedFiles, payload, loadCurrent 
     ];
   }
 
+  logSkip(
+    diagnostics,
+    `Pull request action ${action} with merged=${String(payload.pull_request?.merged)} does not trigger a lifecycle update.`
+  );
+
   return [];
 }
 
-export function buildOperations({ eventName, payload, changedFiles, loadCurrent, loadPrevious }) {
+export function buildOperations({
+  eventName,
+  payload,
+  changedFiles,
+  loadCurrent,
+  loadPrevious,
+  diagnostics = [],
+}) {
   if (eventName === "push") {
-    return buildPushOperations({ changedFiles, payload, loadCurrent, loadPrevious });
+    return buildPushOperations({ changedFiles, payload, loadCurrent, loadPrevious, diagnostics });
   }
 
   if (eventName === "pull_request") {
-    return buildPullRequestOperations({ changedFiles, payload, loadCurrent });
+    return buildPullRequestOperations({ changedFiles, payload, loadCurrent, diagnostics });
   }
 
+  logSkip(diagnostics, `Event ${eventName} is not supported by this script.`);
   return [];
 }
 
@@ -748,6 +808,12 @@ function main() {
       : eventName === "pull_request"
         ? getChangedFilesForPullRequest(payload)
         : [];
+  const diagnostics = [];
+
+  logInfo(`Processing ${eventName} event with ${changedFiles.length} changed file(s).`);
+  for (const changedFile of changedFiles) {
+    logInfo(`Changed file: ${changedFile.status} ${changedFile.path}`);
+  }
 
   const operations = buildOperations({
     eventName,
@@ -755,11 +821,21 @@ function main() {
     changedFiles,
     loadCurrent: loadCurrentFile,
     loadPrevious: loadFileAtRevision,
+    diagnostics,
   });
 
   if (operations.length === 0) {
-    console.log("No story lifecycle operations detected.");
+    logInfo("No story lifecycle operations detected.");
+    for (const diagnostic of diagnostics) {
+      logInfo(`Reason: ${diagnostic}`);
+    }
     return;
+  }
+
+  for (const operation of operations) {
+    logInfo(
+      `Planned story operation for ${operation.fullTitle}: issue=${operation.ensureIssue}, projectItem=${operation.ensureProjectItem}, targetStatus=${operation.targetStatus ?? "none"}`
+    );
   }
 
   const commandPlan = [];

--- a/scripts/story-project-sync.mjs
+++ b/scripts/story-project-sync.mjs
@@ -1,0 +1,818 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STORY_HEADING_REGEX = /^#{1,6}\s+Story\s+(\d+\.\d+):\s*(.+?)\s*$/gim;
+const STORY_TITLE_REGEX = /^Story\s+(\d+\.\d+):\s*(.+)$/i;
+const STATUS_LINE_REGEX = /^Status:\s*(.+?)\s*$/im;
+const IMPLEMENTATION_DIR = "_bmad-output/implementation-artifacts/";
+const PLANNING_DIR = "_bmad-output/planning-artifacts/";
+const ZERO_SHA = "0000000000000000000000000000000000000000";
+
+const STATUS_PRIORITY = {
+  null: 0,
+  "ready-for-dev": 1,
+  review: 2,
+  done: 3,
+};
+
+const DEFAULT_CONFIG = {
+  repo: process.env.GITHUB_REPOSITORY ?? "REW1L/munch-helper",
+  projectOwner: process.env.PROJECT_OWNER ?? "REW1L",
+  projectNumber: Number(process.env.PROJECT_NUMBER ?? "1"),
+  projectTitle: process.env.PROJECT_TITLE ?? "Munch Helper project",
+  issueLabel: process.env.STORY_ISSUE_LABEL ?? "",
+};
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) {
+    return value;
+  }
+
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function formatCommand(argv) {
+  return argv.map(shellQuote).join(" ");
+}
+
+function ghCommand(args, { dryRun = false, stdin = null } = {}) {
+  if (dryRun) {
+    return "";
+  }
+
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    input: stdin ?? undefined,
+    stdio: stdin === null ? ["ignore", "pipe", "pipe"] : ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+function gitCommand(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function parseJsonOutput(text, fallback) {
+  if (!text) {
+    return fallback;
+  }
+
+  return JSON.parse(text);
+}
+
+function normalizeWhitespace(value) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function cleanupPlanningTitle(rawTitle) {
+  return normalizeWhitespace(
+    rawTitle
+      .replace(/`[^`]*`/g, "")
+      .replace(/\[[^\]]+\]/g, "")
+      .replace(/⛔.*$/u, "")
+  );
+}
+
+function normalizeStoryStatus(rawStatus) {
+  return rawStatus
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, "-");
+}
+
+export function parseStoryTitle(title) {
+  const match = title.match(STORY_TITLE_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const storyNumber = match[1];
+  const storyName = normalizeWhitespace(match[2]);
+  return {
+    storyNumber,
+    title: storyName,
+    fullTitle: `Story ${storyNumber}: ${storyName}`,
+  };
+}
+
+export function extractStoryRefsFromMarkdown(markdown) {
+  const stories = [];
+  let match;
+
+  while ((match = STORY_HEADING_REGEX.exec(markdown)) !== null) {
+    const storyNumber = match[1];
+    const title = cleanupPlanningTitle(match[2]);
+
+    if (!title) {
+      continue;
+    }
+
+    stories.push({
+      storyNumber,
+      title,
+      fullTitle: `Story ${storyNumber}: ${title}`,
+    });
+  }
+
+  return stories;
+}
+
+export function parseImplementationArtifact(markdown) {
+  const headingMatch = markdown.match(/^#\s+(Story\s+\d+\.\d+:\s*.+)$/im);
+  const statusMatch = markdown.match(STATUS_LINE_REGEX);
+  const story = headingMatch ? parseStoryTitle(normalizeWhitespace(headingMatch[1])) : null;
+
+  if (!story) {
+    return null;
+  }
+
+  return {
+    ...story,
+    status: statusMatch ? normalizeStoryStatus(statusMatch[1]) : null,
+  };
+}
+
+export function isPlanningArtifact(filePath) {
+  return filePath.startsWith(PLANNING_DIR) && filePath.endsWith(".md");
+}
+
+export function isImplementationArtifact(filePath) {
+  if (!filePath.startsWith(IMPLEMENTATION_DIR) || !filePath.endsWith(".md")) {
+    return false;
+  }
+
+  const basename = path.basename(filePath);
+  return basename !== "spec-wip.md" && basename !== "deferred-work.md" && !basename.startsWith("spec-");
+}
+
+export function parseNameStatusLine(line) {
+  const parts = line.split("\t");
+  const statusToken = parts[0] ?? "";
+  const status = statusToken[0] ?? "";
+
+  if (!status) {
+    return null;
+  }
+
+  if ((status === "R" || status === "C") && parts.length >= 3) {
+    return {
+      status,
+      previousPath: parts[1],
+      path: parts[2],
+    };
+  }
+
+  return {
+    status,
+    previousPath: null,
+    path: parts[1] ?? "",
+  };
+}
+
+export function parseNameStatus(output) {
+  return output
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map(parseNameStatusLine)
+    .filter(Boolean);
+}
+
+function choosePreferredTitle(currentTitle, nextTitle) {
+  if (!currentTitle) {
+    return nextTitle;
+  }
+
+  if (!nextTitle) {
+    return currentTitle;
+  }
+
+  return nextTitle.length >= currentTitle.length ? nextTitle : currentTitle;
+}
+
+function mergeStoryAction(store, story, partialAction) {
+  if (!story) {
+    return;
+  }
+
+  const existing = store.get(story.storyNumber) ?? {
+    storyNumber: story.storyNumber,
+    title: story.title,
+    fullTitle: story.fullTitle,
+    sourcePaths: new Set(),
+    ensureIssue: false,
+    ensureProjectItem: false,
+    targetStatus: null,
+    onlyIfCurrentStatus: null,
+  };
+
+  existing.title = choosePreferredTitle(existing.title, story.title);
+  existing.fullTitle = `Story ${story.storyNumber}: ${existing.title}`;
+  existing.ensureIssue ||= Boolean(partialAction.ensureIssue);
+  existing.ensureProjectItem ||= Boolean(partialAction.ensureProjectItem);
+
+  if (
+    STATUS_PRIORITY[partialAction.targetStatus ?? null] >
+    STATUS_PRIORITY[existing.targetStatus ?? null]
+  ) {
+    existing.targetStatus = partialAction.targetStatus ?? null;
+  }
+
+  if (partialAction.onlyIfCurrentStatus) {
+    existing.onlyIfCurrentStatus = partialAction.onlyIfCurrentStatus;
+  }
+
+  for (const sourcePath of partialAction.sourcePaths ?? []) {
+    existing.sourcePaths.add(sourcePath);
+  }
+
+  store.set(story.storyNumber, existing);
+}
+
+function loadFileAtRevision(revision, filePath) {
+  if (!revision || revision === ZERO_SHA) {
+    return null;
+  }
+
+  try {
+    return gitCommand(["show", `${revision}:${filePath}`]);
+  } catch {
+    return null;
+  }
+}
+
+function loadCurrentFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function getChangedFilesForPush(payload) {
+  const before = payload.before ?? ZERO_SHA;
+  const after = payload.after ?? "HEAD";
+
+  if (!before || before === ZERO_SHA) {
+    return parseNameStatus(gitCommand(["diff-tree", "--root", "--name-status", "-r", after]));
+  }
+
+  return parseNameStatus(gitCommand(["diff", "--name-status", before, after]));
+}
+
+function getChangedFilesForPullRequest(payload) {
+  const baseSha = payload.pull_request?.base?.sha;
+  const headSha = payload.pull_request?.head?.sha;
+
+  if (!baseSha || !headSha) {
+    throw new Error("Pull request payload is missing base/head SHAs.");
+  }
+
+  return parseNameStatus(gitCommand(["diff", "--name-status", baseSha, headSha]));
+}
+
+export function buildPushOperations({ changedFiles, payload, loadCurrent, loadPrevious }) {
+  const operations = new Map();
+  const beforeSha = payload.before ?? ZERO_SHA;
+
+  for (const changedFile of changedFiles) {
+    if (isPlanningArtifact(changedFile.path) && changedFile.status !== "D") {
+      const markdown = loadCurrent(changedFile.path);
+      const stories = markdown ? extractStoryRefsFromMarkdown(markdown) : [];
+
+      for (const story of stories) {
+        mergeStoryAction(operations, story, {
+          ensureIssue: true,
+          ensureProjectItem: true,
+          sourcePaths: [changedFile.path],
+        });
+      }
+    }
+
+    if (!isImplementationArtifact(changedFile.path) || changedFile.status === "D") {
+      continue;
+    }
+
+    const currentMarkdown = loadCurrent(changedFile.path);
+    const currentStory = currentMarkdown ? parseImplementationArtifact(currentMarkdown) : null;
+    if (!currentStory) {
+      continue;
+    }
+
+    if (changedFile.status === "A") {
+      mergeStoryAction(operations, currentStory, {
+        ensureIssue: true,
+        ensureProjectItem: true,
+        targetStatus: "ready-for-dev",
+        sourcePaths: [changedFile.path],
+      });
+    }
+
+    const previousPath = changedFile.previousPath ?? changedFile.path;
+    const previousMarkdown = loadPrevious(beforeSha, previousPath);
+    const previousStory = previousMarkdown ? parseImplementationArtifact(previousMarkdown) : null;
+    const previousStatus = previousStory?.status ?? null;
+
+    if (currentStory.status === "done" && previousStatus !== "done") {
+      mergeStoryAction(operations, currentStory, {
+        ensureIssue: true,
+        ensureProjectItem: true,
+        targetStatus: "done",
+        sourcePaths: [changedFile.path],
+      });
+    }
+  }
+
+  return Array.from(operations.values()).map((operation) => ({
+    ...operation,
+    sourcePaths: Array.from(operation.sourcePaths).sort(),
+  }));
+}
+
+export function buildPullRequestOperations({ changedFiles, payload, loadCurrent }) {
+  const actionableFiles = changedFiles.filter(
+    (changedFile) => changedFile.status !== "D" && isImplementationArtifact(changedFile.path)
+  );
+
+  if (actionableFiles.length !== 1) {
+    return [];
+  }
+
+  const changedFile = actionableFiles[0];
+  const markdown = loadCurrent(changedFile.path);
+  const story = markdown ? parseImplementationArtifact(markdown) : null;
+
+  if (!story) {
+    return [];
+  }
+
+  const action = payload.action;
+  if (action === "opened" || action === "reopened") {
+    if (story.status === "ready-for-dev") {
+      return [];
+    }
+
+    return [
+      {
+        storyNumber: story.storyNumber,
+        title: story.title,
+        fullTitle: story.fullTitle,
+        sourcePaths: [changedFile.path],
+        ensureIssue: true,
+        ensureProjectItem: true,
+        targetStatus: "review",
+        onlyIfCurrentStatus: null,
+      },
+    ];
+  }
+
+  if (action === "closed" && payload.pull_request?.merged === false) {
+    return [
+      {
+        storyNumber: story.storyNumber,
+        title: story.title,
+        fullTitle: story.fullTitle,
+        sourcePaths: [changedFile.path],
+        ensureIssue: true,
+        ensureProjectItem: true,
+        targetStatus: "ready-for-dev",
+        onlyIfCurrentStatus: "review",
+      },
+    ];
+  }
+
+  return [];
+}
+
+export function buildOperations({ eventName, payload, changedFiles, loadCurrent, loadPrevious }) {
+  if (eventName === "push") {
+    return buildPushOperations({ changedFiles, payload, loadCurrent, loadPrevious });
+  }
+
+  if (eventName === "pull_request") {
+    return buildPullRequestOperations({ changedFiles, payload, loadCurrent });
+  }
+
+  return [];
+}
+
+function issueBodyForStory(operation) {
+  const sources = operation.sourcePaths
+    .map((sourcePath) => `- \`${sourcePath}\``)
+    .join("\n");
+
+  return [
+    "Tracked automatically from BMAD story artifacts.",
+    "",
+    `Story: ${operation.fullTitle}`,
+    "",
+    "Source artifacts:",
+    sources || "- (not recorded)",
+  ].join("\n");
+}
+
+function findIssueByStoryNumber(issues, storyNumber) {
+  return issues.find((issue) => {
+    const parsed = parseStoryTitle(issue.title);
+    return parsed?.storyNumber === storyNumber;
+  }) ?? null;
+}
+
+function chooseProjectItem(items, storyNumber, fullTitle) {
+  const exactTitle = items.find((item) => item.title === fullTitle);
+  if (exactTitle) {
+    return exactTitle;
+  }
+
+  return (
+    items.find((item) => parseStoryTitle(item.title ?? "")?.storyNumber === storyNumber) ?? null
+  );
+}
+
+function getProjectItemQuery(operation, currentStatus = null) {
+  const query = [`is:issue`, `title:"Story ${operation.storyNumber}*"`];
+  if (currentStatus) {
+    query.push(`status:"${projectStatusLabel(currentStatus)}"`);
+  }
+
+  return query.join(" ");
+}
+
+function loadProjectMetadata(config, dryRun) {
+  if (dryRun) {
+    return {
+      projectId: `project-${config.projectNumber}`,
+      statusFieldId: "status-field",
+      statusOptionIds: new Map([
+        ["ready-for-dev", "ready-option"],
+        ["review", "review-option"],
+        ["done", "done-option"],
+      ]),
+    };
+  }
+
+  const projectListOutput = ghCommand(
+    [
+      "project",
+      "list",
+      "--owner",
+      config.projectOwner,
+      "--limit",
+      "50",
+      "--format",
+      "json",
+    ],
+    { dryRun }
+  );
+  const projectList = parseJsonOutput(projectListOutput, { projects: [] });
+  const project = (projectList.projects ?? []).find(
+    (entry) => Number(entry.number) === config.projectNumber
+  );
+
+  if (!project) {
+    throw new Error(
+      `Unable to find project ${config.projectOwner}/${config.projectNumber}.`
+    );
+  }
+
+  if (config.projectTitle && project.title !== config.projectTitle) {
+    throw new Error(
+      `Project ${config.projectNumber} title mismatch. Expected "${config.projectTitle}", got "${project.title}".`
+    );
+  }
+
+  const fieldListOutput = ghCommand(
+    [
+      "project",
+      "field-list",
+      String(config.projectNumber),
+      "--owner",
+      config.projectOwner,
+      "--format",
+      "json",
+    ],
+    { dryRun }
+  );
+  const fieldList = parseJsonOutput(fieldListOutput, { fields: [] });
+  const statusField = (fieldList.fields ?? []).find((field) => field.name === "Status");
+
+  if (!statusField) {
+    throw new Error("Project is missing the Status field.");
+  }
+
+  const optionIds = new Map();
+  for (const option of statusField.options ?? []) {
+    optionIds.set(normalizeStoryStatus(option.name), option.id);
+  }
+
+  for (const status of ["ready-for-dev", "review", "done"]) {
+    if (!optionIds.has(status)) {
+      throw new Error(`Project Status field is missing the "${projectStatusLabel(status)}" option.`);
+    }
+  }
+
+  return {
+    projectId: project.id,
+    statusFieldId: statusField.id,
+    statusOptionIds: optionIds,
+  };
+}
+
+function loadExistingIssues(config, dryRun) {
+  if (dryRun) {
+    return [];
+  }
+
+  const output = ghCommand(
+    [
+      "issue",
+      "list",
+      "--repo",
+      config.repo,
+      "--state",
+      "all",
+      "--limit",
+      "200",
+      "--json",
+      "number,title,url,state",
+    ],
+    { dryRun }
+  );
+
+  if (dryRun && !output) {
+    return [];
+  }
+
+  return parseJsonOutput(output, []);
+}
+
+function loadProjectItemsForStory(config, operation, dryRun, onlyIfCurrentStatus = null) {
+  if (dryRun) {
+    return [];
+  }
+
+  const args = [
+    "project",
+    "item-list",
+    String(config.projectNumber),
+    "--owner",
+    config.projectOwner,
+    "--limit",
+    "200",
+    "--query",
+    getProjectItemQuery(operation, onlyIfCurrentStatus),
+    "--format",
+    "json",
+  ];
+  const output = ghCommand(args, { dryRun });
+  const parsed = parseJsonOutput(output, { items: [] });
+  return parsed.items ?? [];
+}
+
+function projectStatusLabel(normalizedStatus) {
+  switch (normalizedStatus) {
+    case "ready-for-dev":
+      return "Ready for Dev";
+    case "review":
+      return "Review";
+    case "done":
+      return "Done";
+    default:
+      return normalizedStatus;
+  }
+}
+
+function recordCommand(plan, argv) {
+  plan.push(formatCommand(argv));
+}
+
+function ensureIssue(config, issues, operation, dryRun, commandPlan) {
+  let issue = findIssueByStoryNumber(issues, operation.storyNumber);
+
+  if (issue && issue.title !== operation.fullTitle) {
+    const editArgs = [
+      "issue",
+      "edit",
+      String(issue.number),
+      "--repo",
+      config.repo,
+      "--title",
+      operation.fullTitle,
+    ];
+    recordCommand(commandPlan, ["gh", ...editArgs]);
+    ghCommand(editArgs, { dryRun });
+    issue = {
+      ...issue,
+      title: operation.fullTitle,
+    };
+  }
+
+  if (!issue) {
+    const createArgs = [
+      "issue",
+      "create",
+      "--repo",
+      config.repo,
+      "--title",
+      operation.fullTitle,
+      "--body-file",
+      "-",
+    ];
+    if (config.issueLabel) {
+      createArgs.push("--label", config.issueLabel);
+    }
+
+    recordCommand(commandPlan, ["gh", ...createArgs]);
+    const issueUrl = ghCommand(createArgs, {
+      dryRun,
+      stdin: issueBodyForStory(operation),
+    });
+
+    issue = {
+      number: Number.NaN,
+      title: operation.fullTitle,
+      url:
+        issueUrl ||
+        `https://github.com/${config.repo}/issues/STORY-${operation.storyNumber.replace(/\./g, "-")}`,
+      state: "OPEN",
+    };
+  }
+
+  if (!issues.some((entry) => entry.url === issue.url || entry.title === issue.title)) {
+    issues.push(issue);
+  }
+
+  return issue;
+}
+
+function ensureProjectItem(config, issue, operation, dryRun, commandPlan) {
+  let projectItems = loadProjectItemsForStory(config, operation, dryRun);
+  let projectItem = chooseProjectItem(projectItems, operation.storyNumber, operation.fullTitle);
+
+  if (!projectItem) {
+    const addArgs = [
+      "project",
+      "item-add",
+      String(config.projectNumber),
+      "--owner",
+      config.projectOwner,
+      "--url",
+      issue.url,
+    ];
+    recordCommand(commandPlan, ["gh", ...addArgs]);
+    ghCommand(addArgs, { dryRun });
+    projectItems = loadProjectItemsForStory(config, operation, dryRun);
+    projectItem = chooseProjectItem(projectItems, operation.storyNumber, operation.fullTitle);
+  }
+
+  if (dryRun && !projectItem) {
+    projectItem = {
+      id: `item-${operation.storyNumber.replace(/\./g, "-")}`,
+      title: operation.fullTitle,
+    };
+  }
+
+  if (!projectItem) {
+    throw new Error(`Unable to resolve project item for ${operation.fullTitle}.`);
+  }
+
+  return projectItem;
+}
+
+function updateProjectStatus(config, metadata, projectItem, normalizedStatus, dryRun, commandPlan) {
+  const optionId = metadata.statusOptionIds.get(normalizedStatus);
+  if (!optionId) {
+    throw new Error(`Missing project option id for status ${normalizedStatus}.`);
+  }
+
+  const editArgs = [
+    "project",
+    "item-edit",
+    "--project-id",
+    metadata.projectId,
+    "--id",
+    projectItem.id,
+    "--field-id",
+    metadata.statusFieldId,
+    "--single-select-option-id",
+    optionId,
+  ];
+  recordCommand(commandPlan, ["gh", ...editArgs]);
+  ghCommand(editArgs, { dryRun });
+}
+
+function parseArgs(argv) {
+  return {
+    dryRun: argv.includes("--dry-run"),
+    help: argv.includes("--help") || argv.includes("-h"),
+  };
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/story-project-sync.mjs [--dry-run] [--help]
+
+Environment:
+  GITHUB_EVENT_NAME   GitHub event name (push or pull_request)
+  GITHUB_EVENT_PATH   Path to the GitHub event payload JSON
+  GITHUB_REPOSITORY   Repository in owner/name form (default: REW1L/munch-helper)
+  PROJECT_OWNER       GitHub Projects owner login (default: REW1L)
+  PROJECT_NUMBER      GitHub Project number (default: 1)
+  PROJECT_TITLE       Expected project title (default: Munch Helper project)
+  GH_TOKEN            Token used by gh for issue/project commands
+  STORY_ISSUE_LABEL   Optional label to add to newly created story issues
+`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const eventName = process.env.GITHUB_EVENT_NAME;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+
+  if (!eventName || !eventPath) {
+    throw new Error("GITHUB_EVENT_NAME and GITHUB_EVENT_PATH are required.");
+  }
+
+  const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  const changedFiles =
+    eventName === "push"
+      ? getChangedFilesForPush(payload)
+      : eventName === "pull_request"
+        ? getChangedFilesForPullRequest(payload)
+        : [];
+
+  const operations = buildOperations({
+    eventName,
+    payload,
+    changedFiles,
+    loadCurrent: loadCurrentFile,
+    loadPrevious: loadFileAtRevision,
+  });
+
+  if (operations.length === 0) {
+    console.log("No story lifecycle operations detected.");
+    return;
+  }
+
+  const commandPlan = [];
+  const config = { ...DEFAULT_CONFIG };
+  const metadata = loadProjectMetadata(config, args.dryRun);
+  const issues = loadExistingIssues(config, args.dryRun);
+
+  for (const operation of operations) {
+    const issue = ensureIssue(config, issues, operation, args.dryRun, commandPlan);
+    let projectItem;
+
+    if (operation.onlyIfCurrentStatus && !args.dryRun) {
+      const matchingItems = loadProjectItemsForStory(
+        config,
+        operation,
+        args.dryRun,
+        operation.onlyIfCurrentStatus
+      );
+      projectItem = chooseProjectItem(matchingItems, operation.storyNumber, operation.fullTitle);
+      if (!projectItem) {
+        continue;
+      }
+    }
+
+    projectItem ??= ensureProjectItem(config, issue, operation, args.dryRun, commandPlan);
+
+    if (operation.targetStatus) {
+      updateProjectStatus(
+        config,
+        metadata,
+        projectItem,
+        operation.targetStatus,
+        args.dryRun,
+        commandPlan
+      );
+    }
+  }
+
+  if (args.dryRun) {
+    console.log(commandPlan.join("\n"));
+  } else {
+    console.log(`Applied ${operations.length} story sync operation(s).`);
+  }
+}
+
+const isEntryPoint =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isEntryPoint) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/story-project-sync.mjs
+++ b/scripts/story-project-sync.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 const STORY_HEADING_REGEX = /^#{1,6}\s+Story\s+(\d+\.\d+):\s*(.+?)\s*$/gim;
 const STORY_TITLE_REGEX = /^Story\s+(\d+\.\d+):\s*(.+)$/i;
 const STATUS_LINE_REGEX = /^Status:\s*(.+?)\s*$/im;
+const FRONTMATTER_REGEX = /^---\s*\n([\s\S]*?)\n---\s*/;
 const IMPLEMENTATION_DIR = "_bmad-output/implementation-artifacts/";
 const PLANNING_DIR = "_bmad-output/planning-artifacts/";
 const ZERO_SHA = "0000000000000000000000000000000000000000";
@@ -144,17 +145,73 @@ export function parseImplementationArtifact(markdown) {
   };
 }
 
+function parseFrontmatterValue(frontmatter, key) {
+  const match = frontmatter.match(new RegExp(`^${key}:\\s*['"]?(.+?)['"]?\\s*$`, "im"));
+  return match ? normalizeWhitespace(match[1]) : null;
+}
+
+export function parseTrackedImplementationArtifact(markdown, filePath = "") {
+  const storyArtifact = parseImplementationArtifact(markdown);
+  if (storyArtifact) {
+    return {
+      kind: "story",
+      identityKey: `story:${storyArtifact.storyNumber}`,
+      queryTitle: `Story ${storyArtifact.storyNumber}*`,
+      ...storyArtifact,
+    };
+  }
+
+  const frontmatterMatch = markdown.match(FRONTMATTER_REGEX);
+  if (!frontmatterMatch) {
+    return null;
+  }
+
+  const title = parseFrontmatterValue(frontmatterMatch[1], "title");
+  const status = parseFrontmatterValue(frontmatterMatch[1], "status");
+
+  if (!title) {
+    return null;
+  }
+
+  return {
+    kind: "spec",
+    identityKey: `spec:${title.toLowerCase()}`,
+    storyNumber: null,
+    title,
+    fullTitle: title,
+    queryTitle: title,
+    status: status ? normalizeStoryStatus(status) : null,
+    filePath,
+  };
+}
+
 export function isPlanningArtifact(filePath) {
   return filePath.startsWith(PLANNING_DIR) && filePath.endsWith(".md");
 }
 
-export function isImplementationArtifact(filePath) {
-  if (!filePath.startsWith(IMPLEMENTATION_DIR) || !filePath.endsWith(".md")) {
-    return false;
+export function getImplementationArtifactSkipReason(filePath) {
+  if (!filePath.startsWith(IMPLEMENTATION_DIR)) {
+    return "outside the implementation-artifacts directory";
+  }
+
+  if (!filePath.endsWith(".md")) {
+    return "not a markdown artifact";
   }
 
   const basename = path.basename(filePath);
-  return basename !== "spec-wip.md" && basename !== "deferred-work.md" && !basename.startsWith("spec-");
+  if (basename === "spec-wip.md") {
+    return "the BMAD work-in-progress spec file";
+  }
+
+  if (basename === "deferred-work.md") {
+    return "the BMAD deferred-work control file";
+  }
+
+  return null;
+}
+
+export function isImplementationArtifact(filePath) {
+  return getImplementationArtifactSkipReason(filePath) === null;
 }
 
 export function parseNameStatusLine(line) {
@@ -202,15 +259,18 @@ function choosePreferredTitle(currentTitle, nextTitle) {
   return nextTitle.length >= currentTitle.length ? nextTitle : currentTitle;
 }
 
-function mergeStoryAction(store, story, partialAction) {
-  if (!story) {
+function mergeTrackedAction(store, artifact, partialAction) {
+  if (!artifact) {
     return;
   }
 
-  const existing = store.get(story.storyNumber) ?? {
-    storyNumber: story.storyNumber,
-    title: story.title,
-    fullTitle: story.fullTitle,
+  const existing = store.get(artifact.identityKey) ?? {
+    kind: artifact.kind,
+    identityKey: artifact.identityKey,
+    storyNumber: artifact.storyNumber,
+    title: artifact.title,
+    fullTitle: artifact.fullTitle,
+    queryTitle: artifact.queryTitle,
     sourcePaths: new Set(),
     ensureIssue: false,
     ensureProjectItem: false,
@@ -218,8 +278,11 @@ function mergeStoryAction(store, story, partialAction) {
     onlyIfCurrentStatus: null,
   };
 
-  existing.title = choosePreferredTitle(existing.title, story.title);
-  existing.fullTitle = `Story ${story.storyNumber}: ${existing.title}`;
+  existing.title = choosePreferredTitle(existing.title, artifact.title);
+  existing.fullTitle = artifact.storyNumber
+    ? `Story ${artifact.storyNumber}: ${existing.title}`
+    : existing.title;
+  existing.queryTitle = artifact.queryTitle ?? existing.fullTitle;
   existing.ensureIssue ||= Boolean(partialAction.ensureIssue);
   existing.ensureProjectItem ||= Boolean(partialAction.ensureProjectItem);
 
@@ -238,7 +301,7 @@ function mergeStoryAction(store, story, partialAction) {
     existing.sourcePaths.add(sourcePath);
   }
 
-  store.set(story.storyNumber, existing);
+  store.set(artifact.identityKey, existing);
 }
 
 function loadFileAtRevision(revision, filePath) {
@@ -305,7 +368,12 @@ export function buildPushOperations({
       }
 
       for (const story of stories) {
-        mergeStoryAction(operations, story, {
+        mergeTrackedAction(operations, {
+          kind: "story",
+          identityKey: `story:${story.storyNumber}`,
+          queryTitle: `Story ${story.storyNumber}*`,
+          ...story,
+        }, {
           ensureIssue: true,
           ensureProjectItem: true,
           sourcePaths: [changedFile.path],
@@ -315,26 +383,29 @@ export function buildPushOperations({
 
     if (!isImplementationArtifact(changedFile.path) || changedFile.status === "D") {
       if (changedFile.status !== "D") {
+        const skipReason = getImplementationArtifactSkipReason(changedFile.path);
         logSkip(
           diagnostics,
-          `Changed file ${changedFile.path} does not qualify as a tracked implementation artifact.`
+          `Changed file ${changedFile.path} does not qualify as a tracked implementation artifact${skipReason ? `: ${skipReason}.` : "."}`
         );
       }
       continue;
     }
 
     const currentMarkdown = loadCurrent(changedFile.path);
-    const currentStory = currentMarkdown ? parseImplementationArtifact(currentMarkdown) : null;
-    if (!currentStory) {
+    const currentArtifact = currentMarkdown
+      ? parseTrackedImplementationArtifact(currentMarkdown, changedFile.path)
+      : null;
+    if (!currentArtifact) {
       logSkip(
         diagnostics,
-        `Implementation artifact ${changedFile.path} changed but its story heading or status could not be parsed.`
+        `Implementation artifact ${changedFile.path} changed but its title or status could not be parsed.`
       );
       continue;
     }
 
     if (changedFile.status === "A") {
-      mergeStoryAction(operations, currentStory, {
+      mergeTrackedAction(operations, currentArtifact, {
         ensureIssue: true,
         ensureProjectItem: true,
         targetStatus: "ready-for-dev",
@@ -344,11 +415,13 @@ export function buildPushOperations({
 
     const previousPath = changedFile.previousPath ?? changedFile.path;
     const previousMarkdown = loadPrevious(beforeSha, previousPath);
-    const previousStory = previousMarkdown ? parseImplementationArtifact(previousMarkdown) : null;
-    const previousStatus = previousStory?.status ?? null;
+    const previousArtifact = previousMarkdown
+      ? parseTrackedImplementationArtifact(previousMarkdown, previousPath)
+      : null;
+    const previousStatus = previousArtifact?.status ?? null;
 
-    if (currentStory.status === "done" && previousStatus !== "done") {
-      mergeStoryAction(operations, currentStory, {
+    if (currentArtifact.status === "done" && previousStatus !== "done") {
+      mergeTrackedAction(operations, currentArtifact, {
         ensureIssue: true,
         ensureProjectItem: true,
         targetStatus: "done",
@@ -357,7 +430,7 @@ export function buildPushOperations({
     } else if (changedFile.status !== "A") {
       logSkip(
         diagnostics,
-        `Implementation artifact ${changedFile.path} did not trigger a lifecycle change (status ${previousStatus ?? "unknown"} -> ${currentStory.status ?? "unknown"}).`
+        `Implementation artifact ${changedFile.path} did not trigger a lifecycle change (status ${previousStatus ?? "unknown"} -> ${currentArtifact.status ?? "unknown"}).`
       );
     }
   }
@@ -369,33 +442,48 @@ export function buildPushOperations({
 }
 
 export function buildPullRequestOperations({ changedFiles, payload, loadCurrent, diagnostics = [] }) {
-  const actionableFiles = changedFiles.filter(
-    (changedFile) => changedFile.status !== "D" && isImplementationArtifact(changedFile.path)
-  );
+  const actionableFiles = [];
+
+  for (const changedFile of changedFiles) {
+    if (changedFile.status === "D") {
+      continue;
+    }
+
+    if (!isImplementationArtifact(changedFile.path)) {
+      const skipReason = getImplementationArtifactSkipReason(changedFile.path);
+      logSkip(
+        diagnostics,
+        `Pull request file ${changedFile.path} is excluded from implementation-artifact review transitions${skipReason ? `: ${skipReason}.` : "."}`
+      );
+      continue;
+    }
+
+    actionableFiles.push(changedFile);
+  }
 
   if (actionableFiles.length !== 1) {
     logSkip(
       diagnostics,
-      `Pull request event requires exactly one changed implementation artifact, found ${actionableFiles.length}.`
+      `Pull request event requires exactly one changed tracked implementation artifact, found ${actionableFiles.length}.`
     );
     return [];
   }
 
   const changedFile = actionableFiles[0];
   const markdown = loadCurrent(changedFile.path);
-  const story = markdown ? parseImplementationArtifact(markdown) : null;
+  const artifact = markdown ? parseTrackedImplementationArtifact(markdown, changedFile.path) : null;
 
-  if (!story) {
+  if (!artifact) {
     logSkip(
       diagnostics,
-      `Pull request artifact ${changedFile.path} could not be parsed into a story title and status.`
+      `Pull request artifact ${changedFile.path} could not be parsed into a title and status.`
     );
     return [];
   }
 
   const action = payload.action;
   if (action === "opened" || action === "reopened") {
-    if (story.status === "ready-for-dev") {
+    if (artifact.status === "ready-for-dev") {
       logSkip(
         diagnostics,
         `Pull request action ${action} ignored because ${changedFile.path} is still ready-for-dev.`
@@ -405,9 +493,12 @@ export function buildPullRequestOperations({ changedFiles, payload, loadCurrent,
 
     return [
       {
-        storyNumber: story.storyNumber,
-        title: story.title,
-        fullTitle: story.fullTitle,
+        kind: artifact.kind,
+        identityKey: artifact.identityKey,
+        storyNumber: artifact.storyNumber,
+        title: artifact.title,
+        fullTitle: artifact.fullTitle,
+        queryTitle: artifact.queryTitle,
         sourcePaths: [changedFile.path],
         ensureIssue: true,
         ensureProjectItem: true,
@@ -420,9 +511,12 @@ export function buildPullRequestOperations({ changedFiles, payload, loadCurrent,
   if (action === "closed" && payload.pull_request?.merged === false) {
     return [
       {
-        storyNumber: story.storyNumber,
-        title: story.title,
-        fullTitle: story.fullTitle,
+        kind: artifact.kind,
+        identityKey: artifact.identityKey,
+        storyNumber: artifact.storyNumber,
+        title: artifact.title,
+        fullTitle: artifact.fullTitle,
+        queryTitle: artifact.queryTitle,
         sourcePaths: [changedFile.path],
         ensureIssue: true,
         ensureProjectItem: true,
@@ -482,6 +576,14 @@ function findIssueByStoryNumber(issues, storyNumber) {
   }) ?? null;
 }
 
+function findIssueForArtifact(issues, operation) {
+  if (operation.storyNumber) {
+    return findIssueByStoryNumber(issues, operation.storyNumber);
+  }
+
+  return issues.find((issue) => issue.title === operation.fullTitle) ?? null;
+}
+
 function chooseProjectItem(items, storyNumber, fullTitle) {
   const exactTitle = items.find((item) => item.title === fullTitle);
   if (exactTitle) {
@@ -494,7 +596,7 @@ function chooseProjectItem(items, storyNumber, fullTitle) {
 }
 
 function getProjectItemQuery(operation, currentStatus = null) {
-  const query = [`is:issue`, `title:"Story ${operation.storyNumber}*"`];
+  const query = [`is:issue`, `title:"${operation.queryTitle}"`];
   if (currentStatus) {
     query.push(`status:"${projectStatusLabel(currentStatus)}"`);
   }
@@ -650,8 +752,16 @@ function recordCommand(plan, argv) {
   plan.push(formatCommand(argv));
 }
 
+function dryRunIssueSlug(operation) {
+  if (operation.storyNumber) {
+    return `STORY-${operation.storyNumber.replace(/\./g, "-")}`;
+  }
+
+  return encodeURIComponent(operation.fullTitle.toLowerCase().replace(/\s+/g, "-"));
+}
+
 function ensureIssue(config, issues, operation, dryRun, commandPlan) {
-  let issue = findIssueByStoryNumber(issues, operation.storyNumber);
+  let issue = findIssueForArtifact(issues, operation);
 
   if (issue && issue.title !== operation.fullTitle) {
     const editArgs = [
@@ -695,9 +805,7 @@ function ensureIssue(config, issues, operation, dryRun, commandPlan) {
     issue = {
       number: Number.NaN,
       title: operation.fullTitle,
-      url:
-        issueUrl ||
-        `https://github.com/${config.repo}/issues/STORY-${operation.storyNumber.replace(/\./g, "-")}`,
+      url: issueUrl || `https://github.com/${config.repo}/issues/${dryRunIssueSlug(operation)}`,
       state: "OPEN",
     };
   }
@@ -731,7 +839,7 @@ function ensureProjectItem(config, issue, operation, dryRun, commandPlan) {
 
   if (dryRun && !projectItem) {
     projectItem = {
-      id: `item-${operation.storyNumber.replace(/\./g, "-")}`,
+      id: `item-${dryRunIssueSlug(operation)}`,
       title: operation.fullTitle,
     };
   }
@@ -834,7 +942,7 @@ function main() {
 
   for (const operation of operations) {
     logInfo(
-      `Planned story operation for ${operation.fullTitle}: issue=${operation.ensureIssue}, projectItem=${operation.ensureProjectItem}, targetStatus=${operation.targetStatus ?? "none"}`
+      `Planned tracked-artifact operation for ${operation.fullTitle}: issue=${operation.ensureIssue}, projectItem=${operation.ensureProjectItem}, targetStatus=${operation.targetStatus ?? "none"}`
     );
   }
 

--- a/scripts/story-project-sync.test.mjs
+++ b/scripts/story-project-sync.test.mjs
@@ -5,7 +5,9 @@ import {
   buildPullRequestOperations,
   buildPushOperations,
   extractStoryRefsFromMarkdown,
+  getImplementationArtifactSkipReason,
   parseImplementationArtifact,
+  parseTrackedImplementationArtifact,
   parseNameStatus,
   parseStoryTitle,
 } from "./story-project-sync.mjs";
@@ -63,6 +65,34 @@ test("parseNameStatus handles rename records", () => {
   ]);
 });
 
+test("getImplementationArtifactSkipReason still excludes only control files", () => {
+  assert.equal(
+    getImplementationArtifactSkipReason("_bmad-output/implementation-artifacts/spec-wip.md"),
+    "the BMAD work-in-progress spec file"
+  );
+});
+
+test("parseTrackedImplementationArtifact extracts title and status from spec frontmatter", () => {
+  const markdown = `---
+title: 'Story Project Status Sync'
+status: 'done'
+---
+
+## Intent
+`;
+
+  assert.deepEqual(parseTrackedImplementationArtifact(markdown), {
+    kind: "spec",
+    identityKey: "spec:story project status sync",
+    storyNumber: null,
+    title: "Story Project Status Sync",
+    fullTitle: "Story Project Status Sync",
+    queryTitle: "Story Project Status Sync",
+    status: "done",
+    filePath: "",
+  });
+});
+
 test("buildPushOperations plans issue creation and ready-for-dev on artifact add", () => {
   const changedFiles = [
     {
@@ -92,9 +122,12 @@ Status: ready-for-dev
 
   assert.deepEqual(operations, [
     {
+      kind: "story",
+      identityKey: "story:3.8",
       storyNumber: "3.8",
       title: "Realtime Update Signal on Character Cards",
       fullTitle: "Story 3.8: Realtime Update Signal on Character Cards",
+      queryTitle: "Story 3.8*",
       sourcePaths: [
         "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
       ],
@@ -203,9 +236,12 @@ Status: in-progress
   });
 
   assert.deepEqual(operations[0], {
+    kind: "story",
+    identityKey: "story:3.8",
     storyNumber: "3.8",
     title: "Realtime Update Signal on Character Cards",
     fullTitle: "Story 3.8: Realtime Update Signal on Character Cards",
+    queryTitle: "Story 3.8*",
     sourcePaths: [
       "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
     ],
@@ -213,5 +249,46 @@ Status: in-progress
     ensureProjectItem: true,
     targetStatus: "ready-for-dev",
     onlyIfCurrentStatus: "review",
+  });
+});
+
+test("buildPullRequestOperations tracks spec artifacts in implementation-artifacts", () => {
+  const changedFiles = [
+    {
+      status: "A",
+      previousPath: null,
+      path: "_bmad-output/implementation-artifacts/spec-story-project-status-sync.md",
+    },
+  ];
+
+  const currentFiles = new Map([
+    [
+      "_bmad-output/implementation-artifacts/spec-story-project-status-sync.md",
+      `---
+title: 'Story Project Status Sync'
+status: 'in-progress'
+---
+`,
+    ],
+  ]);
+
+  const operations = buildPullRequestOperations({
+    changedFiles,
+    payload: { action: "opened", pull_request: { merged: false } },
+    loadCurrent: (filePath) => currentFiles.get(filePath) ?? null,
+  });
+
+  assert.deepEqual(operations[0], {
+    kind: "spec",
+    identityKey: "spec:story project status sync",
+    storyNumber: null,
+    title: "Story Project Status Sync",
+    fullTitle: "Story Project Status Sync",
+    queryTitle: "Story Project Status Sync",
+    sourcePaths: ["_bmad-output/implementation-artifacts/spec-story-project-status-sync.md"],
+    ensureIssue: true,
+    ensureProjectItem: true,
+    targetStatus: "review",
+    onlyIfCurrentStatus: null,
   });
 });

--- a/scripts/story-project-sync.test.mjs
+++ b/scripts/story-project-sync.test.mjs
@@ -1,0 +1,217 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildPullRequestOperations,
+  buildPushOperations,
+  extractStoryRefsFromMarkdown,
+  parseImplementationArtifact,
+  parseNameStatus,
+  parseStoryTitle,
+} from "./story-project-sync.mjs";
+
+test("parseStoryTitle extracts the story number and title", () => {
+  assert.deepEqual(parseStoryTitle("Story 3.8: Realtime Update Signal on Character Cards"), {
+    storyNumber: "3.8",
+    title: "Realtime Update Signal on Character Cards",
+    fullTitle: "Story 3.8: Realtime Update Signal on Character Cards",
+  });
+});
+
+test("extractStoryRefsFromMarkdown strips BMAD status tags from planning headings", () => {
+  const markdown = `
+## Story 3.1: AppTheme Token Migration (technical prerequisite) \`[TODO]\` ⛔ Gate for Epics 5–6
+## Story 3.8: Realtime Update Signal on Character Cards \`[TODO]\`
+`;
+
+  assert.deepEqual(extractStoryRefsFromMarkdown(markdown), [
+    {
+      storyNumber: "3.1",
+      title: "AppTheme Token Migration (technical prerequisite)",
+      fullTitle: "Story 3.1: AppTheme Token Migration (technical prerequisite)",
+    },
+    {
+      storyNumber: "3.8",
+      title: "Realtime Update Signal on Character Cards",
+      fullTitle: "Story 3.8: Realtime Update Signal on Character Cards",
+    },
+  ]);
+});
+
+test("parseImplementationArtifact extracts title and normalized status", () => {
+  const markdown = `
+# Story 3.10: Character Removal
+
+Status: Ready for Dev
+`;
+
+  assert.deepEqual(parseImplementationArtifact(markdown), {
+    storyNumber: "3.10",
+    title: "Character Removal",
+    fullTitle: "Story 3.10: Character Removal",
+    status: "ready-for-dev",
+  });
+});
+
+test("parseNameStatus handles rename records", () => {
+  assert.deepEqual(parseNameStatus("R100\told.md\tnew.md\n"), [
+    {
+      status: "R",
+      previousPath: "old.md",
+      path: "new.md",
+    },
+  ]);
+});
+
+test("buildPushOperations plans issue creation and ready-for-dev on artifact add", () => {
+  const changedFiles = [
+    {
+      status: "A",
+      previousPath: null,
+      path: "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+    },
+  ];
+
+  const currentFiles = new Map([
+    [
+      "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+      `
+# Story 3.8: Realtime Update Signal on Character Cards
+
+Status: ready-for-dev
+`,
+    ],
+  ]);
+
+  const operations = buildPushOperations({
+    changedFiles,
+    payload: { before: "abc123" },
+    loadCurrent: (filePath) => currentFiles.get(filePath) ?? null,
+    loadPrevious: () => null,
+  });
+
+  assert.deepEqual(operations, [
+    {
+      storyNumber: "3.8",
+      title: "Realtime Update Signal on Character Cards",
+      fullTitle: "Story 3.8: Realtime Update Signal on Character Cards",
+      sourcePaths: [
+        "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+      ],
+      ensureIssue: true,
+      ensureProjectItem: true,
+      targetStatus: "ready-for-dev",
+      onlyIfCurrentStatus: null,
+    },
+  ]);
+});
+
+test("buildPushOperations upgrades to done when the artifact status changes to done", () => {
+  const changedFiles = [
+    {
+      status: "M",
+      previousPath: null,
+      path: "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+    },
+  ];
+
+  const currentFiles = new Map([
+    [
+      "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+      `
+# Story 3.8: Realtime Update Signal on Character Cards
+
+Status: done
+`,
+    ],
+  ]);
+
+  const previousFiles = new Map([
+    [
+      "abc123:_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+      `
+# Story 3.8: Realtime Update Signal on Character Cards
+
+Status: in-review
+`,
+    ],
+  ]);
+
+  const operations = buildPushOperations({
+    changedFiles,
+    payload: { before: "abc123" },
+    loadCurrent: (filePath) => currentFiles.get(filePath) ?? null,
+    loadPrevious: (revision, filePath) => previousFiles.get(`${revision}:${filePath}`) ?? null,
+  });
+
+  assert.equal(operations[0].targetStatus, "done");
+});
+
+test("buildPullRequestOperations plans review when one implementation artifact is active", () => {
+  const changedFiles = [
+    {
+      status: "M",
+      previousPath: null,
+      path: "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+    },
+  ];
+
+  const currentFiles = new Map([
+    [
+      "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+      `
+# Story 3.8: Realtime Update Signal on Character Cards
+
+Status: in-progress
+`,
+    ],
+  ]);
+
+  const operations = buildPullRequestOperations({
+    changedFiles,
+    payload: { action: "opened", pull_request: { merged: false } },
+    loadCurrent: (filePath) => currentFiles.get(filePath) ?? null,
+  });
+
+  assert.equal(operations[0].targetStatus, "review");
+});
+
+test("buildPullRequestOperations plans ready-for-dev only for unmerged closes", () => {
+  const changedFiles = [
+    {
+      status: "M",
+      previousPath: null,
+      path: "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+    },
+  ];
+
+  const currentFiles = new Map([
+    [
+      "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+      `
+# Story 3.8: Realtime Update Signal on Character Cards
+
+Status: in-progress
+`,
+    ],
+  ]);
+
+  const operations = buildPullRequestOperations({
+    changedFiles,
+    payload: { action: "closed", pull_request: { merged: false } },
+    loadCurrent: (filePath) => currentFiles.get(filePath) ?? null,
+  });
+
+  assert.deepEqual(operations[0], {
+    storyNumber: "3.8",
+    title: "Realtime Update Signal on Character Cards",
+    fullTitle: "Story 3.8: Realtime Update Signal on Character Cards",
+    sourcePaths: [
+      "_bmad-output/implementation-artifacts/3-8-realtime-update-signal-on-character-cards.md",
+    ],
+    ensureIssue: true,
+    ensureProjectItem: true,
+    targetStatus: "ready-for-dev",
+    onlyIfCurrentStatus: "review",
+  });
+});

--- a/scripts/story-project-sync.test.mjs
+++ b/scripts/story-project-sync.test.mjs
@@ -292,3 +292,85 @@ status: 'in-progress'
     onlyIfCurrentStatus: null,
   });
 });
+
+test("buildPullRequestOperations handles the current mixed PR shape with one tracked spec artifact", () => {
+  const changedFiles = [
+    {
+      status: "A",
+      previousPath: null,
+      path: ".github/workflows/story-project-sync.yml",
+    },
+    {
+      status: "M",
+      previousPath: null,
+      path: "README.md",
+    },
+    {
+      status: "A",
+      previousPath: null,
+      path: "_bmad-output/implementation-artifacts/spec-story-project-status-sync.md",
+    },
+    {
+      status: "A",
+      previousPath: null,
+      path: "scripts/story-project-sync.mjs",
+    },
+    {
+      status: "A",
+      previousPath: null,
+      path: "scripts/story-project-sync.test.mjs",
+    },
+  ];
+
+  const diagnostics = [];
+  const currentFiles = new Map([
+    [
+      "_bmad-output/implementation-artifacts/spec-story-project-status-sync.md",
+      `---
+title: 'Story Project Status Sync'
+status: 'in-review'
+---
+`,
+    ],
+  ]);
+
+  const operations = buildPullRequestOperations({
+    changedFiles,
+    payload: { action: "opened", pull_request: { merged: false } },
+    loadCurrent: (filePath) => currentFiles.get(filePath) ?? null,
+    diagnostics,
+  });
+
+  assert.deepEqual(operations, [
+    {
+      kind: "spec",
+      identityKey: "spec:story project status sync",
+      storyNumber: null,
+      title: "Story Project Status Sync",
+      fullTitle: "Story Project Status Sync",
+      queryTitle: "Story Project Status Sync",
+      sourcePaths: ["_bmad-output/implementation-artifacts/spec-story-project-status-sync.md"],
+      ensureIssue: true,
+      ensureProjectItem: true,
+      targetStatus: "review",
+      onlyIfCurrentStatus: null,
+    },
+  ]);
+
+  assert.ok(
+    diagnostics.some((entry) =>
+      entry.includes("Pull request file .github/workflows/story-project-sync.yml is excluded")
+    )
+  );
+  assert.ok(
+    diagnostics.some((entry) => entry.includes("Pull request file README.md is excluded"))
+  );
+  assert.ok(
+    diagnostics.every(
+      (entry) =>
+        !entry.includes(
+          "Pull request file _bmad-output/implementation-artifacts/spec-story-project-status-sync.md is excluded"
+        )
+    )
+  );
+});


### PR DESCRIPTION
## What changed
- added a GitHub Actions workflow to sync BMAD story lifecycle changes into the GitHub Project
- added a Node script that detects story changes from BMAD planning and implementation artifacts, reuses or creates matching repository issues, adds them to Project 1, and updates the `Status` field via `gh project`
- added regression tests for story parsing and lifecycle transition planning
- documented the required `GH_PROJECT_TOKEN` secret and project assumptions in the README
- added the completed BMAD implementation spec with a suggested review order

## Why it changed
BMAD story state was drifting from the repository issues and GitHub Project board, leaving ticket creation and status transitions manual. This change automates the requested lifecycle:
- story mention on `main` creates the issue and adds it to the project
- implementation artifact creation moves the story to `Ready for Dev`
- PR open or reopen moves the story to `Review`
- merge-to-main with artifact status `done` moves the story to `Done`
- PR close without merge returns the story to `Ready for Dev`

## User and developer impact
- reduces manual project-board upkeep for BMAD stories
- keeps repository issues as the canonical tickets instead of draft project items
- makes the project workflow reviewable and testable from the repository itself

## Validation
- `node --test scripts/story-project-sync.test.mjs`
- `node scripts/story-project-sync.mjs --help`
- local dry-run path verified for command planning