### PR TITLE
[codex] Implement reduced motion support

### DIFF
--- a/_bmad-output/implementation-artifacts/4-6-reduced-motion-support.md
+++ b/_bmad-output/implementation-artifacts/4-6-reduced-motion-support.md
@@ -1,6 +1,6 @@
 # Story 4.6: Reduced Motion Support
 
-Status: ready-for-dev
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -33,28 +33,32 @@ so that animations don't cause discomfort during play.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Verify and lock the realtime-flash reduced-motion behaviour (AC: 1, 3, 4)
-  - [ ] Confirm `RoomCharacterCard.tsx` already implements the reduced-motion path: immediate border colour, `surfaceWarm` restore after `REALTIME_FLASH_DURATION_MS` (700ms), no interpolation. **Do NOT rewrite this** — it shipped in Story 3.8.
-  - [ ] Confirm existing regression coverage exists in `frontend/components/munchkin/RoomCharacterCard.test.tsx` ("shows reduced-motion realtime border signal when an external update arrives", line ~186; "waits for reduced-motion preference resolution before processing the first realtime signal", line ~212).
-  - [ ] If (and only if) a gap exists, add coverage for the preference-change-at-runtime case (`reduceMotionChanged` listener flipping after mount). Do not duplicate already-passing assertions.
+- [x] Task 1: Verify and lock the realtime-flash reduced-motion behaviour (AC: 1, 3, 4)
+  - [x] Confirm `RoomCharacterCard.tsx` already implements the reduced-motion path: immediate border colour, `surfaceWarm` restore after `REALTIME_FLASH_DURATION_MS` (700ms), no interpolation. **Do NOT rewrite this** — it shipped in Story 3.8.
+  - [x] Confirm existing regression coverage exists in `frontend/components/munchkin/RoomCharacterCard.test.tsx` ("shows reduced-motion realtime border signal when an external update arrives", line ~186; "waits for reduced-motion preference resolution before processing the first realtime signal", line ~212).
+  - [x] If (and only if) a gap exists, add coverage for the preference-change-at-runtime case (`reduceMotionChanged` listener flipping after mount). Do not duplicate already-passing assertions.
 
-- [ ] Task 2: Add reduced-motion support to `QuickEditSheet` (AC: 2, 3, 4)
-  - [ ] Resolve the reduced-motion preference using the **same pattern already used in `RoomCharacterCard.tsx`**: `AccessibilityInfo.isReduceMotionEnabled()` for the initial value plus an `AccessibilityInfo.addEventListener('reduceMotionChanged', ...)` subscription, with the subscription removed on unmount. Track it in component state initialised to `null` (unknown) and treat unknown as "animate" (default behaviour) until resolved.
-  - [ ] In `animateSheetTo`, when reduced motion is enabled, set the target values directly (`translateY.setValue(toValue)`, `backdropOpacity.setValue(toValue === 0 ? 1 : 0)`) and invoke the `onFinished` callback synchronously instead of running `Animated.parallel`/`Animated.timing`. The open/close state machine (`isRendered`, `isClosing`, `isSaving`, `onOpenFullEdit` sequencing) MUST behave identically — only the tween is skipped.
-  - [ ] Ensure the `panResponder` release path still settles correctly under reduced motion (the snap-back / dismiss decision must remain; just skip the tween).
-  - [ ] Keep the change localised to `QuickEditSheet.tsx`. Do not change the component's props, the parent route, or `RoomCharactersList`.
+- [x] Task 2: Add reduced-motion support to `QuickEditSheet` (AC: 2, 3, 4)
+  - [x] Resolve the reduced-motion preference using the **same pattern already used in `RoomCharacterCard.tsx`**: `AccessibilityInfo.isReduceMotionEnabled()` for the initial value plus an `AccessibilityInfo.addEventListener('reduceMotionChanged', ...)` subscription, with the subscription removed on unmount. Track it in component state initialised to `null` (unknown) and treat unknown as "animate" (default behaviour) until resolved.
+  - [x] In `animateSheetTo`, when reduced motion is enabled, set the target values directly (`translateY.setValue(toValue)`, `backdropOpacity.setValue(toValue === 0 ? 1 : 0)`) and invoke the `onFinished` callback synchronously instead of running `Animated.parallel`/`Animated.timing`. The open/close state machine (`isRendered`, `isClosing`, `isSaving`, `onOpenFullEdit` sequencing) MUST behave identically — only the tween is skipped.
+  - [x] Ensure the `panResponder` release path still settles correctly under reduced motion (the snap-back / dismiss decision must remain; just skip the tween).
+  - [x] Keep the change localised to `QuickEditSheet.tsx`. Do not change the component's props, the parent route, or `RoomCharactersList`.
 
