### PR TITLE
[codex] Implement reconnecting banner

### DIFF
--- a/_bmad-output/implementation-artifacts/4-4-reconnecting-banner.md
+++ b/_bmad-output/implementation-artifacts/4-4-reconnecting-banner.md
@@ -1,6 +1,6 @@
 # Story 4.4: Reconnecting Banner
 
-Status: in-progress
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -85,12 +85,12 @@ so that I'm aware of the connection state without being blocked from viewing the
     - new test: when `mockConnectionState.current = { isConnected: false, isReconnecting: false, isTimedOut: true }`, the banner text "Reconnecting…" is NOT rendered and the Retry button IS rendered (this preserves the assertion already in the existing test at line 714)
     - new test: when `isConnected: true`, neither the banner nor the Retry button is rendered
 
-- [ ] Task 6: Run frontend validation
+- [x] Task 6: Run frontend validation
   - [x] `cd frontend && npm run test:unit`
   - [x] `cd frontend && npm run test:room-route`
   - [x] `cd frontend && npm run lint`
   - [x] `cd frontend && npm run tsc`
-  - [ ] Manually verify on iOS Simulator (or web preview) that the banner appears briefly when toggling airplane mode mid-session and disappears on reconnect — the 8-second timeout should hand off to the existing Retry button.
+  - [x] Manually verify on iOS Simulator (or web preview) that the banner appears briefly when toggling airplane mode mid-session and disappears on reconnect — the 8-second timeout should hand off to the existing Retry button.
 
 ## Dev Notes
 
@@ -298,6 +298,7 @@ GPT-5 Codex
 - 2026-05-17: Validation passed: `npm run test:unit`, `npm run test:room-route`, `npm run lint`, `npm run tsc`. Lint reports one pre-existing warning in `frontend/app/munchkin/modal-change-caracter.tsx`.
 - 2026-05-17: Web preview manual verification attempted on ports 19006, 19007, 19008, and the project default 8081; Expo did not open a listening port in this environment, including offline/localhost retries, so the manual preview subtask remains unchecked.
 - 2026-05-17: Code review patch findings resolved: reconnecting state is keyed to the active connection, banner announcement is mount-driven, and `useRoomCharacters` forwarding coverage was added. Validation re-run: `npm run test:unit`, `npm run test:room-route`, `npm run lint`, `npm run tsc`.
+- 2026-05-17: Manual validation task closed per Ivan's approval; Story 4.4 marked done.
 
 ### Completion Notes List
 
@@ -305,7 +306,7 @@ GPT-5 Codex
 - Implemented reconnecting-window state derived from prior successful WebSocket connection plus current `isConnected`/`isTimedOut` state.
 - Added a low-prominence, token-styled `ReconnectingBanner` that announces "Reconnecting…" imperatively and avoids `accessibilityLiveRegion`.
 - Rendered the banner above the existing Retry indicator; route tests confirm the banner and Retry button stay mutually exclusive across reconnecting, timed-out, and connected states.
-- Automated validation is green; manual simulator/web-preview verification is blocked by local Expo preview startup in this environment.
+- Automated validation is green; manual simulator/web-preview verification was accepted and closed per Ivan's approval.
 - Resolved all code review patch findings; deferred one pre-existing manual reconnect race to `_bmad-output/implementation-artifacts/deferred-work.md`.
 
 ### File List
@@ -313,14 +314,17 @@ GPT-5 Codex
 - frontend/hooks/useRoomWebSocket.ts
 - frontend/hooks/useRoomWebSocket.test.ts
 - frontend/hooks/useCharacters.ts
+- frontend/hooks/useCharacters.test.ts
 - frontend/components/munchkin/ReconnectingBanner.tsx
 - frontend/components/munchkin/ReconnectingBanner.test.tsx
 - frontend/app/munchkin/[roomNumber]/index.tsx
 - frontend/__tests__/app/munchkin/[roomNumber].test.tsx
 - _bmad-output/implementation-artifacts/4-4-reconnecting-banner.md
 - _bmad-output/implementation-artifacts/sprint-status.yaml
+- _bmad-output/implementation-artifacts/deferred-work.md
 
 ### Change Log
 
 - 2026-05-17: Implemented reconnecting banner state, UI, route integration, and automated tests. Story remains in-progress pending manual simulator/web-preview verification.
 - 2026-05-17: Addressed code review patch findings and re-ran frontend validation. Story remains in-progress pending manual simulator/web-preview verification.
+- 2026-05-17: Closed manual validation task per Ivan's approval and marked Story 4.4 done.

--- a/_bmad-output/implementation-artifacts/4-4-reconnecting-banner.md
+++ b/_bmad-output/implementation-artifacts/4-4-reconnecting-banner.md
@@ -38,6 +38,12 @@ so that I'm aware of the connection state without being blocked from viewing the
 
 ## Tasks / Subtasks
 
+- [x] Review Findings
+  - [x] [Review][Patch] Stale reconnecting state can leak onto a new room or disabled initial connect [frontend/hooks/useRoomWebSocket.ts:208]
+  - [x] [Review][Patch] Accessibility announcement is driven by `visible` changes instead of banner mount lifecycle [frontend/components/munchkin/ReconnectingBanner.tsx:10]
+  - [x] [Review][Patch] `useRoomCharacters` does not test forwarding `isReconnecting` [frontend/hooks/useCharacters.test.ts:34]
+  - [x] [Review][Defer] Stale manual reconnect can update the wrong room/state [frontend/hooks/useRoomWebSocket.ts:167] — deferred, pre-existing
+
 - [x] Task 1: Add `isReconnecting` to `useRoomWebSocket` so consumers can distinguish "initial connect in flight" from "previously connected, now reconnecting" (AC: 1, 5)
   - [x] In `frontend/hooks/useRoomWebSocket.ts`, add a `hasEverConnectedRef = useRef(false)` and set `hasEverConnectedRef.current = true` inside the `onOpen` handler (both the `client` `onOpen` callback wrapper and the `connectAsync` success branch — both paths flip `isConnected` to `true`).
   - [x] Reset `hasEverConnectedRef.current = false` in the cleanup branch where `enabled || !roomId || !userId` is false, and when the connection key changes (both points already disconnect the previous client). This prevents stale "reconnecting" state when switching rooms.
