### PR TITLE
chore: remove issue_comment input from ready-for-dev orchestrator

### DIFF
--- a/.github/workflows/ready-for-dev-orchestrator.yml
+++ b/.github/workflows/ready-for-dev-orchestrator.yml
@@ -12,9 +12,6 @@ on:
         required: false
         default: "claude,codex,copilot,kiro-cli"
         type: string
-  issue_comment:
-    types:
-      - created
 
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 node_modules/
 screenshots/
 videos/
+**/worktrees/


### PR DESCRIPTION
This pull request disables autodev for now.