-- [ ] Task 3: Tests for `QuickEditSheet` reduced motion (AC: 2, 3, 4)
-  - [ ] In `frontend/components/munchkin/QuickEditSheet.test.tsx`, add an `AccessibilityInfo` mock following the `RoomCharacterCard.test.tsx` pattern (`isReduceMotionEnabled` default `false`; `addEventListener` returning a `{ remove }` subscription). The existing `react-native` mock spreads `actual`, so `AccessibilityInfo` is available — extend the mock object, do not replace `actual`.
-  - [ ] Add a test: with reduced motion **enabled**, opening the sheet leaves `translateY` at `0` and backdrop opacity at `1` immediately (no pending animation), and closing leaves `translateY` at `dismissOffset` immediately, with `Animated.timing`/`Animated.parallel` NOT called for the transition.
-  - [ ] Add a test: with reduced motion **disabled** (default), existing animated behaviour and all current assertions still hold (regression guard).
-  - [ ] Add a test: `onClose` / `onOpenFullEdit` sequencing still fires correctly in reduced-motion mode (sheet "dismisses" before `onOpenFullEdit` is called).
+- [x] Task 3: Tests for `QuickEditSheet` reduced motion (AC: 2, 3, 4)
+  - [x] In `frontend/components/munchkin/QuickEditSheet.test.tsx`, add an `AccessibilityInfo` mock following the `RoomCharacterCard.test.tsx` pattern (`isReduceMotionEnabled` default `false`; `addEventListener` returning a `{ remove }` subscription). The existing `react-native` mock spreads `actual`, so `AccessibilityInfo` is available — extend the mock object, do not replace `actual`.
+  - [x] Add a test: with reduced motion **enabled**, opening the sheet leaves `translateY` at `0` and backdrop opacity at `1` immediately (no pending animation), and closing leaves `translateY` at `dismissOffset` immediately, with `Animated.timing`/`Animated.parallel` NOT called for the transition.
+  - [x] Add a test: with reduced motion **disabled** (default), existing animated behaviour and all current assertions still hold (regression guard).
+  - [x] Add a test: `onClose` / `onOpenFullEdit` sequencing still fires correctly in reduced-motion mode (sheet "dismisses" before `onOpenFullEdit` is called).
 
-- [ ] Task 4: Frontend validation (AC: 1, 2, 3, 4)
-  - [ ] `cd frontend && npm run test:unit -- QuickEditSheet.test.tsx RoomCharacterCard.test.tsx`
-  - [ ] `cd frontend && npm run lint`
-  - [ ] `cd frontend && npm run tsc`
-  - [ ] `cd frontend && npm test` (full suite: unit + room-route) to confirm no regressions
+- [x] Task 4: Frontend validation (AC: 1, 2, 3, 4)
+  - [x] `cd frontend && npm run test:unit -- QuickEditSheet.test.tsx RoomCharacterCard.test.tsx`
+  - [x] `cd frontend && npm run lint`
+  - [x] `cd frontend && npm run tsc`
+  - [x] `cd frontend && npm test` (full suite: unit + room-route) to confirm no regressions
+
+### Review Findings
+
+- [x] [Review][Patch] Add reduced-motion coverage for pan-responder settle paths [frontend/components/munchkin/QuickEditSheet.test.tsx:81]
 
 ## Dev Notes
 
@@ -160,10 +164,34 @@ _bmad-output/implementation-artifacts/sprint-status.yaml             status tran
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+GPT-5 Codex
 
 ### Debug Log References
 