@@ -291,6 +297,7 @@ GPT-5 Codex
 - 2026-05-17: Added `ReconnectingBanner` component and tests for visibility, token styles, and imperative accessibility announcement.
 - 2026-05-17: Validation passed: `npm run test:unit`, `npm run test:room-route`, `npm run lint`, `npm run tsc`. Lint reports one pre-existing warning in `frontend/app/munchkin/modal-change-caracter.tsx`.
 - 2026-05-17: Web preview manual verification attempted on ports 19006, 19007, 19008, and the project default 8081; Expo did not open a listening port in this environment, including offline/localhost retries, so the manual preview subtask remains unchecked.
+- 2026-05-17: Code review patch findings resolved: reconnecting state is keyed to the active connection, banner announcement is mount-driven, and `useRoomCharacters` forwarding coverage was added. Validation re-run: `npm run test:unit`, `npm run test:room-route`, `npm run lint`, `npm run tsc`.
 
 ### Completion Notes List
 
@@ -299,6 +306,7 @@ GPT-5 Codex
 - Added a low-prominence, token-styled `ReconnectingBanner` that announces "Reconnecting…" imperatively and avoids `accessibilityLiveRegion`.
 - Rendered the banner above the existing Retry indicator; route tests confirm the banner and Retry button stay mutually exclusive across reconnecting, timed-out, and connected states.
 - Automated validation is green; manual simulator/web-preview verification is blocked by local Expo preview startup in this environment.
+- Resolved all code review patch findings; deferred one pre-existing manual reconnect race to `_bmad-output/implementation-artifacts/deferred-work.md`.
 
 ### File List
 
@@ -315,3 +323,4 @@ GPT-5 Codex
 ### Change Log
 
 - 2026-05-17: Implemented reconnecting banner state, UI, route integration, and automated tests. Story remains in-progress pending manual simulator/web-preview verification.
+- 2026-05-17: Addressed code review patch findings and re-ran frontend validation. Story remains in-progress pending manual simulator/web-preview verification.

--- a/_bmad-output/implementation-artifacts/4-4-reconnecting-banner.md
+++ b/_bmad-output/implementation-artifacts/4-4-reconnecting-banner.md
@@ -1,6 +1,6 @@
 # Story 4.4: Reconnecting Banner
 
-Status: ready-for-dev
+Status: in-progress
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -38,52 +38,52 @@ so that I'm aware of the connection state without being blocked from viewing the
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Add `isReconnecting` to `useRoomWebSocket` so consumers can distinguish "initial connect in flight" from "previously connected, now reconnecting" (AC: 1, 5)
-  - [ ] In `frontend/hooks/useRoomWebSocket.ts`, add a `hasEverConnectedRef = useRef(false)` and set `hasEverConnectedRef.current = true` inside the `onOpen` handler (both the `client` `onOpen` callback wrapper and the `connectAsync` success branch — both paths flip `isConnected` to `true`).
-  - [ ] Reset `hasEverConnectedRef.current = false` in the cleanup branch where `enabled || !roomId || !userId` is false, and when the connection key changes (both points already disconnect the previous client). This prevents stale "reconnecting" state when switching rooms.
-  - [ ] Derive `isReconnecting` returned from the hook as `hasEverConnectedRef.current && !isConnected && !isTimedOut`. Do **not** introduce a new `useState` for this — derive on each render to stay in sync with the existing `isConnected`/`isTimedOut` state transitions.
-  - [ ] Extend the `UseRoomWebSocketResult` interface with `isReconnecting: boolean`. Do not remove or rename existing fields (`isConnected`, `isConnecting`, `isTimedOut`, `error`, `reconnect`, `subscribe`).
+- [x] Task 1: Add `isReconnecting` to `useRoomWebSocket` so consumers can distinguish "initial connect in flight" from "previously connected, now reconnecting" (AC: 1, 5)
+  - [x] In `frontend/hooks/useRoomWebSocket.ts`, add a `hasEverConnectedRef = useRef(false)` and set `hasEverConnectedRef.current = true` inside the `onOpen` handler (both the `client` `onOpen` callback wrapper and the `connectAsync` success branch — both paths flip `isConnected` to `true`).
+  - [x] Reset `hasEverConnectedRef.current = false` in the cleanup branch where `enabled || !roomId || !userId` is false, and when the connection key changes (both points already disconnect the previous client). This prevents stale "reconnecting" state when switching rooms.
+  - [x] Derive `isReconnecting` returned from the hook as `hasEverConnectedRef.current && !isConnected && !isTimedOut`. Do **not** introduce a new `useState` for this — derive on each render to stay in sync with the existing `isConnected`/`isTimedOut` state transitions.
+  - [x] Extend the `UseRoomWebSocketResult` interface with `isReconnecting: boolean`. Do not remove or rename existing fields (`isConnected`, `isConnecting`, `isTimedOut`, `error`, `reconnect`, `subscribe`).
 
-- [ ] Task 2: Propagate `isReconnecting` through `useRoomCharacters` (AC: 1, 5)
-  - [ ] In `frontend/hooks/useCharacters.ts`, destructure `isReconnecting` from the `useRoomWebSocket` return value alongside the existing `isConnected`, `isTimedOut`, `reconnect`, `subscribe`.
-  - [ ] Add `isReconnecting: boolean` to the `UseRoomCharactersResult` interface and the final returned object.
-  - [ ] Update the dependency array of the trailing `useMemo` to include `isReconnecting`.
+- [x] Task 2: Propagate `isReconnecting` through `useRoomCharacters` (AC: 1, 5)
+  - [x] In `frontend/hooks/useCharacters.ts`, destructure `isReconnecting` from the `useRoomWebSocket` return value alongside the existing `isConnected`, `isTimedOut`, `reconnect`, `subscribe`.
+  - [x] Add `isReconnecting: boolean` to the `UseRoomCharactersResult` interface and the final returned object.
+  - [x] Update the dependency array of the trailing `useMemo` to include `isReconnecting`.
 
