### PR TITLE
docs: add ready-for-dev story 6.1 (Character Events Are Published for Room History)

### DIFF
--- a/_bmad-output/implementation-artifacts/6-1-character-events-are-published-for-room-history.md
+++ b/_bmad-output/implementation-artifacts/6-1-character-events-are-published-for-room-history.md
@@ -1,0 +1,158 @@
+# Story 6.1: Character Events Are Published for Room History
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a player,
+I want character creation, update, and removal events to appear in room history,
+so that the group can understand how the session state changed over time.
+
+## Acceptance Criteria
+
+1. **Given** a character is created, updated, or deleted, **when** `character-service` processes the event, **then** it publishes that event to **both** the notifications topic/channel **and** the log topic/channel using `Promise.allSettled` (parallel, not sequential).
+2. **Given** `LOG_TOPIC_ARN` (Lambda) or the log Redis channel (local) is **not configured**, **when** `character-service` starts, **then** it emits a single startup warning and continues running in degraded mode (notifications publish still works; the service does **not** crash and requests are unaffected).
+3. **Given** any character event is published, **when** the payload is constructed, **then** it carries enough display context for `log-service` to render a room-history summary **without any outbound HTTP call** — for create/delete: character `id`, `name`, `avatarId`, `color`; for update: the same identity fields **plus** a per-field `prev → next` map of exactly the fields that changed.
+4. **Given** publishing to one topic/channel fails (throws or rejects), **when** the fan-out runs, **then** the other topic/channel publish attempt still completes, and the request flow is never broken by a publish failure (publish errors are logged, never propagated to the HTTP response).
+5. **Given** the notifications consumer (`room-notifications-service`), **when** the enriched payload is delivered, **then** existing realtime character fan-out behavior is unchanged (no regression to Epic 3/4 realtime features) — the legacy payload fields `event`, `roomId`, `event_body.characterId`, `emittedAt`, `correlationId` keep their exact names and shapes.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1 — Enrich the character event payload contract (AC: 3, 5)**
+  - [ ] In `backend/character-service/src/publisher.ts`, extend `CharacterEventPayload` with an **additive** display-context section. Do NOT rename or remove existing fields (`event`, `roomId`, `event_body.characterId`, `emittedAt`, `correlationId`) — `room-notifications-service` depends on them.
+  - [ ] Add `character: { id: string; name: string; avatarId: number; color: string }`.
+  - [ ] Add optional `changes?: Record<string, { prev: unknown; next: unknown }>` — present **only** for `character_updated`, containing exactly the fields whose value changed.
+  - [ ] Add canonical mirror fields to forward-align with the architecture event contract (these are duplicates of existing data, additive only): `eventType` (= `event`), `actorId` (= `character.id`), `occurredAt` (= `emittedAt`).
+  - [ ] Update `createCharacterEventPayload(...)` to accept the full character snapshot and an optional `changes` map and build the enriched payload. Keep `emittedAt`/`occurredAt` deterministic via `new Date().toISOString()` (existing pattern; fake-timer testable).
+- [ ] **Task 2 — Dual-target fan-out publisher (AC: 1, 4)**
+  - [ ] Introduce a composite/fan-out publisher in `publisher.ts` that wraps an ordered list of leg publishers (notifications leg + log leg) and publishes via `await Promise.allSettled(legs.map(p => p.publish(payload)))`. Each rejected leg is logged with the failing target; no rejection is rethrown.
+  - [ ] Reuse the existing `SnsCharacterEventPublisher` / `RedisCharacterEventPublisher` / `NoopCharacterEventPublisher` classes as legs — do NOT duplicate SNS/Redis client logic.
+  - [ ] The `CharacterEventPublisher` interface (`publish(payload): Promise<void>`) is unchanged; the composite implements the same interface so `app.ts` / `service.ts` wiring stays as-is.
+- [ ] **Task 3 — Capture prev→next for updates (AC: 3)**
+  - [ ] In `backend/character-service/src/app.ts` PATCH handler, obtain the pre-update character so changed-field `prev` values are available. Add `findById(id): Promise<CharacterLike | null>` to `CharacterModelLike` and implement it in `createCharacterModel()` (`backend/character-service/src/service.ts`) mirroring the existing method style (logging + field mapping). Read the character before calling `findByIdAndUpdate`.
+  - [ ] Compute `changes` as only the keys present in the validated `updates` object whose normalized value differs from the pre-update value. Do not include unchanged fields. Do not emit `changes` for create/delete.
+  - [ ] Concurrency note: read-before-update is last-write-wins (consistent with the system's existing concurrency posture); acceptable for display context — do not add locking.
+  - [ ] Pass the post-update character snapshot + `changes` into `createCharacterEventPayload` for `character_updated`; pass the created/deleted character snapshot for `character_created` / `character_deleted`.
+- [ ] **Task 4 — Lambda wiring: notifications + log SNS legs with degraded mode (AC: 1, 2, 4)**
+  - [ ] In `backend/character-service/src/lambda.ts`, build the notifications leg from the existing `ROOM_CHARACTER_EVENTS_TOPIC_ARN` env var (unchanged — see Project Structure Notes) and a new log leg from `LOG_TOPIC_ARN`.
+  - [ ] If `LOG_TOPIC_ARN` is absent/empty: `console.warn` once at bootstrap (degraded — log history will be absent) and use `NoopCharacterEventPublisher` for the log leg. Service must NOT throw or `process.exit`.
+  - [ ] Compose both legs into the fan-out publisher and pass it to `buildCharacterApp`. Keep the existing bootstrap-config `console.info` and add `logTopicArnConfigured: Boolean(process.env.LOG_TOPIC_ARN)`.
+- [ ] **Task 5 — Local server wiring: notifications + log Redis legs with degraded mode (AC: 1, 2, 4)**
+  - [ ] In `backend/character-service/src/index.ts`, keep the existing notifications Redis leg (`CHARACTER_EVENTS_REDIS_URL` + `ROOM_CHARACTER_EVENTS_CHANNEL`, default `room-character-events`). Add a log Redis leg on a new channel env `ROOM_LOG_EVENTS_CHANNEL` (default `room-log-events`) using the same `CHARACTER_EVENTS_REDIS_URL`.
+  - [ ] If `CHARACTER_EVENTS_REDIS_URL` is unset (already the Noop path) OR the log channel cannot be configured, `console.warn` once and use `NoopCharacterEventPublisher` for the log leg. Do not crash.
+  - [ ] Compose both legs into the fan-out publisher; extend the existing bootstrap `console.info` with `logEventsChannel` + `logConfigured`.
+- [ ] **Task 6 — Tests (AC: 1, 2, 3, 4, 5)**
+  - [ ] `publisher.test.ts`: fan-out calls every leg; uses `Promise.allSettled` (assert both legs invoked even when one rejects); a rejecting leg does not cause the composite `publish` to reject; `createCharacterEventPayload` produces the enriched superset incl. `changes` for updates and omits `changes` for create/delete; legacy fields preserved exactly (regression guard for AC 5).
+  - [ ] `lambda.test.ts`: both env vars set → composite with two SNS legs; `LOG_TOPIC_ARN` absent → startup `console.warn` + notifications leg still active + handler still boots and responds (no throw); follow existing `vi.hoisted` mock + `delete process.env.*` reset pattern, and add `delete process.env.LOG_TOPIC_ARN` to `beforeEach`.
+  - [ ] `app.test.ts`: create/delete publish a payload containing `character` display context; update publishes `changes` with correct `prev → next` for changed fields only; a publisher that throws does NOT change the HTTP status (create still `201`, update `200`, delete `204`) — regression guard for AC 4. Inject a spy publisher via the existing `createApp(model, { publisher })` option.
+  - [ ] Add/extend a `findById` test in `service.test.ts` if the existing model-mapping tests assert method coverage there.
+  - [ ] Run backend test + coverage gate: `cd backend/character-service && npm test` (Vitest 3.2.4, v8 coverage, 70% line floor — do not lower).
+
+## Dev Notes
+
+### What this story is (and is not)
+
+- **Is:** the `character-service` *publisher extension* — make character lifecycle events go to a second (log) target with enough context for room-history summaries. This is step 4 of the architecture Implementation Sequence ([Source: architecture/core-architectural-decisions.md#Implementation Sequence]).
+- **Is not:** building `log-service`, the `LogEvent` model, the SNS subscriber, or the read API — those are Stories 6.2/6.4. This story must ship and run correctly **before `log-service` and the log topic exist**; that is exactly why AC 2 (degraded mode when `LOG_TOPIC_ARN` absent) exists ([Source: architecture/core-architectural-decisions.md#ADR-12]).
+
+### Current state of files being modified (read before editing)
+
+- `backend/character-service/src/publisher.ts` — defines `CharacterEventPayload` (`{ event, roomId, event_body:{characterId}, emittedAt, correlationId? }`), the `CharacterEventPublisher` interface, `Sns`/`Redis`/`Noop` publishers, and `createCharacterEventPayload`. Single-target today.
+- `backend/character-service/src/app.ts` — Express factory. `POST /characters`, `PATCH /characters/:characterId`, `DELETE /characters/:characterId` each call `publisher.publish(createCharacterEventPayload(...))` inside a local `try/catch` that logs and swallows publish errors (this swallow behavior is correct and must be preserved — it is the AC 4 guarantee at the call site). PATCH uses `findByIdAndUpdate(..., { new: true })` so only the post-update doc is available today — Task 3 adds the pre-update read.
+- `backend/character-service/src/service.ts` — `createCharacterModel()` maps Mongoose docs to `CharacterLike`. Add `findById` here mirroring existing method style.
+- `backend/character-service/src/lambda.ts` — picks `SnsCharacterEventPublisher` when `ROOM_CHARACTER_EVENTS_TOPIC_ARN` set, else `NoopCharacterEventPublisher`. Single target today.
+- `backend/character-service/src/index.ts` — picks `RedisCharacterEventPublisher` when `CHARACTER_EVENTS_REDIS_URL` set (channel `ROOM_CHARACTER_EVENTS_CHANNEL`, default `room-character-events`), else Noop. Single target today.
+- **Must be preserved (regression surface):** `room-notifications-service` consumes the notifications payload. Its parser `parseNotificationEvent` ([backend/room-notifications-service/src/app.ts](backend/room-notifications-service/src/app.ts)) reads **only** `event`, `roomId`, `event_body.characterId`, `emittedAt`, `correlationId` and **ignores unknown fields** — confirmed safe for additive enrichment. Its type `RoomCharacterNotificationEvent` ([backend/room-notifications-service/src/types.ts](backend/room-notifications-service/src/types.ts)) defines the legacy shape. **Do not change `room-notifications-service`** in this story and do not rename any legacy field.
+
+### Key design decision — payload shape (recommended approach)
+
+The architecture's canonical event contract uses `eventType`/`actorId`/`occurredAt` ([Source: architecture/implementation-patterns-consistency-rules.md#Event Payload Contract]), but the live notifications path uses legacy `event`/`event_body`/`emittedAt`, and the architecture explicitly scopes this story as **"additive to existing notifications publish"** ([Source: architecture/core-architectural-decisions.md#IAM Policy Additions]).
+
+**Recommended: a single additive *superset* payload** — preserve every legacy field unchanged, and add display-context + canonical mirror fields. One payload builder, both legs send the same payload, **no consumer rewrite**, forward-aligned with the architecture contract, zero notifications regression risk. This is the clean *and* low-blast-radius choice; prefer it.
+
+Rejected alternative: migrate the notifications payload to the canonical `eventType`/`actorId`/`occurredAt` contract and rewrite `room-notifications-service` + its types + tests as a coordinated breaking change. Cleaner on paper but a large blast radius into Epic 3/4 realtime features for no AC benefit, and the architecture explicitly says "additive." Do not do this here.
+
+Recommended payload (superset):
+
+```ts
+interface CharacterEventPayload {
+  // legacy notifications contract — names/shapes are FROZEN (room-notifications-service depends on these)
+  event: 'character_created' | 'character_updated' | 'character_deleted';
+  roomId: string;
+  event_body: { characterId: string };
+  emittedAt: string;            // ISO-8601
+  correlationId?: string;
+  // canonical mirrors (additive; forward-align with architecture BaseEvent)
+  eventType: string;            // === event
+  actorId: string;              // === character.id
+  occurredAt: string;           // === emittedAt
+  // display context for log-service summary rendering (NO outbound HTTP needed)
+  character: { id: string; name: string; avatarId: number; color: string };
+  changes?: Record<string, { prev: unknown; next: unknown }>; // character_updated only
+}
+```
+
+`character.color` should be the resolved/display color. `app.ts` already has `getCharacterColor()` / `toResponseCharacter()` — reuse that resolution so the logged color matches what the UI shows; do not re-implement color logic.
+
+### Why display context must travel in the payload
+
+`log-service` (Story 6.2) writes a pre-rendered `summary` and the raw `payload`, and **must render the summary with no outbound HTTP calls** ([Source: architecture/core-architectural-decisions.md#ADR-11]). Story 6.6 requires the Room History view to show character avatar + name for create/delete and **every changed field as an individual `prev → new` row** for updates ([Source: epics/epic-6-room-history.md#Story 6.6]). Therefore the `character_updated` payload must carry the full per-field `prev/next` diff produced here — there is no other place it can come from later.
+
+### Dual-topic publishing rule (must follow exactly)
+
+Use `Promise.allSettled` over the legs. Never sequential `await publishA; await publishB` — sequential means a topic-1 failure blocks topic-2 ([Source: architecture/implementation-patterns-consistency-rules.md#Publisher Pattern — dual-topic fan-out], explicit anti-pattern). Notifications leg first, log leg second, but both must always be attempted.
+
+### Conventions to honor (from project-context.md & architecture)
+
+- Backend service is **non-strict TypeScript** and **NodeNext** modules — match existing import style (note existing tests `import('./lambda.js')`). Do not normalize to frontend strictness.
+- Event type strings stay `snake_case` (`character_created`/`character_updated`/`character_deleted`). Env vars `ALL_CAPS_SNAKE_CASE` (`LOG_TOPIC_ARN`, `ROOM_LOG_EVENTS_CHANNEL`).
+- Keep `character-service` self-contained — no cross-service coupling; do not import from `room-notifications-service`/`log-service`.
+- Co-locate tests as `<source>.test.ts`; backend tests run in Node env via Vitest 3.2.4, v8 coverage, **70% line floor is a CI hard gate** — do not lower it; coverage is a floor, assert real behavior (fan-out, degraded mode, diff correctness, error-swallow).
+- Preserve the existing publish-error swallow in `app.ts` route handlers (logs + continues) — this is the request-flow guarantee for AC 4; do not let publish failures reach the HTTP response.
+- Update the nearest docs if you add env vars: `backend/docker-compose.local.yml` (add `ROOM_LOG_EVENTS_CHANNEL` to the `character-service` service env so local fan-out has a second channel), and any character-service README/env reference if present. Do not hardcode endpoints/ARNs.
+
+### Testing standards summary
+
+- Mock external boundaries (SNS client, Redis `createClient`) — do not mock the unit under test. Reuse the existing `vi.hoisted` Redis mock pattern in `publisher.test.ts` and the `vi.mock`/`delete process.env.*` pattern in `lambda.test.ts`.
+- Provide one success-path and one failure-path test per new behavior (fan-out success; one-leg-rejects; missing `LOG_TOPIC_ARN` degraded boot).
+- Keep tests deterministic — control `Date` via fake timers (existing pattern) for `emittedAt`/`occurredAt`; no real network/timing.
+- Failure-path AC 4 test: publisher throws → HTTP status unchanged (`201`/`200`/`204`).
+
+### Project Structure Notes
+
+- **Env var naming (`ROOM_CHARACTER_EVENTS_TOPIC_ARN` vs architecture's `NOTIFICATIONS_TOPIC_ARN`):** the architecture/implementation-patterns docs use the name `NOTIFICATIONS_TOPIC_ARN`, but the live SAM stack + `lambda.ts` + `lambda.test.ts` use `ROOM_CHARACTER_EVENTS_TOPIC_ARN` ([backend/sam/template.yaml](backend/sam/template.yaml) `RoomCharacterEventsTopic`, env at line ~278; IAM `sns:Publish` at line ~110). A rename is a breaking, deploy-time config change touching the SAM stack and is **out of scope** here (project-context: no breaking env/config renames without coordinated atomic updates; this story is explicitly "additive"). **Decision: keep `ROOM_CHARACTER_EVENTS_TOPIC_ARN` for the notifications leg; introduce `LOG_TOPIC_ARN` for the new log leg.** This is a documented, intentional variance from the doc's naming — do not "fix" it silently.
+- **SAM/IAM infra wiring is a cross-story dependency, not this story's blocker:** the log SNS topic is **owned by `log-service`**, which does not exist yet (Story 6.2) ([Source: architecture/core-architectural-decisions.md#ADR-6, #SNS Topic Architecture]). The in-scope deliverable here is the **code path** that publishes to `LOG_TOPIC_ARN` when present and degrades gracefully when absent (AC 2). Adding the `LOG_TOPIC_ARN` env var + `sns:Publish` IAM to `backend/sam/template.yaml` should be done when the `LogTopic` resource exists (Story 6.2) to avoid a dangling `!Ref`; if you choose to pre-wire it, use a SAM parameter defaulting to empty and conditional IAM so `sam` still deploys with no log topic. Either way, the running service must satisfy AC 2 with no `LOG_TOPIC_ARN` set. Note this clearly in Completion Notes.
+- File locations follow the mandated backend structure ([Source: architecture/implementation-patterns-consistency-rules.md#Backend Service File Structure]); all changes stay within `backend/character-service/src/**` plus the local `docker-compose.local.yml` env addition. No new top-level files needed — extend `publisher.ts` rather than adding a new module.
+
+### Cross-story context
+
+- This is the first story of Epic 6 (no prior Epic 6 story to inherit learnings from). Epic 5 (battle-service) is `ready-for-dev`, not done — **do not assume `battle-service` exists or import from it.** Story 6.3 applies this same dual-publish pattern to `battle-service`; keep the fan-out/payload approach here clean and self-contained so 6.3 can mirror it.
+- Story 6.2 (`logWriter`) is the consumer of what you emit here; it handles `character_created`/`character_updated`/`character_deleted` (plus battle events). The field names you choose in the payload are the contract 6.2 will read — the superset above is designed so 6.2 can read either canonical (`eventType`/`actorId`/`occurredAt`) or legacy names.
+
+### References
+
+- [Source: epics/epic-6-room-history.md#Story 6.1] — story + acceptance criteria
+- [Source: epics/epic-6-room-history.md#Story 6.2] — downstream `logWriter` consumer / supported event types
+- [Source: epics/epic-6-room-history.md#Story 6.6] — Room History view requires avatar/name + per-field `prev → new` rows (drives the `changes` map)
+- [Source: architecture/core-architectural-decisions.md#SNS Topic Architecture (Consumer-Owned)] — consumer-owned topics; character-service publishes to both
+- [Source: architecture/core-architectural-decisions.md#ADR-6, #ADR-11, #ADR-12] — topic ownership; payload-carries-context (no HTTP); `LOG_TOPIC_ARN` required-but-degraded
+- [Source: architecture/core-architectural-decisions.md#Implementation Sequence] — step 4: character-service publisher extension
+- [Source: architecture/core-architectural-decisions.md#IAM Policy Additions] — "additive to existing notifications publish"
+- [Source: architecture/implementation-patterns-consistency-rules.md#Publisher Pattern — dual-topic fan-out] — `Promise.allSettled`; sequential-publish anti-pattern
+- [Source: architecture/implementation-patterns-consistency-rules.md#Event Payload Contract] — canonical `eventType`/`roomId`/`actorId`/`occurredAt` + display context
+- [Source: _bmad-output/project-context.md] — backend non-strict TS/NodeNext, service-boundary isolation, event-contract guardrails, 70% coverage floor, docs-in-same-change
+- [backend/character-service/src/publisher.ts](backend/character-service/src/publisher.ts), [app.ts](backend/character-service/src/app.ts), [service.ts](backend/character-service/src/service.ts), [lambda.ts](backend/character-service/src/lambda.ts), [index.ts](backend/character-service/src/index.ts) — modification targets
+- [backend/room-notifications-service/src/app.ts](backend/room-notifications-service/src/app.ts), [types.ts](backend/room-notifications-service/src/types.ts) — notifications consumer (regression surface; do not modify)
+- [backend/sam/template.yaml](backend/sam/template.yaml), [backend/docker-compose.local.yml](backend/docker-compose.local.yml) — infra/env wiring references
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-17T18:08:00+03:00
+last_updated: 2026-05-17T23:55:00+03:00
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -88,8 +88,8 @@ development_status:
   5-7-discard-a-battle: ready-for-dev
   epic-5-retrospective: optional
 
-  epic-6: backlog
-  6-1-character-events-are-published-for-room-history: backlog
+  epic-6: in-progress
+  6-1-character-events-are-published-for-room-history: ready-for-dev
   6-2-published-events-are-stored-and-readable-in-room-history: backlog
   6-3-battle-lifecycle-events-are-published-for-room-history: backlog
   6-4-room-history-api-returns-paginated-events: backlog


### PR DESCRIPTION
## Summary

- Adds the Epic 6 opener story spec `6-1-character-events-are-published-for-room-history.md` (status: `ready-for-dev`).
- Marks `epic-6` `in-progress` and the story `ready-for-dev` in `sprint-status.yaml` (first story of the epic).

## What the story specifies

Extend `character-service` so character create/update/delete events fan out to **both** the notifications target and a new log target via `Promise.allSettled`, carrying enough display context for room-history summaries with **no outbound HTTP**.

Key design decisions resolved for the dev agent:

- **Additive superset payload** — legacy notifications fields (`event`/`event_body`/`emittedAt`/`correlationId`) are frozen so `room-notifications-service` (Epic 3/4 realtime) does not regress; canonical mirrors (`eventType`/`actorId`/`occurredAt`) + display context (`character`, per-field `changes` for updates) are added for `log-service`. Verified `parseNotificationEvent` ignores unknown fields. Rejected alternative (rewriting the notifications consumer) documented with rationale.
- **Degraded mode** — missing `LOG_TOPIC_ARN` (or local log Redis channel) emits a startup warning and continues; notifications still publish, service does not crash. This is what lets 6.1 ship before `log-service` exists.
- **prev→new for updates** — adds `findById` + pre-update read so `character_updated` carries the per-field diff Story 6.6 needs.
- **Scope boundaries flagged** — env-var naming variance (`ROOM_CHARACTER_EVENTS_TOPIC_ARN` vs doc's `NOTIFICATIONS_TOPIC_ARN`) and log-topic infra ownership (`log-service`, not yet built) called out so they aren't "fixed" silently.

## Reviewer notes

- Docs/spec only — no application code changes in this PR. The story file is the implementation contract for a later `dev-story` pass.
- `sprint-status.yaml` change is part of the create-story workflow (epic/story status transition + `last_updated`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)