+- 2026-05-17: Started Story 4.6 implementation; sprint status moved to in-progress.
+- 2026-05-17: Verified `RoomCharacterCard.tsx` already contains the shipped reduced-motion realtime flash path and added runtime preference-change coverage.
+- 2026-05-17: Added `AccessibilityInfo` reduced-motion handling to `QuickEditSheet.tsx`; reduced mode snaps target values and default/unknown mode preserves animated timings.
+- 2026-05-17: Validation passed: `npm run test:unit -- QuickEditSheet.test.tsx RoomCharacterCard.test.tsx`, `npm run lint`, `npm run tsc`, and `npm test`.
+- 2026-05-17: Code review found one patch item; added reduced-motion pan-responder snap-back and dismiss coverage, then reran validation successfully.
+
 ### Completion Notes List
 
+- Confirmed the realtime card flash implementation already satisfies AC1 and AC3, then added an AC4 regression test for `reduceMotionChanged` switching after mount.
+- Implemented reduced-motion support in `QuickEditSheet` using the same `AccessibilityInfo.isReduceMotionEnabled()` plus `reduceMotionChanged` subscription pattern as `RoomCharacterCard`.
+- Preserved the existing open/close/full-edit/pan-responder state machine while skipping only the `Animated.parallel`/`Animated.timing` tween when reduced motion is enabled.
+- Added QuickEditSheet tests for reduced-motion snap open/close, default animated timings, and reduced-motion full-edit sequencing.
+- Resolved review finding by covering reduced-motion pan-responder snap-back and drag-dismiss behavior without animation.
+- `npm run lint` passes with one unrelated existing warning in `frontend/app/munchkin/modal-change-caracter.tsx` about `initialCharacter` in a `useEffect` dependency array.
+
 ### File List