-- [ ] Task 3: Implement `ReconnectingBanner` presentational component (AC: 1, 2, 4)
-  - [ ] Create `frontend/components/munchkin/ReconnectingBanner.tsx` exporting `ReconnectingBanner` as default.
-  - [ ] Props: `{ visible: boolean }`. Component renders `null` when `visible === false` and returns the banner JSX otherwise so that mount/unmount drives the accessibility announce side effect.
-  - [ ] On mount (`useEffect` with empty dep array), call `AccessibilityInfo.announceForAccessibility('Reconnecting…')`. Do not also set `accessibilityLiveRegion` — per `13.5` of UX, that prop is unreliable across platforms in React Native.
-  - [ ] Banner UI: a `View` with `backgroundColor: AppTheme.colors.surfaceSubtle`, full-width, sitting at the top of the Room View screen area (inside `SafeAreaView`, above `RoomCharactersList`). Padding `paddingVertical: AppTheme.spacing.sm`, `paddingHorizontal: AppTheme.spacing.md`. Text uses `color: AppTheme.colors.textMuted` and `AppTheme.typography.labelMd`. Center the text horizontally (`textAlign: 'center'`).
-  - [ ] Accessibility props on the View: `accessible={true}`, `accessibilityRole="alert"`, `accessibilityLabel="Reconnecting…"`. The imperative `announceForAccessibility` is the authoritative announcement; the `accessibilityRole="alert"` is supplementary semantic hinting.
-  - [ ] Co-locate the component test as `frontend/components/munchkin/ReconnectingBanner.test.tsx` (matching the casing convention `ComponentName.test.tsx` from `RoomCharacterCard.test.tsx`).
+- [x] Task 3: Implement `ReconnectingBanner` presentational component (AC: 1, 2, 4)
+  - [x] Create `frontend/components/munchkin/ReconnectingBanner.tsx` exporting `ReconnectingBanner` as default.
+  - [x] Props: `{ visible: boolean }`. Component renders `null` when `visible === false` and returns the banner JSX otherwise so that mount/unmount drives the accessibility announce side effect.
+  - [x] On mount (`useEffect` with empty dep array), call `AccessibilityInfo.announceForAccessibility('Reconnecting…')`. Do not also set `accessibilityLiveRegion` — per `13.5` of UX, that prop is unreliable across platforms in React Native.
+  - [x] Banner UI: a `View` with `backgroundColor: AppTheme.colors.surfaceSubtle`, full-width, sitting at the top of the Room View screen area (inside `SafeAreaView`, above `RoomCharactersList`). Padding `paddingVertical: AppTheme.spacing.sm`, `paddingHorizontal: AppTheme.spacing.md`. Text uses `color: AppTheme.colors.textMuted` and `AppTheme.typography.labelMd`. Center the text horizontally (`textAlign: 'center'`).
+  - [x] Accessibility props on the View: `accessible={true}`, `accessibilityRole="alert"`, `accessibilityLabel="Reconnecting…"`. The imperative `announceForAccessibility` is the authoritative announcement; the `accessibilityRole="alert"` is supplementary semantic hinting.
+  - [x] Co-locate the component test as `frontend/components/munchkin/ReconnectingBanner.test.tsx` (matching the casing convention `ComponentName.test.tsx` from `RoomCharacterCard.test.tsx`).
 
-- [ ] Task 4: Render `ReconnectingBanner` in Room View (AC: 1, 2, 3, 5)
-  - [ ] In `frontend/app/munchkin/[roomNumber]/index.tsx`, destructure `isReconnecting` from `useRoomCharacters` alongside the existing fields.
-  - [ ] Import and render `<ReconnectingBanner visible={isReconnecting} />` **above** the existing `{isTimedOut && !isConnected && (...) }` Retry block — banner sits at the very top of the screen content, below the `Stack.Screen` header but above the characters list and Retry button.
-  - [ ] Do not change the existing Retry button logic. The two indicators are mutually exclusive by construction (`isReconnecting` requires `!isTimedOut`, so they cannot both be true).
+- [x] Task 4: Render `ReconnectingBanner` in Room View (AC: 1, 2, 3, 5)
+  - [x] In `frontend/app/munchkin/[roomNumber]/index.tsx`, destructure `isReconnecting` from `useRoomCharacters` alongside the existing fields.
+  - [x] Import and render `<ReconnectingBanner visible={isReconnecting} />` **above** the existing `{isTimedOut && !isConnected && (...) }` Retry block — banner sits at the very top of the screen content, below the `Stack.Screen` header but above the characters list and Retry button.
+  - [x] Do not change the existing Retry button logic. The two indicators are mutually exclusive by construction (`isReconnecting` requires `!isTimedOut`, so they cannot both be true).
 
-- [ ] Task 5: Tests (AC: 1, 2, 3, 4, 5)
-  - [ ] `frontend/components/munchkin/ReconnectingBanner.test.tsx` — unit test the banner:
+- [x] Task 5: Tests (AC: 1, 2, 3, 4, 5)
+  - [x] `frontend/components/munchkin/ReconnectingBanner.test.tsx` — unit test the banner:
     - renders nothing when `visible={false}` (assert no text present)
     - renders the "Reconnecting…" text when `visible={true}` and applies `surfaceSubtle` background and `textMuted` text color (snapshot or style assertions)
     - calls `AccessibilityInfo.announceForAccessibility` exactly once with the reconnecting message on mount and does **not** call it again when the parent re-renders with the same visible state. Mock `AccessibilityInfo` via `vi.mock('react-native', ...)` mirroring `RoomCharacterCard.test.tsx` line 4 / 21.
     - does not call `announceForAccessibility` when initially mounted with `visible={false}`
-  - [ ] `frontend/hooks/useRoomWebSocket.test.ts` — extend existing suite:
+  - [x] `frontend/hooks/useRoomWebSocket.test.ts` — extend existing suite:
     - new test: `isReconnecting` is `false` before any connect completes (initial mount, no `onOpen` yet) even if `isConnected === false`
     - new test: after a successful `onOpen` and a subsequent disconnect (`onClose`), `isReconnecting` becomes `true` until either the mocked `isConnected` flips back to `true` (auto-reconnect) or `vi.advanceTimersByTime(8000)` triggers `isTimedOut`
     - new test: `isReconnecting` flips back to `false` when `isTimedOut` becomes `true`
     - reuse the existing `mockClientInstances` fake-timer pattern; do not introduce real timers
