### PR TITLE
Fix CLI preflight/auth and Copilot binary for ready-for-dev orchestrator

### DIFF
--- a/.github/workflows/ready-for-dev-orchestrator.yml
+++ b/.github/workflows/ready-for-dev-orchestrator.yml
@@ -77,7 +77,7 @@ jobs:
             echo "Installing codex..." && npm install -g @openai/codex || echo "codex install failed"
           fi
           if [ -n "${COPILOT_GITHUB_TOKEN:-}" ]; then
-            echo "Installing copilot..." && npm install -g @githubnext/github-copilot-cli || echo "copilot install failed"
+            echo "Installing GitHub Copilot CLI..." && npm install -g @githubnext/github-copilot-cli || echo "GitHub Copilot CLI install failed"
           fi
           if [ -n "${KIRO_API_KEY:-}" ]; then
             echo "Installing kiro-cli..." && npm install -g kiro-cli || echo "kiro-cli install failed"

--- a/.github/workflows/ready-for-dev-orchestrator.yml
+++ b/.github/workflows/ready-for-dev-orchestrator.yml
@@ -31,8 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      (
+      github.event_name == 'workflow_dispatch' || (
         github.event.issue.pull_request == null &&
         contains(github.event.comment.body, '<!-- auto-dev:trigger v1 -->') &&
         (
@@ -55,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
+          # ref: main
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ready-for-dev-orchestrator.yml
+++ b/.github/workflows/ready-for-dev-orchestrator.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # ref: main
+          ref: main
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ready-for-dev-orchestrator.yml
+++ b/.github/workflows/ready-for-dev-orchestrator.yml
@@ -76,7 +76,7 @@ jobs:
             echo "Installing codex..." && npm install -g @openai/codex || echo "codex install failed"
           fi
           if [ -n "${COPILOT_GITHUB_TOKEN:-}" ]; then
-            echo "Installing GitHub Copilot CLI..." && npm install -g @githubnext/github-copilot-cli || echo "GitHub Copilot CLI install failed"
+            echo "Installing GitHub Copilot CLI..." && npm install -g @github/copilot || echo "GitHub Copilot CLI install failed"
           fi
           if [ -n "${KIRO_API_KEY:-}" ]; then
             echo "Installing kiro-cli..." && npm install -g kiro-cli || echo "kiro-cli install failed"

--- a/_bmad-output/implementation-artifacts/spec-ready-for-dev-orchestrator.md
+++ b/_bmad-output/implementation-artifacts/spec-ready-for-dev-orchestrator.md
@@ -2,7 +2,7 @@
 title: 'Ready For Dev Orchestrator'
 type: 'feature'
 created: '2026-05-02'
-status: 'in-review'
+status: 'done'
 baseline_commit: '1909673d0a6ab50cf57c9b4f3569123c7c92d759'
 context:
   - '_bmad-output/project-context.md'
@@ -53,9 +53,9 @@ context:
 ## Tasks & Acceptance
 
 **Execution:**
-- [x] `scripts/ready-for-dev-orchestrator.mjs` -- Implement orchestration. Inputs: `--issue <n>` (from dispatch input or parsed from `github.event.issue.number` on comment events), `--order claude,codex,copilot,kiro-cli`, `--timeout 30m`, `--dry-run`. Steps: resolve issue + spec file path (prefer the `spec_file` carried in the marker comment payload when present, fall back to deriving from issue title); checkout-or-create `auto-dev/issue-<n>` branch (resume if it exists); pre-flight each requested CLI (`which` + minimal auth probe — env var present and `--version` succeeds); for each CLI in order, run `timeout <T> <cli> <flags> "bmad-dev-story implement '<title>'"` with stdout/stderr captured to per-agent log files; after each, re-read spec frontmatter; on `status: review`, `status: in-review`, or `status: done` stage all changes, commit (`Co-authored-by` line per CLI that ran), push, `gh pr create --title "<issue title>" --body "Closes #<n>"`, exit 0; otherwise log the quota regex match (informational), continue. If no CLI succeeds, push the branch (if it has commits ahead of base), exit non-zero. Use the existing `ghCommand` helper style and `--dry-run` semantics from `story-project-sync.mjs`.
+- [x] `scripts/ready-for-dev-orchestrator.mjs` -- Implement orchestration. Inputs: `--issue <n>` (from dispatch input or parsed from `github.event.issue.number` on comment events), `--order claude,codex,copilot,kiro-cli`, `--timeout 30m`, `--dry-run`. Steps: resolve issue + spec file path (prefer the `spec_file` carried in the marker comment payload when present, fall back to deriving from issue title); checkout-or-create `auto-dev/issue-<n>` branch (resume if it exists); pre-flight each requested CLI (`which` + minimal auth probe — env var present, `--version` succeeds, and any non-interactive login step succeeds); for each CLI in order, run `timeout <T> <cli> <flags> "bmad-dev-story implement '<title>'"` with stdout/stderr captured to per-agent log files; after each, re-read spec frontmatter; on `status: review`, `status: in-review`, or `status: done` stage all changes, commit (`Co-authored-by` line per CLI that ran), push, `gh pr create --title "<issue title>" --body "Closes #<n>"`, exit 0; otherwise log the quota regex match (informational), continue. If no CLI succeeds, push the branch (if it has commits ahead of base), exit non-zero. Use the existing `ghCommand` helper style and `--dry-run` semantics from `story-project-sync.mjs`.
 - [x] `.github/workflows/ready-for-dev-orchestrator.yml` -- Triggers: `workflow_dispatch` with `issue_number` (required) and optional `agent_order` input; `issue_comment: { types: [created] }`. Top-level `if` on the comment-triggered job: `github.event_name == 'workflow_dispatch' || (github.event.issue.pull_request == null && contains(github.event.comment.body, '<!-- auto-dev:trigger v1 -->') && (github.event.comment.user.login == 'REW1L' || github.event.comment.user.login == 'github-actions[bot]'))`. `concurrency: { group: 'auto-dev-${{ github.event.issue.number || inputs.issue_number }}', cancel-in-progress: false }`. Permissions: `contents: write`, `pull-requests: write`, `issues: write` (for posting any progress comments back). Steps: checkout with `fetch-depth: 0` and explicit `ref: main`, setup Node 20, install CLIs that have credentials (skip ones whose secret is missing), `git config user.name/email` for the bot, run `node scripts/ready-for-dev-orchestrator.mjs ...`, `actions/upload-artifact` of the per-agent logs. Env passthrough: `ANTHROPIC_API_KEY`, `CODEX_API_KEY`, `OPENAI_API_KEY`, `COPILOT_GITHUB_TOKEN`, `KIRO_API_KEY`, plus the existing `GH_PROJECT_TOKEN` set as `GH_TOKEN` and `GITHUB_TOKEN`.
-- [x] `scripts/ready-for-dev-orchestrator.test.mjs` -- `node:test` suites covering: issue title `Story 3.1: AppTheme Token Migration` → `_bmad-output/implementation-artifacts/3-1-apptheme-token-migration.md`; spec status frontmatter parsing for both story-style (`Status: review`) and spec-style (`status: 'review'` / `status: 'in-review'` / `status: 'done'`); cascade decision when each CLI succeeds at position 1/2/3/4, including success on `review`, `in-review`, or `done`; cascade decision when all four fail; quota-signal regex against captured fixtures (Claude `rate_limit_error`, Codex `usage limit`, Copilot `premium request allowance`, Kiro `limit reached`); marker-comment payload extraction (well-formed, malformed JSON, missing marker); dry-run command plan output.
+- [x] `scripts/ready-for-dev-orchestrator.test.mjs` -- `node:test` suites covering: issue title `Story 3.1: AppTheme Token Migration` → `_bmad-output/implementation-artifacts/3-1-apptheme-token-migration.md`; spec status frontmatter parsing for both story-style (`Status: review`) and spec-style (`status: 'review'` / `status: 'in-review'` / `status: 'done'`); cascade decision when each CLI succeeds at position 1/2/3/4, including success on `review`, `in-review`, or `done`; cascade decision when all four fail; quota-signal regex against captured fixtures (Claude `rate_limit_error`, Codex `usage limit`, Copilot `premium request allowance`, Kiro `limit reached`); marker-comment payload extraction (well-formed, malformed JSON, missing marker); dry-run command plan output, including Codex non-interactive flags and the installed GitHub Copilot CLI binary name.
 - [x] `scripts/story-project-sync.mjs` -- Add `postReadyForDevMarker(issue, specFile)` helper invoked whenever the sync emits a status transition to `Ready for Dev`. Body: a brief human-readable line plus `<!-- auto-dev:trigger v1 -->` and a fenced `json` payload `{"issue_number": <n>, "spec_file": "<path>", "version": 1}`. Idempotency: query the last 5 issue comments via `gh issue view <n> --json comments`, skip if the most recent comment is already a v1 marker pointing at the same `spec_file`. Failures are logged but do not fail the sync run. Export the helpers (`parseStoryTitle`, `loadProjectMetadata`, `findIssueForArtifact`, slug derivation) the orchestrator script needs.
 - [x] `scripts/story-project-sync.test.mjs` -- Add coverage: marker is posted on a fresh `Ready for Dev` transition; marker is skipped when an identical recent marker already exists; marker body shape (HTML comment + JSON payload); marker post failure is logged and swallowed (sync still reports success).
 - [x] `README.md` -- Document required secrets (`ANTHROPIC_API_KEY`, `CODEX_API_KEY` *or* `OPENAI_API_KEY`, `COPILOT_GITHUB_TOKEN` (PAT with Copilot Requests), `KIRO_API_KEY`), how to trigger manually (`gh workflow run ready-for-dev-orchestrator.yml -f issue_number=42`), the marker-comment contract (so other automations can post the marker if needed), the cascade order, and how to read the run-log artifact.
@@ -78,8 +78,8 @@ The cascade-stop contract is intentionally outcome-based, not signal-based: the 
 
 CLI invocation flags (default):
 - `claude -p --output-format stream-json --verbose --include-partial-messages` (set `CLAUDE_CODE_MAX_RETRIES=2` to fail fast)
-- `codex exec --json --ask-for-approval never --sandbox workspace-write --skip-git-repo-check`
-- `copilot -p --no-ask-user --allow-all-tools`
+- `codex login --with-api-key` (stdin from `OPENAI_API_KEY` or `CODEX_API_KEY`) before `codex exec --json --ask-for-approval never --sandbox workspace-write --skip-git-repo-check`
+- `github-copilot-cli -p --no-ask-user --allow-all-tools` (the npm package exposes `github-copilot-cli`, not `copilot`)
 - `kiro-cli chat --no-interactive --trust-all-tools`
 
 User-project trigger gap (researched 2026-05-02): `projects_v2_item` does not fire for `users/<name>/projects/<n>` — still organization-only per current GitHub docs and the unresolved community feedback thread #17405. Pure project Status column moves also fire no `issues` events (the `issues.edited` payload carries no project field changes), so filtering issue events on status is a dead end. The chosen design uses a marker-comment contract instead of workflow chaining: when `story-project-sync` transitions an item to `Ready for Dev`, it posts a deterministic comment on the issue, and the orchestrator triggers on `issue_comment.created`. This decouples the orchestrator from any specific source workflow — anything authorized that posts the marker triggers it identically — and keeps the contract textual and inspectable in the issue thread.
@@ -112,3 +112,27 @@ UI-drag gap: when a human drags a card to `Ready for Dev` directly in the projec
 - After a PR is opened by the orchestrator, confirm `story-project-sync` advances the project item from `Ready for Dev` to `Review` automatically.
 - Inspect the uploaded run-log artifact and confirm one log file per agent invocation, plus the final spec `status:` value at the end of the run.
 - Post a non-marker comment from a non-owner account on a test issue; confirm the orchestrator workflow either does not run or runs with the gating job skipped.
+
+
+## Suggested Review Order
+
+**CLI authentication pre-flight**
+
+- Fixes Claude env gating and logs Codex in before cascade execution.
+  [`ready-for-dev-orchestrator.mjs:24`](../../scripts/ready-for-dev-orchestrator.mjs#L24)
+
+- Keeps unauthenticated login failures out of the cascade body.
+  [`ready-for-dev-orchestrator.mjs:326`](../../scripts/ready-for-dev-orchestrator.mjs#L326)
+
+**Copilot executable resolution**
+
+- Uses the binary actually installed by the Copilot npm package.
+  [`ready-for-dev-orchestrator.mjs:46`](../../scripts/ready-for-dev-orchestrator.mjs#L46)
+
+- Clarifies the Actions installation step without changing trigger semantics.
+  [`ready-for-dev-orchestrator.yml:79`](../../.github/workflows/ready-for-dev-orchestrator.yml#L79)
+
+**Regression coverage**
+
+- Locks dry-run output to authenticated Codex flags and Copilot binary.
+  [`ready-for-dev-orchestrator.test.mjs:357`](../../scripts/ready-for-dev-orchestrator.test.mjs#L357)

--- a/scripts/ready-for-dev-orchestrator.mjs
+++ b/scripts/ready-for-dev-orchestrator.mjs
@@ -32,11 +32,7 @@ const CLI_CONFIGS = {
     cmd: "codex",
     args: [
       "exec",
-      "--json",
-      "--ask-for-approval",
-      "never",
-      "--sandbox",
-      "workspace-write",
+      "--dangerously-bypass-approvals-and-sandbox",
       "--skip-git-repo-check",
     ],
     env: {},
@@ -44,7 +40,7 @@ const CLI_CONFIGS = {
     login: { args: ["login", "--with-api-key"], stdinEnv: ["OPENAI_API_KEY", "CODEX_API_KEY"] },
   },
   copilot: {
-    cmd: "github-copilot-cli",
+    cmd: "copilot",
     // --prompt/-p must be last: it consumes the next arg as prompt text
     args: ["--no-ask-user", "--allow-all-tools", "-p"],
     env: {},

--- a/scripts/ready-for-dev-orchestrator.mjs
+++ b/scripts/ready-for-dev-orchestrator.mjs
@@ -26,20 +26,25 @@ const CLI_CONFIGS = {
     cmd: "claude",
     args: ["-p", "--verbose"],
     env: { CLAUDE_CODE_MAX_RETRIES: "2" },
-    authEnv: ["ANTHROPIC_API_KEYS"],
+    authEnv: ["ANTHROPIC_API_KEY"],
   },
   codex: {
     cmd: "codex",
     args: [
       "exec",
-      "--dangerously-bypass-approvals-and-sandbox",
+      "--json",
+      "--ask-for-approval",
+      "never",
+      "--sandbox",
+      "workspace-write",
       "--skip-git-repo-check",
     ],
     env: {},
     authEnv: ["OPENAI_API_KEY", "CODEX_API_KEY"],
+    login: { args: ["login", "--with-api-key"], stdinEnv: ["OPENAI_API_KEY", "CODEX_API_KEY"] },
   },
   copilot: {
-    cmd: "copilot",
+    cmd: "github-copilot-cli",
     // --prompt/-p must be last: it consumes the next arg as prompt text
     args: ["--no-ask-user", "--allow-all-tools", "-p"],
     env: {},
@@ -314,6 +319,38 @@ function findSpecFileOnDisk(derivedPath) {
   return match ? path.join(dir, match) : null;
 }
 
+function firstSetEnv(envVars) {
+  return envVars.find((envVar) => Boolean(process.env[envVar])) ?? null;
+}
+
+function runLoginIfConfigured(name, config) {
+  if (!config.login) {
+    return { ok: true, reason: null };
+  }
+
+  const stdinEnv = firstSetEnv(config.login.stdinEnv ?? []);
+  if (!stdinEnv) {
+    return {
+      ok: false,
+      reason: `missing login stdin env (${(config.login.stdinEnv ?? []).join(" or ")})`,
+    };
+  }
+
+  try {
+    logInfo(`Pre-flight: logging in ${name} with ${stdinEnv}.`);
+    execFileSync(config.cmd, config.login.args, {
+      encoding: "utf8",
+      input: `${process.env[stdinEnv]}\n`,
+      stdio: ["pipe", "ignore", "pipe"],
+      timeout: 30_000,
+    });
+    return { ok: true, reason: null };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: `login failed for ${config.cmd}: ${message}` };
+  }
+}
+
 function preflightCLI(name, config) {
   const hasAuth = config.authEnv.some((envVar) => Boolean(process.env[envVar]));
   if (!hasAuth) {
@@ -333,6 +370,11 @@ function preflightCLI(name, config) {
     execFileSync(config.cmd, ["--version"], { stdio: "ignore", timeout: 5000 });
   } catch {
     return { available: false, reason: `--version check failed for ${config.cmd}` };
+  }
+
+  const loginResult = runLoginIfConfigured(name, config);
+  if (!loginResult.ok) {
+    return { available: false, reason: loginResult.reason };
   }
 
   return { available: true, reason: null };

--- a/scripts/ready-for-dev-orchestrator.test.mjs
+++ b/scripts/ready-for-dev-orchestrator.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import test from "node:test";
 
 import {
@@ -350,4 +351,23 @@ test("deriveSpecFilePath is deterministic and produces a valid path string", () 
   assert.ok(result.startsWith("_bmad-output/implementation-artifacts/"));
   assert.ok(result.endsWith(".md"));
   assert.ok(!result.includes(" "), "Path should not contain spaces");
+});
+
+
+test("dry-run plans authenticated Codex and installed Copilot binary invocations", () => {
+  const output = execFileSync(
+    process.execPath,
+    [
+      "scripts/ready-for-dev-orchestrator.mjs",
+      "--dry-run",
+      "--issue",
+      "42",
+      "--order",
+      "codex,copilot",
+    ],
+    { encoding: "utf8" }
+  );
+
+  assert.match(output, /codex exec --json --ask-for-approval never --sandbox workspace-write/);
+  assert.match(output, /github-copilot-cli --no-ask-user --allow-all-tools -p/);
 });


### PR DESCRIPTION
### Motivation

- The orchestrator failed when agents ran unauthenticated or required interactive login, so CLIs must perform non-interactive login steps before use. 
- Other CLIs may also need non-interactive auth probes to be reliably available in GitHub Actions runs. 
- The installed Copilot npm package exposes a different binary name than previously invoked, causing the Copilot invocation to be missing.

### Description

- Update `scripts/ready-for-dev-orchestrator.mjs` to require the correct Claude env var (`ANTHROPIC_API_KEY`) and to use non-interactive Codex flags plus a preflight `codex login --with-api-key` driven from `OPENAI_API_KEY`/`CODEX_API_KEY` when present. 
- Add `firstSetEnv` and `runLoginIfConfigured` helpers and invoke a login step from `preflightCLI` so non-interactive CLI login runs during preflight and can fail fast. 
- Change Copilot invocation to use the actual binary installed by `@githubnext/github-copilot-cli` (`github-copilot-cli`) and clarify the Actions install log message in `.github/workflows/ready-for-dev-orchestrator.yml`. 
- Add a dry-run regression test in `scripts/ready-for-dev-orchestrator.test.mjs` that asserts the planned `codex exec` flags and the `github-copilot-cli` invocation, and update the Ready-for-Dev spec (`_bmad-output/implementation-artifacts/spec-ready-for-dev-orchestrator.md`) with a Suggested Review Order and mark it `done`.

### Testing

- Ran `node --test scripts/ready-for-dev-orchestrator.test.mjs` and all tests passed. 
- Ran `node --test scripts/story-project-sync.test.mjs` and all tests passed. 
- Ran `node scripts/ready-for-dev-orchestrator.mjs --dry-run --issue 1 --order codex,copilot` and observed the planned command plan includes the non-interactive `codex exec --json --ask-for-approval never --sandbox workspace-write` invocation and a `github-copilot-cli ... -p 'bmad-dev-story implement'` entry as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbabadd42c832086a0f6b10f2248b9)