+
+- `frontend/components/munchkin/QuickEditSheet.tsx`
+- `frontend/components/munchkin/QuickEditSheet.test.tsx`
+- `frontend/components/munchkin/RoomCharacterCard.test.tsx`
+- `_bmad-output/implementation-artifacts/4-6-reduced-motion-support.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+
+### Change Log
+
+- 2026-05-17: Implemented reduced-motion support for QuickEditSheet and added runtime preference-change regression coverage for realtime card flash.
+- 2026-05-17: Addressed code review finding by adding reduced-motion pan-responder settle-path tests.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-17T13:30:00Z
+last_updated: 2026-05-17T17:28:28+03:00
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -75,7 +75,7 @@ development_status:
   4-3-reconnection-session-restore: done
   4-4-reconnecting-banner: done
   4-5-late-join-context-awareness: ready-for-dev
-  4-6-reduced-motion-support: ready-for-dev
+  4-6-reduced-motion-support: done
   epic-4-retrospective: optional
 
   epic-5: in-progress

--- a/frontend/components/munchkin/QuickEditSheet.test.tsx
+++ b/frontend/components/munchkin/QuickEditSheet.test.tsx
@@ -1,8 +1,8 @@
 import { Character } from '@/api/characters';
 import React from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { Dimensions, TouchableOpacity } from 'react-native';
-import { describe, expect, it, vi } from 'vitest';
+import { AccessibilityInfo, Dimensions, TouchableOpacity } from 'react-native';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuickEditSheet from './QuickEditSheet';
 
@@ -23,6 +23,33 @@ const mockAnimatedParallel = vi.hoisted(() =>
     },
   }))
 );
+const mockReduceMotionSubscriptionRemove = vi.hoisted(() => vi.fn());
+const mockReduceMotionSubscription = vi.hoisted(
+  () => ({ remove: mockReduceMotionSubscriptionRemove }) as unknown as ReturnType<typeof AccessibilityInfo.addEventListener>
+);
+const mockPanResponderCreate = vi.hoisted(() =>
+  vi.fn(
+    (config: {
+      onStartShouldSetPanResponder?: (...args: unknown[]) => unknown;
+      onStartShouldSetPanResponderCapture?: (...args: unknown[]) => unknown;
+      onMoveShouldSetPanResponder?: (...args: unknown[]) => unknown;
+      onMoveShouldSetPanResponderCapture?: (...args: unknown[]) => unknown;
+      onPanResponderMove?: (...args: unknown[]) => unknown;
+      onPanResponderRelease?: (...args: unknown[]) => unknown;
+      onPanResponderTerminate?: (...args: unknown[]) => unknown;
+    }) => ({
+      panHandlers: {
+        onStartShouldSetResponder: config.onStartShouldSetPanResponder,
+        onStartShouldSetResponderCapture: config.onStartShouldSetPanResponderCapture,
+        onMoveShouldSetResponder: config.onMoveShouldSetPanResponder,
+        onMoveShouldSetResponderCapture: config.onMoveShouldSetPanResponderCapture,
+        onResponderMove: config.onPanResponderMove,
+        onResponderRelease: config.onPanResponderRelease,
+        onResponderTerminate: config.onPanResponderTerminate,
+      },
+    })
+  )
+);
 
 vi.mock('expo-haptics', () => ({
   ImpactFeedbackStyle: {
@@ -40,6 +67,15 @@ vi.mock('react-native', async () => {
       ...actual.Animated,
       parallel: mockAnimatedParallel,
       timing: mockAnimatedTiming,
+    },
+    AccessibilityInfo: {
+      ...actual.AccessibilityInfo,
+      isReduceMotionEnabled: vi.fn().mockResolvedValue(false),
+      addEventListener: vi.fn(() => mockReduceMotionSubscription),
+    },
+    PanResponder: {
+      ...actual.PanResponder,
+      create: mockPanResponderCreate,
     },
     Modal: ({ children }: { children?: React.ReactNode }) => children,
   };
@@ -59,6 +95,17 @@ const baseCharacter: Character = {
 };
 
 describe('QuickEditSheet', () => {
+  beforeEach(() => {
+    mockImpactAsync.mockClear();
+    mockAnimatedTiming.mockClear();
+    mockAnimatedParallel.mockClear();
+    mockPanResponderCreate.mockClear();
+    mockReduceMotionSubscriptionRemove.mockClear();
+    vi.mocked(AccessibilityInfo.addEventListener).mockClear();
+    vi.mocked(AccessibilityInfo.isReduceMotionEnabled).mockResolvedValue(false);
+    vi.mocked(AccessibilityInfo.addEventListener).mockReturnValue(mockReduceMotionSubscription);
+  });
+
   it('exposes the top drag affordance as the movable gesture target', async () => {
     let renderer: any;
     await act(async () => {
@@ -212,6 +259,226 @@ describe('QuickEditSheet', () => {
     });
 
     expect(onOpenFullEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('snaps open and closed without animation when reduced motion is enabled', async () => {
+    vi.mocked(AccessibilityInfo.isReduceMotionEnabled).mockResolvedValue(true);
+    const dismissOffset = Dimensions.get('window').height;
+
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible={false}
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    mockAnimatedTiming.mockClear();
+    mockAnimatedParallel.mockClear();
+
+    await act(async () => {
+      renderer!.update(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const sheetOpen = renderer!.root.findByProps({ testID: 'quick-edit-sheet' });
+    const translateYOpen = sheetOpen.props.style[2].transform[0].translateY;
+    const overlayBackdropOpen = renderer!.root.findByProps({ testID: 'quick-edit-overlay-backdrop' });
+
+    expect(translateYOpen.__getValue()).toBe(0);
+    expect(overlayBackdropOpen.props.style[1].opacity).toBe(1);
+    expect(mockAnimatedTiming).not.toHaveBeenCalled();
+    expect(mockAnimatedParallel).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer!.update(
+        <QuickEditSheet
+          visible={false}
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const sheetClosed = renderer!.root.findByProps({ testID: 'quick-edit-sheet' });
+    const translateYClosed = sheetClosed.props.style[2].transform[0].translateY;
+
+    expect(translateYClosed.__getValue()).toBe(dismissOffset);
+    expect(mockAnimatedTiming).not.toHaveBeenCalled();
+    expect(mockAnimatedParallel).not.toHaveBeenCalled();
+  });
+
+  it('keeps the default animated transition path when reduced motion is disabled', async () => {
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible={false}
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    mockAnimatedTiming.mockClear();
+    mockAnimatedParallel.mockClear();
+
+    await act(async () => {
+      renderer!.update(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    expect(mockAnimatedParallel).toHaveBeenCalledTimes(1);
+    expect(mockAnimatedTiming).toHaveBeenCalledTimes(2);
+    expect(mockAnimatedTiming).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({ toValue: 0, duration: 180, useNativeDriver: true })
+    );
+    expect(mockAnimatedTiming).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({ toValue: 1, duration: 120, useNativeDriver: true })
+    );
+  });
+
+  it('dismisses before opening full edit when reduced motion is enabled', async () => {
+    vi.mocked(AccessibilityInfo.isReduceMotionEnabled).mockResolvedValue(true);
+    const onOpenFullEdit = vi.fn();
+
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible={false}
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={onOpenFullEdit}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    await act(async () => {
+      renderer!.update(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={onOpenFullEdit}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    const buttons = renderer!.root.findAllByType(TouchableOpacity);
+    const editMoreButton = buttons[4];
+
+    await act(async () => {
+      editMoreButton.props.onPress();
+    });
+
+    const sheet = renderer!.root.findByProps({ testID: 'quick-edit-sheet' });
+    const translateY = sheet.props.style[2].transform[0].translateY;
+
+    expect(translateY.__getValue()).toBe(Dimensions.get('window').height);
+    expect(onOpenFullEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('snaps a reduced-motion drag release back open without animation', async () => {
+    vi.mocked(AccessibilityInfo.isReduceMotionEnabled).mockResolvedValue(true);
+
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={vi.fn()}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    mockAnimatedTiming.mockClear();
+    mockAnimatedParallel.mockClear();
+
+    const dragArea = renderer!.root.findByProps({ testID: 'quick-edit-drag-area' });
+    const sheet = renderer!.root.findByProps({ testID: 'quick-edit-sheet' });
+    const translateY = sheet.props.style[2].transform[0].translateY;
+
+    await act(async () => {
+      dragArea.props.onResponderMove({}, { dx: 0, dy: 80 });
+      dragArea.props.onResponderRelease({}, { dy: 80, vy: 0.2 });
+    });
+
+    expect(translateY.__getValue()).toBe(0);
+    expect(mockAnimatedTiming).not.toHaveBeenCalled();
+    expect(mockAnimatedParallel).not.toHaveBeenCalled();
+  });
+
+  it('keeps reduced-motion drag dismiss routed through close without animation', async () => {
+    vi.mocked(AccessibilityInfo.isReduceMotionEnabled).mockResolvedValue(true);
+    const onClose = vi.fn();
+
+    let renderer: any;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <QuickEditSheet
+          visible
+          character={baseCharacter}
+          onClose={onClose}
+          onSave={vi.fn(async () => undefined)}
+          onOpenFullEdit={vi.fn()}
+          hasErrorFlash={false}
+        />
+      );
+    });
+
+    mockAnimatedTiming.mockClear();
+    mockAnimatedParallel.mockClear();
+
+    const dragArea = renderer!.root.findByProps({ testID: 'quick-edit-drag-area' });
+
+    await act(async () => {
+      dragArea.props.onResponderRelease({}, { dy: 140, vy: 0.2 });
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockAnimatedTiming).not.toHaveBeenCalled();
+    expect(mockAnimatedParallel).not.toHaveBeenCalled();
   });
 
   it('renders a 60% bottom sheet, keeps larger centered actions, and applies floor zero on steppers', async () => {

--- a/frontend/components/munchkin/QuickEditSheet.tsx
+++ b/frontend/components/munchkin/QuickEditSheet.tsx
@@ -1,8 +1,19 @@
 import { Character as RoomCharacter } from '@/api/characters';
 import { AppTheme } from '@/constants/theme';
 import * as Haptics from 'expo-haptics';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Animated, Dimensions, Modal, PanResponder, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AccessibilityInfo,
+  Animated,
+  Dimensions,
+  Modal,
+  PanResponder,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 type QuickEditStats = {
   level: number;
@@ -34,6 +45,9 @@ export default function QuickEditSheet({
   const [isSaving, setIsSaving] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
   const [draftStats, setDraftStats] = useState<QuickEditStats>({ level: 0, power: 0 });
+  const [isReducedMotionEnabled, setIsReducedMotionEnabled] = useState<boolean | null>(null);
+  const hasHandledVisibilityRef = useRef(false);
+  const lastVisibleRef = useRef(visible);
   const translateY = useMemo(() => new Animated.Value(0), []);
   const backdropOpacity = useMemo(() => new Animated.Value(1), []);
   const dismissOffset = useMemo(() => Dimensions.get('window').height, []);
@@ -41,6 +55,25 @@ export default function QuickEditSheet({
     (dx: number, dy: number) => Math.abs(dy) > Math.abs(dx) && dy > 4,
     []
   );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    void AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
+      if (isMounted) {
+        setIsReducedMotionEnabled(enabled);
+      }
+    });
+
+    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', (enabled) => {
+      setIsReducedMotionEnabled(enabled);
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.remove();
+    };
+  }, []);
 
   useEffect(() => {
     const nextStats = {
@@ -59,6 +92,13 @@ export default function QuickEditSheet({
 
   const animateSheetTo = useCallback(
     (toValue: number, onFinished?: () => void) => {
+      if (isReducedMotionEnabled) {
+        translateY.setValue(toValue);
+        backdropOpacity.setValue(toValue === 0 ? 1 : 0);
+        onFinished?.();
+        return;
+      }
+
       Animated.parallel([
         Animated.timing(translateY, {
           toValue,
@@ -76,10 +116,17 @@ export default function QuickEditSheet({
         }
       });
     },
-    [backdropOpacity, translateY]
+    [backdropOpacity, isReducedMotionEnabled, translateY]
   );
 
   useEffect(() => {
+    if (hasHandledVisibilityRef.current && lastVisibleRef.current === visible) {
+      return;
+    }
+
+    hasHandledVisibilityRef.current = true;
+    lastVisibleRef.current = visible;
+
     if (!visible) {
       if (!isRendered) {
         setIsSaving(false);

--- a/frontend/components/munchkin/RoomCharacterCard.test.tsx
+++ b/frontend/components/munchkin/RoomCharacterCard.test.tsx
@@ -58,7 +58,11 @@ function getTextNode(renderer: any, text: string) {
 describe('RoomCharacterCard', () => {
   beforeEach(() => {
     vi.useRealTimers();
+    vi.mocked(AccessibilityInfo.addEventListener).mockClear();
     vi.mocked(AccessibilityInfo.isReduceMotionEnabled).mockResolvedValue(false);
+    vi.mocked(AccessibilityInfo.addEventListener).mockReturnValue(
+      { remove: vi.fn() } as unknown as ReturnType<typeof AccessibilityInfo.addEventListener>
+    );
   });
 
   it('supports full-card press with accessibility label and hint', () => {
@@ -240,6 +244,50 @@ describe('RoomCharacterCard', () => {
     await act(async () => {
       resolveReducedMotion(true);
       await Promise.resolve();
+    });
+
+    expect(timingSpy).not.toHaveBeenCalled();
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 700);
+
+    timingSpy.mockRestore();
+  });
+
+  it('honors reduced-motion preference changes after mount for realtime signals', async () => {
+    vi.useFakeTimers();
+    vi.mocked(AccessibilityInfo.isReduceMotionEnabled).mockResolvedValue(false);
+    const timingSpy = vi.spyOn(Animated, 'timing');
+    const timeoutSpy = vi.spyOn(global, 'setTimeout');
+    let renderer: any;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <RoomCharacterCard character={baseCharacter} onChangePress={vi.fn()} realtimeFlashSignal={0} />
+      );
+    });
+
+    await act(async () => {
+      renderer.update(
+        <RoomCharacterCard character={baseCharacter} onChangePress={vi.fn()} realtimeFlashSignal={1} />
+      );
+    });
+
+    expect(timingSpy).toHaveBeenCalled();
+    expect(timeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 700);
+
+    timingSpy.mockClear();
+    timeoutSpy.mockClear();
+
+    await act(async () => {
+      const reduceMotionListener = vi.mocked(AccessibilityInfo.addEventListener).mock.calls[0][1] as unknown as (
+        enabled: boolean
+      ) => void;
+      reduceMotionListener(true);
+    });
+
+    await act(async () => {
+      renderer.update(
+        <RoomCharacterCard character={baseCharacter} onChangePress={vi.fn()} realtimeFlashSignal={2} />
+      );
     });
 
     expect(timingSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Add reduced-motion support to `QuickEditSheet` using the existing `AccessibilityInfo` pattern from `RoomCharacterCard`.
- Preserve default animated behavior while snapping sheet transitions when reduced motion is enabled.
- Add regression coverage for runtime reduced-motion changes, sheet transitions, and pan-responder settle paths.
- Mark Story 4.6 complete in BMad artifacts and sync sprint status.

## Validation

- `npm run test:unit -- QuickEditSheet.test.tsx RoomCharacterCard.test.tsx`
- `npm run lint` (passes with one unrelated existing warning in `frontend/app/munchkin/modal-change-caracter.tsx`)
- `npm run tsc`
- `npm test`