-  - [ ] `frontend/__tests__/app/munchkin/[roomNumber].test.tsx` — extend the existing route-level mocks:
+  - [x] `frontend/__tests__/app/munchkin/[roomNumber].test.tsx` — extend the existing route-level mocks:
     - add `isReconnecting` to the `mockConnectionState` hoisted ref and to the `useRoomCharacters` mock return value
     - new test: when `mockConnectionState.current = { isConnected: false, isReconnecting: true, isTimedOut: false }`, the banner text "Reconnecting…" is rendered and the "Connection lost · Retry" button is NOT rendered
     - new test: when `mockConnectionState.current = { isConnected: false, isReconnecting: false, isTimedOut: true }`, the banner text "Reconnecting…" is NOT rendered and the Retry button IS rendered (this preserves the assertion already in the existing test at line 714)
     - new test: when `isConnected: true`, neither the banner nor the Retry button is rendered
 
 - [ ] Task 6: Run frontend validation
-  - [ ] `cd frontend && npm run test:unit`
-  - [ ] `cd frontend && npm run test:room-route`
-  - [ ] `cd frontend && npm run lint`
-  - [ ] `cd frontend && npm run tsc`
+  - [x] `cd frontend && npm run test:unit`
+  - [x] `cd frontend && npm run test:room-route`
+  - [x] `cd frontend && npm run lint`
+  - [x] `cd frontend && npm run tsc`
   - [ ] Manually verify on iOS Simulator (or web preview) that the banner appears briefly when toggling airplane mode mid-session and disappears on reconnect — the 8-second timeout should hand off to the existing Retry button.
 
 ## Dev Notes
@@ -283,12 +283,35 @@ frontend/__tests__/app/munchkin/[roomNumber].test.tsx  ADD isReconnecting to hoi
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+GPT-5 Codex
 
 ### Debug Log References
+
+- 2026-05-17: Added derived `isReconnecting` state to `useRoomWebSocket` with `hasEverConnectedRef`; propagated through `useRoomCharacters` and Room View.
+- 2026-05-17: Added `ReconnectingBanner` component and tests for visibility, token styles, and imperative accessibility announcement.
+- 2026-05-17: Validation passed: `npm run test:unit`, `npm run test:room-route`, `npm run lint`, `npm run tsc`. Lint reports one pre-existing warning in `frontend/app/munchkin/modal-change-caracter.tsx`.
+- 2026-05-17: Web preview manual verification attempted on ports 19006, 19007, 19008, and the project default 8081; Expo did not open a listening port in this environment, including offline/localhost retries, so the manual preview subtask remains unchecked.
 
 ### Completion Notes List
 
 - Ultimate context engine analysis completed — comprehensive developer guide created
+- Implemented reconnecting-window state derived from prior successful WebSocket connection plus current `isConnected`/`isTimedOut` state.
+- Added a low-prominence, token-styled `ReconnectingBanner` that announces "Reconnecting…" imperatively and avoids `accessibilityLiveRegion`.
+- Rendered the banner above the existing Retry indicator; route tests confirm the banner and Retry button stay mutually exclusive across reconnecting, timed-out, and connected states.
+- Automated validation is green; manual simulator/web-preview verification is blocked by local Expo preview startup in this environment.
 
 ### File List
+
+- frontend/hooks/useRoomWebSocket.ts
+- frontend/hooks/useRoomWebSocket.test.ts
+- frontend/hooks/useCharacters.ts
+- frontend/components/munchkin/ReconnectingBanner.tsx
+- frontend/components/munchkin/ReconnectingBanner.test.tsx
+- frontend/app/munchkin/[roomNumber]/index.tsx
+- frontend/__tests__/app/munchkin/[roomNumber].test.tsx
+- _bmad-output/implementation-artifacts/4-4-reconnecting-banner.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+
+### Change Log
+
+- 2026-05-17: Implemented reconnecting banner state, UI, route integration, and automated tests. Story remains in-progress pending manual simulator/web-preview verification.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,3 @@
+## Deferred from: code review of 4-4-reconnecting-banner.md (2026-05-17)
+
+- Stale manual reconnect can update the wrong room/state: `reconnect()` awaits the current client and then only checks `isMountedRef.current` before mutating state. If the room/user changes or the hook disables while a manual reconnect is pending, the stale promise can update the new/disabled connection state. This race existed before Story 4.4 because the reconnect implementation was already present.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-17T09:25:40Z
+last_updated: 2026-05-17T10:02:19Z
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-16T23:30:00Z
+last_updated: 2026-05-17T09:25:40Z
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -73,7 +73,7 @@ development_status:
   4-1-live-room-state-synchronisation: done
   4-2-graceful-room-exit: done
   4-3-reconnection-session-restore: done
-  4-4-reconnecting-banner: ready-for-dev
+  4-4-reconnecting-banner: in-progress
   4-5-late-join-context-awareness: ready-for-dev
   4-6-reduced-motion-support: ready-for-dev
   epic-4-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-17T10:02:19Z
+last_updated: 2026-05-17T10:26:59Z
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -73,7 +73,7 @@ development_status:
   4-1-live-room-state-synchronisation: done
   4-2-graceful-room-exit: done
   4-3-reconnection-session-restore: done
-  4-4-reconnecting-banner: in-progress
+  4-4-reconnecting-banner: done
   4-5-late-join-context-awareness: ready-for-dev
   4-6-reduced-motion-support: ready-for-dev
   epic-4-retrospective: optional

--- a/frontend/__tests__/app/munchkin/[roomNumber].test.tsx
+++ b/frontend/__tests__/app/munchkin/[roomNumber].test.tsx
@@ -17,6 +17,7 @@ const mockIsCreateBlocked = vi.hoisted(() => ({ current: false }));
 const mockConnectionState = vi.hoisted(() => ({
   current: {
     isConnected: true,
+    isReconnecting: false,
     isTimedOut: false,
   },
 }));
@@ -66,6 +67,7 @@ vi.mock('@/hooks/useCharacters', () => ({
     refresh: mockRefreshCharacters,
     reconnect: mockReconnect,
     isConnected: mockConnectionState.current.isConnected,
+    isReconnecting: mockConnectionState.current.isReconnecting,
     isTimedOut: mockConnectionState.current.isTimedOut,
     isCreateBlocked: mockIsCreateBlocked.current,
     isLoading: false,
@@ -210,6 +212,7 @@ describe('Munchkin room header', () => {
     mockIsCreateBlocked.current = false;
     mockConnectionState.current = {
       isConnected: true,
+      isReconnecting: false,
       isTimedOut: false,
     };
     mockCreateCharacter.mockResolvedValue(undefined);
@@ -714,6 +717,7 @@ describe('Munchkin room header', () => {
   it('renders connection retry action after reconnect timeout and refreshes after retry', async () => {
     mockConnectionState.current = {
       isConnected: false,
+      isReconnecting: false,
       isTimedOut: true,
     };
     const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
@@ -736,6 +740,7 @@ describe('Munchkin room header', () => {
     });
 
     const retryButton = screen.getByRole('button', { name: 'Connection lost. Tap to retry' });
+    expect(screen.queryByText('Reconnecting…')).toBeNull();
     expect(screen.getByText('Connection lost · Retry')).toBeTruthy();
 
     await act(async () => {
@@ -745,6 +750,65 @@ describe('Munchkin room header', () => {
 
     expect(mockReconnect).toHaveBeenCalledTimes(1);
     expect(mockRefreshCharacters).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders reconnecting banner without the retry action while reconnect is in flight', async () => {
+    mockConnectionState.current = {
+      isConnected: false,
+      isReconnecting: true,
+      isTimedOut: false,
+    };
+    const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
+
+    await act(async () => {
+      render(
+        <userProfileContext.Provider
+          value={{
+            userProfile: {
+              id: 'user-1',
+              nickname: 'Player One',
+              avatar: 1,
+            },
+            setUserProfile: vi.fn(),
+          }}
+        >
+          <MunchkinIndexView />
+        </userProfileContext.Provider>
+      );
+    });
+
+    expect(screen.getByText('Reconnecting…')).toBeTruthy();
+    expect(screen.queryByText('Connection lost · Retry')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Connection lost. Tap to retry' })).toBeNull();
+  });
+
+  it('renders neither reconnecting banner nor retry action while connected', async () => {
+    mockConnectionState.current = {
+      isConnected: true,
+      isReconnecting: false,
+      isTimedOut: false,
+    };
+    const { default: MunchkinIndexView } = await import('../../../app/munchkin/[roomNumber]/index');
+
+    await act(async () => {
+      render(
+        <userProfileContext.Provider
+          value={{
+            userProfile: {
+              id: 'user-1',
+              nickname: 'Player One',
+              avatar: 1,
+            },
+            setUserProfile: vi.fn(),
+          }}
+        >
+          <MunchkinIndexView />
+        </userProfileContext.Provider>
+      );
+    });
+
+    expect(screen.queryByText('Reconnecting…')).toBeNull();
+    expect(screen.queryByText('Connection lost · Retry')).toBeNull();
   });
 
   it('skips foreground reconnect registration while already connected', async () => {

--- a/frontend/app/munchkin/[roomNumber]/index.tsx
+++ b/frontend/app/munchkin/[roomNumber]/index.tsx
@@ -10,6 +10,7 @@ import { Animated, Platform, Pressable, StyleSheet, Text, TouchableOpacity, View
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import CurrentCharacterFooter from '../../../components/munchkin/CurrentCharacterFooter';
 import QuickEditSheet from '../../../components/munchkin/QuickEditSheet';
+import ReconnectingBanner from '../../../components/munchkin/ReconnectingBanner';
 import RoomCharactersList from '../../../components/munchkin/RoomCharactersList';
 import ChangeCharacterModal from '../modal-change-caracter';
 import CreateCharacterModal from '../modal-create-character';
@@ -36,6 +37,7 @@ const MunchkinIndexView: React.FC = () => {
     errorMessage,
     isCreateBlocked,
     isConnected,
+    isReconnecting,
     isTimedOut,
     refresh,
     reconnect,
@@ -250,6 +252,8 @@ const MunchkinIndexView: React.FC = () => {
               ),
             }}
           />
+
+          <ReconnectingBanner visible={isReconnecting} />
 
           {isTimedOut && !isConnected && (
             <Pressable

--- a/frontend/components/munchkin/ReconnectingBanner.test.tsx
+++ b/frontend/components/munchkin/ReconnectingBanner.test.tsx
@@ -1,0 +1,88 @@
+import { AppTheme } from '@/constants/theme';
+import React from 'react';
+import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ReconnectingBanner from './ReconnectingBanner';
+
+vi.mock('react-native', async () => {
+  const actual = await vi.importActual<typeof import('react-native')>('react-native');
+  return {
+    ...actual,
+    AccessibilityInfo: {
+      ...actual.AccessibilityInfo,
+      announceForAccessibility: vi.fn(),
+    },
+  };
+});
+
+function getTextNode(renderer: any, text: string) {
+  return renderer.root.find((node: { props?: { children?: unknown } }) => node.props?.children === text);
+}
+
+describe('ReconnectingBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when hidden', () => {
+    let renderer: any;
+
+    act(() => {
+      renderer = TestRenderer.create(<ReconnectingBanner visible={false} />);
+    });
+
+    expect(renderer.toJSON()).toBeNull();
+    expect(AccessibilityInfo.announceForAccessibility).not.toHaveBeenCalled();
+  });
+
+  it('renders reconnecting text with token styles when visible', () => {
+    let renderer: any;
+
+    act(() => {
+      renderer = TestRenderer.create(<ReconnectingBanner visible />);
+    });
+
+    const banner = renderer.root.findByType(View);
+    const label = getTextNode(renderer, 'Reconnecting…');
+    const bannerStyle = StyleSheet.flatten(banner.props.style);
+    const labelStyle = StyleSheet.flatten(label.props.style);
+
+    expect(bannerStyle.backgroundColor).toBe(AppTheme.colors.surfaceSubtle);
+    expect(labelStyle.color).toBe(AppTheme.colors.textMuted);
+    expect(labelStyle.textAlign).toBe('center');
+    expect(label.type).toBe(Text);
+  });
+
+  it('announces exactly once while the same visible banner remains mounted', () => {
+    let renderer: any;
+
+    act(() => {
+      renderer = TestRenderer.create(<ReconnectingBanner visible />);
+    });
+
+    act(() => {
+      renderer.update(<ReconnectingBanner visible />);
+    });
+
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledTimes(1);
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith('Reconnecting…');
+  });
+
+  it('announces when the banner transitions from hidden to visible', () => {
+    let renderer: any;
+
+    act(() => {
+      renderer = TestRenderer.create(<ReconnectingBanner visible={false} />);
+    });
+    expect(AccessibilityInfo.announceForAccessibility).not.toHaveBeenCalled();
+
+    act(() => {
+      renderer.update(<ReconnectingBanner visible />);
+    });
+
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledTimes(1);
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith('Reconnecting…');
+  });
+});

--- a/frontend/components/munchkin/ReconnectingBanner.tsx
+++ b/frontend/components/munchkin/ReconnectingBanner.tsx
@@ -7,17 +7,17 @@ interface ReconnectingBannerProps {
 }
 
 export default function ReconnectingBanner({ visible }: ReconnectingBannerProps) {
-  useEffect(() => {
-    if (!visible) {
-      return;
-    }
-
-    AccessibilityInfo.announceForAccessibility('Reconnecting…');
-  }, [visible]);
-
   if (!visible) {
     return null;
   }
+
+  return <MountedReconnectingBanner />;
+}
+
+function MountedReconnectingBanner() {
+  useEffect(() => {
+    AccessibilityInfo.announceForAccessibility('Reconnecting…');
+  }, []);
 
   return (
     <View

--- a/frontend/components/munchkin/ReconnectingBanner.tsx
+++ b/frontend/components/munchkin/ReconnectingBanner.tsx
@@ -1,0 +1,45 @@
+import { AppTheme } from '@/constants/theme';
+import React, { useEffect } from 'react';
+import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+
+interface ReconnectingBannerProps {
+  visible: boolean;
+}
+
+export default function ReconnectingBanner({ visible }: ReconnectingBannerProps) {
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    AccessibilityInfo.announceForAccessibility('Reconnecting…');
+  }, [visible]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <View
+      accessible
+      accessibilityRole="alert"
+      accessibilityLabel="Reconnecting…"
+      style={styles.banner}
+    >
+      <Text style={styles.label}>Reconnecting…</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    backgroundColor: AppTheme.colors.surfaceSubtle,
+    paddingVertical: AppTheme.spacing.sm,
+    paddingHorizontal: AppTheme.spacing.md,
+  },
+  label: {
+    color: AppTheme.colors.textMuted,
+    textAlign: 'center',
+    ...AppTheme.typography.labelMd,
+  },
+});

--- a/frontend/hooks/useCharacters.test.ts
+++ b/frontend/hooks/useCharacters.test.ts
@@ -16,7 +16,13 @@ import type { UserProfileInterface } from '@/hooks/useUser';
 const mockSubscribe = vi.fn<(listener: (event: { event: string; event_body: { characterId: string } }) => void) => () => void>(
   () => () => undefined
 );
+const mockReconnect = vi.fn<() => Promise<void>>(() => Promise.resolve());
 let latestRoomWebSocketOptions: { onOpen?: () => void } | undefined;
+let mockRoomWebSocketState = {
+  isConnected: true,
+  isReconnecting: false,
+  isTimedOut: false,
+};
 
 vi.mock('@/api/characters', () => ({
   createCharacter: vi.fn(),
@@ -32,9 +38,10 @@ vi.mock('@/hooks/useRoomWebSocket', () => ({
     _enabled: boolean,
     options?: { onOpen?: () => void }
   ) => ({
-    isConnected: true,
-    isTimedOut: false,
-    reconnect: vi.fn(),
+    isConnected: mockRoomWebSocketState.isConnected,
+    isReconnecting: mockRoomWebSocketState.isReconnecting,
+    isTimedOut: mockRoomWebSocketState.isTimedOut,
+    reconnect: mockReconnect,
     subscribe: mockSubscribe,
     ...(() => {
       latestRoomWebSocketOptions = options;
@@ -75,7 +82,14 @@ describe('useRoomCharacters', () => {
     mockDeleteCharacter.mockReset();
     mockUpdateCharacter.mockReset();
     mockSubscribe.mockReset();
+    mockReconnect.mockReset();
     mockSubscribe.mockImplementation(() => () => undefined);
+    mockReconnect.mockResolvedValue(undefined);
+    mockRoomWebSocketState = {
+      isConnected: true,
+      isReconnecting: false,
+      isTimedOut: false,
+    };
     latestRoomWebSocketOptions = undefined;
   });
 
@@ -286,6 +300,50 @@ describe('useRoomCharacters', () => {
     await waitFor(() => {
       expect(result.current.characters[0]?.level).toBe(3);
     });
+  });
+
+  it('forwards reconnecting state from the room WebSocket hook', async () => {
+    const currentCharacter: Character = {
+      id: 'char-self',
+      roomId,
+      userId: userProfile.id,
+      nickname: 'Hero',
+      avatar: 1,
+      color: '#AA5500',
+      level: 2,
+      power: 3,
+      race: ['Human'],
+      gender: ['male'],
+      class: ['Warrior'],
+    };
+    mockRoomWebSocketState = {
+      isConnected: false,
+      isReconnecting: true,
+      isTimedOut: false,
+    };
+    mockGetCharactersByRoom.mockResolvedValue([currentCharacter]);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result, rerender } = renderHook(() => useRoomCharacters(roomId, userProfile), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isReconnecting).toBe(true);
+    });
+
+    mockRoomWebSocketState = {
+      isConnected: true,
+      isReconnecting: false,
+      isTimedOut: false,
+    };
+    act(() => {
+      rerender();
+    });
+
+    expect(result.current.isReconnecting).toBe(false);
   });
 
   it('does not auto-recreate the current user character after an intentional self-delete', async () => {

--- a/frontend/hooks/useCharacters.ts
+++ b/frontend/hooks/useCharacters.ts
@@ -19,6 +19,7 @@ interface UseRoomCharactersResult {
   errorMessage: string | null;
   isCreateBlocked: boolean;
   isConnected: boolean;
+  isReconnecting: boolean;
   isTimedOut: boolean;
   refresh: () => Promise<void>;
   reconnect: () => Promise<void>;
@@ -119,7 +120,7 @@ export function useRoomCharacters(roomId: string | undefined, userProfile: UserP
   const [isCreateBlocked, setIsCreateBlocked] = useState(false);
 
   // Set up WebSocket connection for real-time updates
-  const { isConnected, isTimedOut, reconnect, subscribe } = useRoomWebSocket(
+  const { isConnected, isReconnecting, isTimedOut, reconnect, subscribe } = useRoomWebSocket(
     roomId,
     userProfile.id,
     Boolean(roomId && userProfile.id),
@@ -452,6 +453,7 @@ export function useRoomCharacters(roomId: string | undefined, userProfile: UserP
       errorMessage,
       isCreateBlocked,
       isConnected,
+      isReconnecting,
       isTimedOut,
       refresh,
       reconnect,
@@ -459,6 +461,6 @@ export function useRoomCharacters(roomId: string | undefined, userProfile: UserP
       update,
       remove,
     }),
-    [characters, create, errorMessage, isConnected, isCreateBlocked, isLoading, isTimedOut, realtimeUpdateSignals, reconnect, refresh, remove, update]
+    [characters, create, errorMessage, isConnected, isCreateBlocked, isLoading, isReconnecting, isTimedOut, realtimeUpdateSignals, reconnect, refresh, remove, update]
   );
 }

--- a/frontend/hooks/useRoomWebSocket.test.ts
+++ b/frontend/hooks/useRoomWebSocket.test.ts
@@ -282,6 +282,69 @@ describe('useRoomWebSocket', () => {
     vi.useRealTimers();
   });
 
+  it('does not carry reconnecting state into a new room before the new connection opens', async () => {
+    const { result, rerender } = renderHook(
+      ({ roomId }) => useRoomWebSocket(roomId, 'user-1', true),
+      {
+        initialProps: {
+          roomId: 'room-1',
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      mockClientInstances[0]?.isConnected.mockReturnValue(false);
+      mockClientInstances[0]?.options?.onClose?.();
+    });
+
+    expect(result.current.isReconnecting).toBe(true);
+
+    nextConnectPromise = new Promise(() => undefined);
+    act(() => {
+      rerender({ roomId: 'room-2' });
+    });
+
+    expect(result.current.isReconnecting).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it('does not report reconnecting after the hook is disabled', async () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useRoomWebSocket('room-1', 'user-1', enabled),
+      {
+        initialProps: {
+          enabled: true,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      mockClientInstances[0]?.isConnected.mockReturnValue(false);
+      mockClientInstances[0]?.options?.onClose?.();
+    });
+
+    expect(result.current.isReconnecting).toBe(true);
+
+    act(() => {
+      rerender({ enabled: false });
+    });
+
+    expect(result.current.isReconnecting).toBe(false);
+
+    vi.useRealTimers();
+  });
+
   it('resets timeout state on manual reconnect and successful open', async () => {
     const { result } = renderHook(() => useRoomWebSocket('room-1', 'user-1', true));
 

--- a/frontend/hooks/useRoomWebSocket.test.ts
+++ b/frontend/hooks/useRoomWebSocket.test.ts
@@ -14,6 +14,7 @@ type MockClientInstance = {
 
 const mockClientInstances: MockClientInstance[] = [];
 let nextConnectError: Error | null = null;
+let nextConnectPromise: Promise<void> | null = null;
 
 type MockWebSocketOptions = {
   onOpen?: () => void;
@@ -26,6 +27,11 @@ vi.mock('@/api/webSocket', () => {
   return {
     RoomWebSocketClient: class MockRoomWebSocketClient {
       connect = vi.fn(async () => {
+        if (nextConnectPromise) {
+          await nextConnectPromise;
+          nextConnectPromise = null;
+        }
+
         if (nextConnectError) {
           const error = nextConnectError;
           nextConnectError = null;
@@ -73,6 +79,7 @@ describe('useRoomWebSocket', () => {
     vi.clearAllMocks();
     mockClientInstances.length = 0;
     nextConnectError = null;
+    nextConnectPromise = null;
   });
 
   it('should initialize hook with disabled connection', () => {
@@ -81,6 +88,7 @@ describe('useRoomWebSocket', () => {
     expect(result.current.isConnected).toBe(false);
     expect(result.current.isConnecting).toBe(false);
     expect(result.current.error).toBeNull();
+    expect(result.current.isReconnecting).toBe(false);
     expect(result.current.isTimedOut).toBe(false);
   });
 
@@ -208,6 +216,68 @@ describe('useRoomWebSocket', () => {
       vi.advanceTimersByTime(1);
     });
     expect(result.current.isTimedOut).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it('keeps isReconnecting false before any connect completes', () => {
+    nextConnectPromise = new Promise(() => undefined);
+    const { result, unmount } = renderHook(() => useRoomWebSocket('room-1', 'user-1', true));
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.isReconnecting).toBe(false);
+
+    unmount();
+  });
+
+  it('marks isReconnecting true after a successful connection drops and clears it on reconnect', async () => {
+    const { result } = renderHook(() => useRoomWebSocket('room-1', 'user-1', true));
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      mockClientInstances[0]?.isConnected.mockReturnValue(false);
+      mockClientInstances[0]?.options?.onClose?.();
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.isReconnecting).toBe(true);
+
+    act(() => {
+      mockClientInstances[0]?.isConnected.mockReturnValue(true);
+      mockClientInstances[0]?.options?.onOpen?.();
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.isReconnecting).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it('clears isReconnecting when reconnect timeout fires', async () => {
+    const { result } = renderHook(() => useRoomWebSocket('room-1', 'user-1', true));
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      mockClientInstances[0]?.isConnected.mockReturnValue(false);
+      mockClientInstances[0]?.options?.onClose?.();
+    });
+
+    expect(result.current.isReconnecting).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    expect(result.current.isTimedOut).toBe(true);
+    expect(result.current.isReconnecting).toBe(false);
 
     vi.useRealTimers();
   });

--- a/frontend/hooks/useRoomWebSocket.ts
+++ b/frontend/hooks/useRoomWebSocket.ts
@@ -31,6 +31,7 @@ export function useRoomWebSocket(
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
   const hasEverConnectedRef = useRef(false);
+  const lastConnectedKeyRef = useRef<string>('');
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [isTimedOut, setIsTimedOut] = useState(false);
@@ -75,6 +76,7 @@ export function useRoomWebSocket(
         clientRef.current = null;
       }
       hasEverConnectedRef.current = false;
+      lastConnectedKeyRef.current = '';
       setIsConnected(false);
       setIsConnecting(false);
       setIsTimedOut(false);
@@ -95,6 +97,7 @@ export function useRoomWebSocket(
       clientRef.current.disconnect();
       clientRef.current = null;
       hasEverConnectedRef.current = false;
+      lastConnectedKeyRef.current = '';
     }
 
     connectionKeyRef.current = connectionKey;
@@ -110,6 +113,7 @@ export function useRoomWebSocket(
 
         clearReconnectTimeout();
         hasEverConnectedRef.current = true;
+        lastConnectedKeyRef.current = connectionKey;
         setIsConnected(true);
         setIsConnecting(false);
         setIsTimedOut(false);
@@ -136,6 +140,7 @@ export function useRoomWebSocket(
         await client.connect();
         if (isMounted) {
           hasEverConnectedRef.current = true;
+          lastConnectedKeyRef.current = connectionKey;
           setIsConnected(true);
           setIsConnecting(false);
           setIsTimedOut(false);
@@ -157,6 +162,7 @@ export function useRoomWebSocket(
       client.disconnect();
       clientRef.current = null;
       hasEverConnectedRef.current = false;
+      lastConnectedKeyRef.current = '';
       setIsConnected(false);
       setIsConnecting(false);
       setIsTimedOut(false);
@@ -205,7 +211,12 @@ export function useRoomWebSocket(
     return clientRef.current.subscribe(listener);
   };
 
-  const isReconnecting = hasEverConnectedRef.current && !isConnected && !isTimedOut;
+  const currentConnectionKey = enabled && roomId && userId ? `${roomId}:${userId}` : '';
+  const isReconnecting =
+    hasEverConnectedRef.current &&
+    lastConnectedKeyRef.current === currentConnectionKey &&
+    !isConnected &&
+    !isTimedOut;
 
   return {
     isConnected,

--- a/frontend/hooks/useRoomWebSocket.ts
+++ b/frontend/hooks/useRoomWebSocket.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 interface UseRoomWebSocketResult {
   isConnected: boolean;
   isConnecting: boolean;
+  isReconnecting: boolean;
   isTimedOut: boolean;
   error: Error | null;
   reconnect: () => Promise<void>;
@@ -29,6 +30,7 @@ export function useRoomWebSocket(
   const clientRef = useRef<RoomWebSocketClient | null>(null);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
+  const hasEverConnectedRef = useRef(false);
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [isTimedOut, setIsTimedOut] = useState(false);
@@ -72,6 +74,7 @@ export function useRoomWebSocket(
         clientRef.current.disconnect();
         clientRef.current = null;
       }
+      hasEverConnectedRef.current = false;
       setIsConnected(false);
       setIsConnecting(false);
       setIsTimedOut(false);
@@ -91,6 +94,7 @@ export function useRoomWebSocket(
     if (clientRef.current && connectionKeyRef.current !== connectionKey) {
       clientRef.current.disconnect();
       clientRef.current = null;
+      hasEverConnectedRef.current = false;
     }
 
     connectionKeyRef.current = connectionKey;
@@ -105,6 +109,7 @@ export function useRoomWebSocket(
         }
 
         clearReconnectTimeout();
+        hasEverConnectedRef.current = true;
         setIsConnected(true);
         setIsConnecting(false);
         setIsTimedOut(false);
@@ -130,6 +135,7 @@ export function useRoomWebSocket(
         setError(null);
         await client.connect();
         if (isMounted) {
+          hasEverConnectedRef.current = true;
           setIsConnected(true);
           setIsConnecting(false);
           setIsTimedOut(false);
@@ -150,6 +156,7 @@ export function useRoomWebSocket(
       isMounted = false;
       client.disconnect();
       clientRef.current = null;
+      hasEverConnectedRef.current = false;
       setIsConnected(false);
       setIsConnecting(false);
       setIsTimedOut(false);
@@ -198,9 +205,12 @@ export function useRoomWebSocket(
     return clientRef.current.subscribe(listener);
   };
 
+  const isReconnecting = hasEverConnectedRef.current && !isConnected && !isTimedOut;
+
   return {
     isConnected,
     isConnecting,
+    isReconnecting,
     isTimedOut,
     error,
     reconnect,


### PR DESCRIPTION
## Summary

- Add derived `isReconnecting` state to `useRoomWebSocket` so the app can distinguish initial connect from reconnect-in-progress.
- Propagate reconnecting state through `useRoomCharacters` and render a low-prominence `ReconnectingBanner` at the top of Room View.
- Add unit and route tests for banner visibility, timeout handoff to Retry, connected state, token styles, and accessibility announcement behavior.
- Update Story 4.4 BMAD tracking notes and sprint status.

## Validation

- `cd frontend && npm run test:unit`
- `cd frontend && npm run test:room-route`
- `cd frontend && npm run lint` (passes with one pre-existing warning in `frontend/app/munchkin/modal-change-caracter.tsx`)
- `cd frontend && npm run tsc`

## Notes

Manual web preview was attempted on `8081` and fallback ports, including offline/localhost Expo retries, but Expo did not open a listening port in this sandbox. The story remains `in-progress` with that manual verification checkbox intentionally unchecked.