### PR TITLE
feat: Story 5.5 realtime battle updates from character changes

### DIFF
--- a/_bmad-output/implementation-artifacts/5-5-realtime-battle-updates-from-character-changes.md
+++ b/_bmad-output/implementation-artifacts/5-5-realtime-battle-updates-from-character-changes.md
@@ -1,6 +1,6 @@
 # Story 5.5: Realtime Battle Updates from Character Changes
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -189,8 +189,8 @@ build here):**
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Pure reconciliation helper** (AC: 1, 2, 3)
-  - [ ] Add `frontend/utils/battlePlayerSide.ts` (match 5.3's util dir; if 5.3
+- [x] **Task 1 — Pure reconciliation helper** (AC: 1, 2, 3)
+  - [x] Add `frontend/utils/battlePlayerSide.ts` (match 5.3's util dir; if 5.3
     created `frontend/utils/uuid.ts`, colocate here). Export:
     - `reconcilePlayerParticipants(characterIds: string[], roomCharacters:
       Character[]): { active: { id: string; character: Character }[]; removed:
@@ -205,18 +205,18 @@ build here):**
       5.3's player effective-strength formula exactly (read 5.3's implemented
       total; this helper replaces/centralises that computation — do not invent a
       different formula).
-  - [ ] Import `Character` from `@/api/characters` and `BonusItem` from
+  - [x] Import `Character` from `@/api/characters` and `BonusItem` from
     `@/api/battles` (5.1 types) — do not redefine types.
-  - [ ] Co-located `frontend/utils/battlePlayerSide.test.ts`: all-resolved;
+  - [x] Co-located `frontend/utils/battlePlayerSide.test.ts`: all-resolved;
     some-removed (order preserved, removed ids collected); empty `characterIds`;
     duplicate id; total excludes removed and includes signed/negative bonuses.
 
-- [ ] **Task 2 — Battle View: live derived player side** (AC: 1, 2, 3, 4)
-  - [ ] In `(battle)/index.tsx`, reuse 5.3's existing `useRoomCharacters(roomId,
+- [x] **Task 2 — Battle View: live derived player side** (AC: 1, 2, 3, 4)
+  - [x] In `(battle)/index.tsx`, reuse 5.3's existing `useRoomCharacters(roomId,
     userProfile)` instance (5.3 Task 6 already adds `useUserProfile()` +
     `useRoomCharacters` here). Do **not** add a second `useRoomCharacters` and do
     **not** add `useRoomWebSocket`/WS code.
-  - [ ] Replace 5.3's mount-time player-side resolution with a `useMemo`
+  - [x] Replace 5.3's mount-time player-side resolution with a `useMemo`
     derivation: `reconcilePlayerParticipants(draft.playerSide.characterIds,
     roomCharacters)` recomputed whenever `draft.playerSide.characterIds` or
     `roomCharacters` change (so a `['characters', roomId]` invalidation →
@@ -224,24 +224,24 @@ build here):**
     active, draft.playerSide.bonuses)`. This is a **derived render value**, not
     state and not an effect — do not `setState`/`useEffect` from the room-character
     list (prevents AC3 spurious draft mutation / dirty flips).
-  - [ ] **Draft is not mutated by reconciliation.** Keep 5.3's draft init (from
+  - [x] **Draft is not mutated by reconciliation.** Keep 5.3's draft init (from
     `battle` on load) and dirty/Clean/Saving model exactly. A remote character
     change must not re-init the draft, not set dirty, not enable Save (AC3). The
     deleted id stays in `draft.playerSide.characterIds` (tombstone is
     display-only — Resolved decision #1).
-  - [ ] Pass `active` (resolved participants) and `removed` (tombstone ids) into
+  - [x] Pass `active` (resolved participants) and `removed` (tombstone ids) into
     the 5.3 player-side list/row component(s). The participant **add picker**
     (5.3) still lists room characters not already in `characterIds`; the per-row
     `−` remove (5.3) still mutates the **draft** as before (explicit user action →
     dirty → Save) — unchanged.
-  - [ ] AC4 is satisfied structurally: on Battle View (re)mount 5.3 re-inits the
+  - [x] AC4 is satisfied structurally: on Battle View (re)mount 5.3 re-inits the
     draft from the refetched `['battle', roomId]` and the join derives from the
     current shared `['characters', roomId]` cache (kept live by the Room View's
     mounted `useRoomCharacters` + 5.4 shared socket). No extra code needed —
     **do not** add a refetch/effect for "return to view"; assert it in tests.
 
-- [ ] **Task 3 — Player-side row: resolved / tombstone rendering** (AC: 1, 2)
-  - [ ] In 5.3's player-side row/list component(s) (exact filenames per 5.3's
+- [x] **Task 3 — Player-side row: resolved / tombstone rendering** (AC: 1, 2)
+  - [x] In 5.3's player-side row/list component(s) (exact filenames per 5.3's
     actual code under `frontend/components/munchkin/`): render
     - **resolved/active row:** live `character.nickname`/`level`/`avatar`/`color`
       from the matched room character (re-renders on `character_updated` because
@@ -259,21 +259,21 @@ build here):**
     - This **replaces** 5.3's neutral "Unavailable" row for unresolved ids — the
       tombstone is the single representation for "id in `characterIds` but not in
       live room characters".
-  - [ ] Styling strictly via `AppTheme` tokens (player side stays
+  - [x] Styling strictly via `AppTheme` tokens (player side stays
     `AppTheme.colors.accent` for active values per 5.3/UX-DR13; tombstone uses
     muted/subtle tokens). No hardcoded hex/px/font-size. Mirror 5.3's component
     conventions (PascalCase file, `memo`, explicit prop interface, default export,
     `StyleSheet.create` at bottom referencing `AppTheme`, `testID` +
     accessibility props).
 
-- [ ] **Task 4 — Tests** (AC: 1, 2, 3, 4)
-  - [ ] Helper unit test (Task 1) — pure, deterministic.
-  - [ ] Co-located component test(s) for the player-side row/list: renders an
+- [x] **Task 4 — Tests** (AC: 1, 2, 3, 4)
+  - [x] Helper unit test (Task 1) — pure, deterministic.
+  - [x] Co-located component test(s) for the player-side row/list: renders an
     active row from a resolved character; renders a struck-through tombstone for a
     removed id; tombstone is excluded from the displayed total; updating the
     matched character's level changes the active row + total; a non-participant
     character in the list does not add a row (AC3).
-  - [ ] Extend 5.3's Battle View route test under
+  - [x] Extend 5.3's Battle View route test under
     `frontend/__tests__/app/munchkin/[roomNumber]/(battle)/...` (NOT under
     `frontend/app` — Expo Router forbids non-route files there). Mock
     `@/hooks/useRoomBattle`, `@/hooks/useCharacters` (or `useRoomCharacters`),
@@ -291,7 +291,7 @@ build here):**
     - **AC4:** simulate remount (changed characters since mount) → rows/total
       reflect the latest mocked character state, no duplicate rows, no stale
       values; no auto-navigation.
-  - [ ] Meet the **70% line coverage floor** for the frontend pipeline. Note:
+  - [x] Meet the **70% line coverage floor** for the frontend pipeline. Note:
     `frontend/vitest.config.ts` coverage `include` is `api/**`,`config/**`,
     `hooks/**` only — 5.5 adds **no** hook/api code (Battle-View + component +
     `utils/` only), so it does not move the coverage gate (same situation as 5.2).
@@ -299,12 +299,12 @@ build here):**
     is a floor not the goal). **Do not widen** the coverage `include` scope to
     pad `utils/`.
 
-- [ ] **Task 5 — Frontend cross-surface verification** (AC: 1, 2, 3, 4)
-  - [ ] From `frontend/`: strict TS typecheck passes with the helper + Battle
+- [x] **Task 5 — Frontend cross-surface verification** (AC: 1, 2, 3, 4)
+  - [x] From `frontend/`: strict TS typecheck passes with the helper + Battle
     View/row changes; `vitest run --coverage` passes (≥70% line floor, **no
     regression** in existing `useCharacters`/`webSocket`/`useRoomWebSocket`/Battle
     View/Room View tests — 5.5 must not perturb the live character flow).
-  - [ ] Local manual smoke (`docker-compose up`, after 5.1–5.4 merged), two web
+  - [x] Local manual smoke (`docker-compose up`, after 5.1–5.4 merged), two web
     tabs, same room, two device identities:
     - Tab A starts a battle, opens Battle View, adds two room characters to the
       player side, Saves. Tab B opens the same Battle View.
@@ -321,7 +321,7 @@ build here):**
     - Return: Tab B leaves Battle View, Tab A makes more participant edits, Tab B
       reopens Battle View → state consistent with latest, no duplicates (AC4).
     - Verify web at minimum; note any platform (iOS/Android) not verified.
-  - [ ] No backend/infra/transport changes expected — if you edit `backend/**`,
+  - [x] No backend/infra/transport changes expected — if you edit `backend/**`,
     `frontend/api/webSocket.ts`, `frontend/hooks/useRoomWebSocket.ts`, or
     `frontend/hooks/useRoomBattle.ts`, you are out of scope (re-read ADR-9 +
     Scope Boundaries).
@@ -537,12 +537,39 @@ effect (see "AC3 anti-pattern guard").
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+GPT-5 Codex
 
 ### Debug Log References
+
+- `npm install` in `frontend/` to restore local dependencies for verification.
+- `npm run tsc` in `frontend/` passed.
+- `npx vitest run utils/battlePlayerSide.test.ts components/munchkin/BattleSidePanel.test.tsx` passed: 11 tests.
+- `npx vitest run -c vitest.room-route.config.ts __tests__/app/munchkin/[roomNumber]/(battle)/index.test.tsx` passed: 13 tests.
+- `npm run test:coverage` in `frontend/` passed: 156 unit/component/hook tests, 49 route tests, 84.31% line coverage.
+- `npm run lint` in `frontend/` passed with one existing warning in `frontend/app/munchkin/modal-change-caracter.tsx` about a missing `useEffect` dependency.
+- Local two-client manual smoke passed, confirmed by Ivan on 2026-05-20.
 
 ### Completion Notes List
 
 - Ultimate context engine analysis completed - comprehensive developer guide created.
+- Added a pure battle player-side reconciliation helper that preserves participant order, de-duplicates ids, separates active vs removed participants, and computes totals from active levels plus signed bonuses.
+- Battle View now derives player participants from the current `useRoomCharacters` result on every render without mutating the draft, auto-saving, patching, or touching realtime/backend surfaces.
+- Player-side rows now render active participants from live character data and removed participants as muted, struck-through tombstones excluded from totals while keeping explicit remove/save behavior available.
+- Added helper, component, and route tests covering participating updates, deleted tombstones, non-participant no-ops, remount consistency, total exclusion, and retained draft `characterIds`.
+- Manual two-client web smoke passed, confirming live participant updates, tombstone rendering, non-participant no-op behavior, and return-to-view consistency.
 
 ### File List
+
+- frontend/app/munchkin/[roomNumber]/(battle)/index.tsx
+- frontend/components/munchkin/BattleSidePanel.tsx
+- frontend/components/munchkin/BattleSidePanel.test.tsx
+- frontend/__tests__/app/munchkin/[roomNumber]/(battle)/index.test.tsx
+- frontend/utils/battlePlayerSide.ts
+- frontend/utils/battlePlayerSide.test.ts
+- _bmad-output/implementation-artifacts/5-5-realtime-battle-updates-from-character-changes.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+
+### Change Log
+
+- 2026-05-19: Implemented live Battle View player-side reconciliation from current room characters, removed tombstone rendering, and AC-focused frontend tests. Automated verification passed.
+- 2026-05-20: Recorded successful local manual smoke, checked the coverage-floor task, and moved story to review.

--- a/_bmad-output/implementation-artifacts/5-5-realtime-battle-updates-from-character-changes.md
+++ b/_bmad-output/implementation-artifacts/5-5-realtime-battle-updates-from-character-changes.md
@@ -1,6 +1,6 @@
 # Story 5.5: Realtime Battle Updates from Character Changes
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -573,3 +573,15 @@ GPT-5 Codex
 
 - 2026-05-19: Implemented live Battle View player-side reconciliation from current room characters, removed tombstone rendering, and AC-focused frontend tests. Automated verification passed.
 - 2026-05-20: Recorded successful local manual smoke, checked the coverage-floor task, and moved story to review.
+- 2026-05-20: Code review applied 6 patches — temp-id filter in BattleView, NaN-safe totals, unique tombstone testID, friendlier tombstone label and accessibility text, removed dead `||` fallback in `BattleSidePanel`. Verified with `npm run tsc`, full `npm run test:coverage` (207 tests pass, 84.31% line coverage), `npm run lint` (only the pre-existing `modal-change-caracter.tsx` warning).
+
+### Review Findings
+
+- [x] [Review][Patch] Filter `temp-*` ids out of the Battle View add picker — optimistic characters (`useCharacters.ts:156` mints `temp-${Date.now()}`) can otherwise be added to `draft.playerSide.characterIds` and, when the server confirms, get replaced by a real id (`useCharacters.ts:185`), flipping the just-added participant to a `Removed · temp-...` tombstone and persisting a dangling temp id on Save. Filter `temp-` ids out so they can never enter the draft. AC1/AC3 fix. Resolved: added `confirmedCharacters` memo in `(battle)/index.tsx` filtering `temp-` ids, passed to `BattleSidePanel.characters`; new route test asserts `select-character-temp-*` never renders.
+- [x] [Review][Patch] `computePlayerTotal` dropped numeric guards — NaN `level`/`value` propagates and silently inverts comparison ternary [frontend/utils/battlePlayerSide.ts:41-42]. Resolved: each reducer now passes through `Number.isFinite(...)` and contributes `0` otherwise; added a unit test that injects NaN and asserts the total stays finite.
+- [x] [Review][Patch] Tombstone row reuses `testID="remove-character-${id}"` of the active row [frontend/components/munchkin/BattleSidePanel.tsx:118 vs :134]. Resolved: tombstone's remove button now `testID={\`discard-removed-character-${id}\`}`; tests updated.
+- [x] [Review][Patch] Tombstone visible label leaked raw UUID [frontend/components/munchkin/BattleSidePanel.tsx:127-129]. Resolved: visible text is now `Removed character` (accessibility label retains the id for screen readers per spec).
+- [x] [Review][Patch] Tombstone remove button accessibilityLabel was nonsensical English [frontend/components/munchkin/BattleSidePanel.tsx:131]. Resolved: now `"Drop removed character from draft"`.
+- [x] [Review][Patch] Dead `||` fallback in `BattleSidePanel.selectedParticipants` [frontend/components/munchkin/BattleSidePanel.tsx:55-63]. Resolved: simplified to `activeParticipants ?? []`; sole caller already passes the prop, and the panel test was updated to provide it explicitly.
+- [x] [Review][Defer] Battle UI gating blanks the whole view on transient empty-room refetch or characters-query error — `useRoomCharacters.isLoading` (`hooks/useCharacters.ts:444-446` returns true while `isFetching && characters.length === 0`) combined with the render gate at `(battle)/index.tsx:152-158` hides battle + draft when all characters are momentarily absent or the characters refetch errors. Pre-existing 5.3 gating; deferred — out of scope for 5.5.
+- [x] [Review][Defer] Story status flip bundled in same commit as code — `_bmad-output/.../5-5-...md` Status moves to `review` and `sprint-status.yaml` is updated inside `a757881`. Common pattern in this repo; deferred as a process matter.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,3 +1,8 @@
+## Deferred from: code review of 5-5-realtime-battle-updates-from-character-changes (2026-05-20)
+
+- Battle UI gating blanks the whole view on transient empty-room refetch or characters-query error — `useRoomCharacters.isLoading` ([frontend/hooks/useCharacters.ts:444-446](frontend/hooks/useCharacters.ts:444)) returns true while `isFetching && characters.length === 0` (e.g., after a mass character delete during refetch), and the render gate at [frontend/app/munchkin/[roomNumber]/(battle)/index.tsx:152-158](frontend/app/munchkin/[roomNumber]/(battle)/index.tsx:152) hides battle+draft on either the loading or the error path. Pre-existing 5.3 gating; mid-edit edits stay in state but become invisible. Out of scope for 5.5.
+- Story status flip bundled in same commit as code — Status moves to `review` and `sprint-status.yaml` is updated inside `a757881` alongside implementation. Common pattern in this repo; deferred as a process matter.
+
 ## Deferred from: code review of 5-3-manage-battle-state (2026-05-19)
 
 - TOCTOU race between `findById` status check and `findByIdAndUpdate` [`backend/battle-service/src/app.ts:380-395`] — no concurrent status flip is possible until Stories 5.6 (Conclude) / 5.7 (Discard) ship; revisit with an atomic `findOneAndUpdate({ _id, status: 'active' }, …)` when those stories land. Harmless now.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-19
+last_updated: 2026-05-20
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -83,7 +83,7 @@ development_status:
   5-2-show-active-battle-in-room-view: done
   5-3-manage-battle-state: done
   5-4-realtime-battle-updates-from-battle-actions: done
-  5-5-realtime-battle-updates-from-character-changes: ready-for-dev
+  5-5-realtime-battle-updates-from-character-changes: review
   5-6-conclude-a-battle: ready-for-dev
   5-7-discard-a-battle: ready-for-dev
   epic-5-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-20
+last_updated: 2026-05-20T01:00:00Z
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -83,7 +83,7 @@ development_status:
   5-2-show-active-battle-in-room-view: done
   5-3-manage-battle-state: done
   5-4-realtime-battle-updates-from-battle-actions: done
-  5-5-realtime-battle-updates-from-character-changes: review
+  5-5-realtime-battle-updates-from-character-changes: done
   5-6-conclude-a-battle: ready-for-dev
   5-7-discard-a-battle: ready-for-dev
   epic-5-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-20T01:00:00Z
+last_updated: 2026-05-20
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system

--- a/frontend/__tests__/app/munchkin/[roomNumber]/(battle)/index.test.tsx
+++ b/frontend/__tests__/app/munchkin/[roomNumber]/(battle)/index.test.tsx
@@ -112,7 +112,19 @@ vi.mock('expo-haptics', () => ({
 describe('Battle view', () => {
   beforeEach(() => {
     mockBattleState.current = mockBattleState.createState();
+    mockCharactersState.current = {
+      characters: [
+        { id: 'character-1', roomId: 'ROOM42', userId: 'user-1', nickname: 'Alice', avatar: 0, level: 4, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
+        { id: 'character-2', roomId: 'ROOM42', userId: 'user-2', nickname: 'Bob', avatar: 1, level: 2, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
+      ],
+      isLoading: false,
+      errorMessage: null,
+    };
     mockBattleActions.patch.mockReset();
+    mockBattleActions.patch.mockImplementation(async (_battleId: string, payload: Partial<Battle>) => ({
+      ...mockBattleState.current.battle!,
+      ...payload,
+    }));
     mockBattleActions.current = { isLoading: false, errorMessage: null };
   });
 
@@ -227,7 +239,7 @@ describe('Battle view', () => {
     await waitFor(() => {
       expect(mockBattleActions.patch).toHaveBeenCalledWith('battle-1', {
         name: 'Dungeon Door',
-        playerSide: { characterIds: ['character-1', 'character-2'], bonuses: [{ id: 'bonus-new', value: 1 }] },
+        playerSide: { characterIds: ['character-1', 'character-2'], bonuses: [{ id: expect.any(String), value: 1 }] },
         monsterSide: { monsters: [], bonuses: [] },
       });
     });
@@ -264,6 +276,139 @@ describe('Battle view', () => {
     expect(saveButton.getAttribute('aria-disabled')).toBe('true');
 
     fireEvent.click(saveButton);
+    expect(mockBattleActions.patch).not.toHaveBeenCalled();
+  });
+
+  it('derives participating character updates into the player row and total without dirtying the draft', async () => {
+    const { default: BattleView } = await import('../../../../../app/munchkin/[roomNumber]/(battle)');
+    mockBattleState.current.battle = {
+      ...mockBattleState.current.battle!,
+      playerSide: { characterIds: ['character-1'], bonuses: [{ id: 'bonus-1', value: 1 }] },
+      monsterSide: { monsters: [], bonuses: [] },
+    };
+
+    const view = render(<BattleView />);
+    expect(screen.getByText('Alice · Level 4')).toBeTruthy();
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('5');
+    expect(screen.getByTestId('save-battle').getAttribute('aria-disabled')).toBe('true');
+
+    mockCharactersState.current = {
+      ...mockCharactersState.current,
+      characters: [
+        { ...mockCharactersState.current.characters[0], nickname: 'Alice Prime', level: 9 },
+        mockCharactersState.current.characters[1],
+      ],
+    };
+    view.rerender(<BattleView />);
+
+    expect(screen.getByText('Alice Prime · Level 9')).toBeTruthy();
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('10');
+    expect(screen.getByTestId('save-battle').getAttribute('aria-disabled')).toBe('true');
+    expect(mockBattleActions.patch).not.toHaveBeenCalled();
+  });
+
+  it('renders deleted participating characters as tombstones and keeps the draft unchanged until explicit save', async () => {
+    const { default: BattleView } = await import('../../../../../app/munchkin/[roomNumber]/(battle)');
+    mockBattleState.current.battle = {
+      ...mockBattleState.current.battle!,
+      playerSide: { characterIds: ['character-1', 'character-2'], bonuses: [] },
+      monsterSide: { monsters: [], bonuses: [] },
+    };
+
+    const view = render(<BattleView />);
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('6');
+
+    mockCharactersState.current = {
+      ...mockCharactersState.current,
+      characters: [mockCharactersState.current.characters[0]],
+    };
+    view.rerender(<BattleView />);
+
+    expect(screen.getByText('Alice · Level 4')).toBeTruthy();
+    expect(screen.getByTestId('battle-participant-removed').textContent).toContain('Removed · character-2');
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('4');
+    expect(screen.getByTestId('save-battle').getAttribute('aria-disabled')).toBe('true');
+    expect(mockBattleActions.patch).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('add-bonus-players-1'));
+    fireEvent.click(screen.getByTestId('save-battle'));
+
+    await waitFor(() => {
+      expect(mockBattleActions.patch).toHaveBeenCalledWith('battle-1', {
+        name: 'Dungeon Door',
+        playerSide: { characterIds: ['character-1', 'character-2'], bonuses: [{ id: expect.any(String), value: 1 }] },
+        monsterSide: { monsters: [], bonuses: [] },
+      });
+    });
+  });
+
+  it('ignores non-participating character changes for player rows, total, and dirty state', async () => {
+    const { default: BattleView } = await import('../../../../../app/munchkin/[roomNumber]/(battle)');
+    mockBattleState.current.battle = {
+      ...mockBattleState.current.battle!,
+      playerSide: { characterIds: ['character-1'], bonuses: [] },
+      monsterSide: { monsters: [], bonuses: [] },
+    };
+
+    const view = render(<BattleView />);
+    const beforeRows = screen.getAllByTestId('battle-participant-active').map((row) => row.textContent);
+    const beforeTotal = screen.getByTestId('battle-players-total').textContent;
+
+    mockCharactersState.current = {
+      ...mockCharactersState.current,
+      characters: [
+        mockCharactersState.current.characters[0],
+        { ...mockCharactersState.current.characters[1], nickname: 'Bob Updated', level: 12 },
+      ],
+    };
+    view.rerender(<BattleView />);
+
+    expect(screen.getAllByTestId('battle-participant-active').map((row) => row.textContent)).toEqual(beforeRows);
+    expect(screen.getByTestId('battle-players-total').textContent).toBe(beforeTotal);
+    expect(screen.getByTestId('save-battle').getAttribute('aria-disabled')).toBe('true');
+    expect(mockBattleActions.patch).not.toHaveBeenCalled();
+
+    mockCharactersState.current = {
+      ...mockCharactersState.current,
+      characters: [mockCharactersState.current.characters[0]],
+    };
+    view.rerender(<BattleView />);
+
+    expect(screen.getAllByTestId('battle-participant-active').map((row) => row.textContent)).toEqual(beforeRows);
+    expect(screen.getByTestId('battle-players-total').textContent).toBe(beforeTotal);
+    expect(screen.queryByTestId('battle-participant-removed')).toBeNull();
+    expect(screen.getByTestId('save-battle').getAttribute('aria-disabled')).toBe('true');
+    expect(mockBattleActions.patch).not.toHaveBeenCalled();
+  });
+
+  it('uses latest room character state on remount without duplicate or stale participant rows', async () => {
+    const { default: BattleView } = await import('../../../../../app/munchkin/[roomNumber]/(battle)');
+    mockBattleState.current.battle = {
+      ...mockBattleState.current.battle!,
+      playerSide: { characterIds: ['character-1', 'character-2'], bonuses: [] },
+      monsterSide: { monsters: [], bonuses: [] },
+    };
+    mockCharactersState.current = {
+      ...mockCharactersState.current,
+      characters: [
+        { ...mockCharactersState.current.characters[0], nickname: 'Alice Latest', level: 6 },
+      ],
+    };
+
+    const view = render(<BattleView />);
+
+    expect(screen.getByText('Alice Latest · Level 6')).toBeTruthy();
+    expect(screen.queryByText('Alice · Level 4')).toBeNull();
+    expect(screen.getAllByTestId('battle-participant-active')).toHaveLength(1);
+    expect(screen.getAllByTestId('battle-participant-removed')).toHaveLength(1);
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('6');
+
+    view.unmount();
+    render(<BattleView />);
+
+    expect(screen.getAllByTestId('battle-participant-active')).toHaveLength(1);
+    expect(screen.getAllByTestId('battle-participant-removed')).toHaveLength(1);
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('6');
     expect(mockBattleActions.patch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/__tests__/app/munchkin/[roomNumber]/(battle)/index.test.tsx
+++ b/frontend/__tests__/app/munchkin/[roomNumber]/(battle)/index.test.tsx
@@ -325,7 +325,8 @@ describe('Battle view', () => {
     view.rerender(<BattleView />);
 
     expect(screen.getByText('Alice · Level 4')).toBeTruthy();
-    expect(screen.getByTestId('battle-participant-removed').textContent).toContain('Removed · character-2');
+    expect(screen.getByTestId('battle-participant-removed').textContent).toContain('Removed character');
+    expect(screen.queryByText(/character-2/)).toBeNull();
     expect(screen.getByTestId('battle-players-total').textContent).toBe('4');
     expect(screen.getByTestId('save-battle').getAttribute('aria-disabled')).toBe('true');
     expect(mockBattleActions.patch).not.toHaveBeenCalled();
@@ -410,5 +411,23 @@ describe('Battle view', () => {
     expect(screen.getAllByTestId('battle-participant-removed')).toHaveLength(1);
     expect(screen.getByTestId('battle-players-total').textContent).toBe('6');
     expect(mockBattleActions.patch).not.toHaveBeenCalled();
+  });
+
+  it('hides optimistic (temp-) characters from the add picker so the just-added participant cannot flip to a tombstone after id swap', async () => {
+    const { default: BattleView } = await import('../../../../../app/munchkin/[roomNumber]/(battle)');
+    mockCharactersState.current = {
+      ...mockCharactersState.current,
+      characters: [
+        ...mockCharactersState.current.characters,
+        { id: 'temp-1700000000000', roomId: 'ROOM42', userId: 'user-1', nickname: 'Pending', avatar: 2, level: 3, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
+      ],
+    };
+
+    render(<BattleView />);
+
+    expect(screen.getByTestId('select-character-character-1')).toBeTruthy();
+    expect(screen.getByTestId('select-character-character-2')).toBeTruthy();
+    expect(screen.queryByTestId('select-character-temp-1700000000000')).toBeNull();
+    expect(screen.queryByText('Pending')).toBeNull();
   });
 });

--- a/frontend/app/munchkin/[roomNumber]/(battle)/index.tsx
+++ b/frontend/app/munchkin/[roomNumber]/(battle)/index.tsx
@@ -75,6 +75,14 @@ export default function BattleView() {
     setSavedDraft((current) => current && areDraftsEqual(current, nextDraft) ? current : nextDraft);
   }, [battle, draft, savedDraft]);
 
+  // Exclude optimistic (temp-) ids from the add picker so users can't add a
+  // character that's about to get its id swapped — otherwise the just-added
+  // participant would flip to a tombstone the moment the server confirms.
+  const confirmedCharacters = useMemo(
+    () => characters.filter((character) => !character.id.startsWith('temp-')),
+    [characters],
+  );
+
   const playerParticipants = useMemo(() => {
     if (!draft) {
       return { active: [], removed: [] };
@@ -194,7 +202,7 @@ export default function BattleView() {
             <BattleSidePanel
               bonuses={draft.playerSide.bonuses}
               activeParticipants={playerParticipants.active}
-              characters={characters}
+              characters={confirmedCharacters}
               removedCharacterIds={playerParticipants.removed}
               selectedCharacterIds={draft.playerSide.characterIds}
               side="players"

--- a/frontend/app/munchkin/[roomNumber]/(battle)/index.tsx
+++ b/frontend/app/munchkin/[roomNumber]/(battle)/index.tsx
@@ -6,6 +6,7 @@ import { useBattleActions } from '@/hooks/useBattleActions';
 import { useRoomCharacters } from '@/hooks/useCharacters';
 import { useRoomBattle } from '@/hooks/useRoomBattle';
 import { useUserProfile } from '@/hooks/useUser';
+import { computePlayerTotal, reconcilePlayerParticipants } from '@/utils/battlePlayerSide';
 import { createUuidV4 } from '@/utils/uuid';
 import { useLocalSearchParams } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -74,18 +75,21 @@ export default function BattleView() {
     setSavedDraft((current) => current && areDraftsEqual(current, nextDraft) ? current : nextDraft);
   }, [battle, draft, savedDraft]);
 
+  const playerParticipants = useMemo(() => {
+    if (!draft) {
+      return { active: [], removed: [] };
+    }
+
+    return reconcilePlayerParticipants(draft.playerSide.characterIds, characters);
+  }, [characters, draft]);
+
   const playerTotal = useMemo(() => {
     if (!draft) {
       return 0;
     }
 
-    const characterLevelTotal = draft.playerSide.characterIds.reduce((total, id) => {
-      const character = characters.find((item) => item.id === id);
-      return total + (character?.level ?? 0);
-    }, 0);
-    const bonusTotal = draft.playerSide.bonuses.reduce((total, bonus) => total + bonus.value, 0);
-    return characterLevelTotal + bonusTotal;
-  }, [characters, draft]);
+    return computePlayerTotal(playerParticipants.active, draft.playerSide.bonuses);
+  }, [draft, playerParticipants]);
 
   const monsterTotal = useMemo(() => {
     if (!draft) {
@@ -103,13 +107,6 @@ export default function BattleView() {
     : playerTotal > monsterTotal
       ? AppTheme.colors.accent
       : AppTheme.colors.danger;
-  const unavailableCharacterIds = useMemo(() => {
-    if (!draft) {
-      return [];
-    }
-
-    return draft.playerSide.characterIds.filter((id) => !characters.some((character) => character.id === id));
-  }, [characters, draft]);
   const isDirty = !areDraftsEqual(draft, savedDraft);
   const isNameValid = !!draft && draft.name.trim().length > 0;
   const canSave = isDirty && isNameValid && !battleActions.isLoading;
@@ -196,13 +193,14 @@ export default function BattleView() {
 
             <BattleSidePanel
               bonuses={draft.playerSide.bonuses}
+              activeParticipants={playerParticipants.active}
               characters={characters}
+              removedCharacterIds={playerParticipants.removed}
               selectedCharacterIds={draft.playerSide.characterIds}
               side="players"
               title="Player Side"
               toneColor={AppTheme.colors.accent}
               total={playerTotal}
-              unavailableCharacterIds={unavailableCharacterIds}
               onAddBonus={(value) => updatePlayerSide((side) => ({
                 ...side,
                 bonuses: [...side.bonuses, { id: createUuidV4(), value }],

--- a/frontend/components/munchkin/BattleSidePanel.test.tsx
+++ b/frontend/components/munchkin/BattleSidePanel.test.tsx
@@ -17,6 +17,7 @@ describe('BattleSidePanel', () => {
 
     render(
       <BattleSidePanel
+        activeParticipants={[{ id: 'character-1', character: characters[0] }]}
         bonuses={[]}
         characters={characters}
         selectedCharacterIds={['character-1']}
@@ -60,8 +61,12 @@ describe('BattleSidePanel', () => {
     );
 
     expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice · Level 4');
-    expect(screen.getByTestId('battle-participant-removed').textContent).toContain('Removed · character-removed');
+    expect(screen.getByTestId('battle-participant-removed').textContent).toContain('Removed character');
+    expect(screen.queryByText(/character-removed/)).toBeNull();
     expect(screen.getByLabelText('character-removed - removed from room')).toBeTruthy();
+    expect(screen.getByLabelText('Drop removed character from draft')).toBeTruthy();
+    expect(screen.getByTestId('discard-removed-character-character-removed')).toBeTruthy();
+    expect(screen.queryByTestId('remove-character-character-removed')).toBeNull();
     expect(screen.getByTestId('battle-players-total').textContent).toBe('4');
     expect(screen.queryByText('Unavailable · character-removed')).toBeNull();
   });

--- a/frontend/components/munchkin/BattleSidePanel.test.tsx
+++ b/frontend/components/munchkin/BattleSidePanel.test.tsx
@@ -40,6 +40,78 @@ describe('BattleSidePanel', () => {
     expect(screen.getByLabelText('Add selected character')).toBeTruthy();
   });
 
+  it('renders active and removed participant states while excluding tombstones from the displayed total', () => {
+    render(
+      <BattleSidePanel
+        activeParticipants={[{ id: 'character-1', character: characters[0] }]}
+        bonuses={[]}
+        characters={characters}
+        removedCharacterIds={['character-removed']}
+        selectedCharacterIds={['character-1', 'character-removed']}
+        side="players"
+        title="Player Side"
+        toneColor={AppTheme.colors.accent}
+        total={4}
+        onAddBonus={vi.fn()}
+        onAddCharacter={vi.fn()}
+        onRemoveBonus={vi.fn()}
+        onRemoveCharacter={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice · Level 4');
+    expect(screen.getByTestId('battle-participant-removed').textContent).toContain('Removed · character-removed');
+    expect(screen.getByLabelText('character-removed - removed from room')).toBeTruthy();
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('4');
+    expect(screen.queryByText('Unavailable · character-removed')).toBeNull();
+  });
+
+  it('updates active participant rows from supplied live character data without adding non-participants', () => {
+    const { rerender } = render(
+      <BattleSidePanel
+        activeParticipants={[{ id: 'character-1', character: characters[0] }]}
+        bonuses={[]}
+        characters={characters}
+        selectedCharacterIds={['character-1']}
+        side="players"
+        title="Player Side"
+        toneColor={AppTheme.colors.accent}
+        total={4}
+        onAddBonus={vi.fn()}
+        onAddCharacter={vi.fn()}
+        onRemoveBonus={vi.fn()}
+        onRemoveCharacter={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice · Level 4');
+
+    const updatedCharacters = [
+      { ...characters[0], nickname: 'Alice Updated', level: 8 },
+      characters[1],
+    ];
+    rerender(
+      <BattleSidePanel
+        activeParticipants={[{ id: 'character-1', character: updatedCharacters[0] }]}
+        bonuses={[]}
+        characters={updatedCharacters}
+        selectedCharacterIds={['character-1']}
+        side="players"
+        title="Player Side"
+        toneColor={AppTheme.colors.accent}
+        total={8}
+        onAddBonus={vi.fn()}
+        onAddCharacter={vi.fn()}
+        onRemoveBonus={vi.fn()}
+        onRemoveCharacter={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice Updated · Level 8');
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('8');
+    expect(screen.queryByText('Bob · Level 2')).toBeNull();
+  });
+
   it('opens a Figma-inspired dialog to add monsters and displays total', () => {
     const onAddMonster = vi.fn();
     const onRemoveMonster = vi.fn();

--- a/frontend/components/munchkin/BattleSidePanel.tsx
+++ b/frontend/components/munchkin/BattleSidePanel.tsx
@@ -52,15 +52,7 @@ function BattleSidePanel({
   const [monsterName, setMonsterName] = useState(DEFAULT_MONSTER_NAME);
   const [monsterLevelText, setMonsterLevelText] = useState(DEFAULT_MONSTER_LEVEL);
   const [isMonsterModalVisible, setIsMonsterModalVisible] = useState(false);
-  const selectedParticipants = useMemo(
-    () => activeParticipants || selectedCharacterIds
-      .map((id) => {
-        const character = characters.find((item) => item.id === id);
-        return character ? { id, character } : null;
-      })
-      .filter((participant): participant is ActivePlayerParticipant => !!participant),
-    [activeParticipants, characters, selectedCharacterIds]
-  );
+  const selectedParticipants = activeParticipants ?? [];
   const availableCharacters = useMemo(
     () => characters.filter((character) => !selectedCharacterIds.includes(character.id)),
     [characters, selectedCharacterIds]
@@ -125,13 +117,13 @@ function BattleSidePanel({
           {removedCharacterIds.map((id) => (
             <View key={id} style={styles.removedRow} testID="battle-participant-removed">
               <Text accessibilityLabel={`${id} - removed from room`} style={styles.removedText}>
-                Removed · {id}
+                Removed character
               </Text>
               <TouchableOpacity
-                accessibilityLabel="Remove removed character"
+                accessibilityLabel="Drop removed character from draft"
                 accessibilityRole="button"
                 style={styles.removeButton}
-                testID={`remove-character-${id}`}
+                testID={`discard-removed-character-${id}`}
                 onPress={() => onRemoveCharacter?.(id)}
               >
                 <Text style={styles.removeButtonText}>-</Text>

--- a/frontend/components/munchkin/BattleSidePanel.tsx
+++ b/frontend/components/munchkin/BattleSidePanel.tsx
@@ -1,6 +1,7 @@
 import { Character as RoomCharacter } from '@/api/characters';
 import { BonusItem, MonsterItem } from '@/api/battles';
 import { AppTheme } from '@/constants/theme';
+import type { ActivePlayerParticipant } from '@/utils/battlePlayerSide';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { Image, Modal, Pressable, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
@@ -9,9 +10,10 @@ export interface BattleSidePanelProps {
   title: string;
   total: number;
   toneColor: string;
+  activeParticipants?: ActivePlayerParticipant[];
   characters?: RoomCharacter[];
   selectedCharacterIds?: string[];
-  unavailableCharacterIds?: string[];
+  removedCharacterIds?: string[];
   monsters?: MonsterItem[];
   bonuses: BonusItem[];
   onAddCharacter?: (characterId: string) => void;
@@ -33,9 +35,10 @@ function BattleSidePanel({
   title,
   total,
   toneColor,
+  activeParticipants,
   characters = [],
   selectedCharacterIds = [],
-  unavailableCharacterIds = [],
+  removedCharacterIds = [],
   monsters = [],
   bonuses,
   onAddCharacter,
@@ -49,9 +52,14 @@ function BattleSidePanel({
   const [monsterName, setMonsterName] = useState(DEFAULT_MONSTER_NAME);
   const [monsterLevelText, setMonsterLevelText] = useState(DEFAULT_MONSTER_LEVEL);
   const [isMonsterModalVisible, setIsMonsterModalVisible] = useState(false);
-  const selectedCharacters = useMemo(
-    () => selectedCharacterIds.map((id) => characters.find((character) => character.id === id)).filter(Boolean) as RoomCharacter[],
-    [characters, selectedCharacterIds]
+  const selectedParticipants = useMemo(
+    () => activeParticipants || selectedCharacterIds
+      .map((id) => {
+        const character = characters.find((item) => item.id === id);
+        return character ? { id, character } : null;
+      })
+      .filter((participant): participant is ActivePlayerParticipant => !!participant),
+    [activeParticipants, characters, selectedCharacterIds]
   );
   const availableCharacters = useMemo(
     () => characters.filter((character) => !selectedCharacterIds.includes(character.id)),
@@ -100,25 +108,27 @@ function BattleSidePanel({
       {side === 'players' && (
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Characters</Text>
-          {selectedCharacters.map((character) => (
-            <View key={character.id} style={styles.row}>
+          {selectedParticipants.map(({ id, character }) => (
+            <View key={id} style={styles.row} testID="battle-participant-active">
               <Text style={styles.rowText}>{character.nickname} · Level {character.level}</Text>
               <TouchableOpacity
                 accessibilityLabel={`Remove ${character.nickname}`}
                 accessibilityRole="button"
                 style={styles.removeButton}
-                testID={`remove-character-${character.id}`}
-                onPress={() => onRemoveCharacter?.(character.id)}
+                testID={`remove-character-${id}`}
+                onPress={() => onRemoveCharacter?.(id)}
               >
                 <Text style={styles.removeButtonText}>-</Text>
               </TouchableOpacity>
             </View>
           ))}
-          {unavailableCharacterIds.map((id) => (
-            <View key={id} style={styles.row}>
-              <Text style={styles.mutedText}>Unavailable · {id}</Text>
+          {removedCharacterIds.map((id) => (
+            <View key={id} style={styles.removedRow} testID="battle-participant-removed">
+              <Text accessibilityLabel={`${id} - removed from room`} style={styles.removedText}>
+                Removed · {id}
+              </Text>
               <TouchableOpacity
-                accessibilityLabel="Remove unavailable character"
+                accessibilityLabel="Remove removed character"
                 accessibilityRole="button"
                 style={styles.removeButton}
                 testID={`remove-character-${id}`}
@@ -345,6 +355,23 @@ const styles = StyleSheet.create({
   mutedText: {
     color: AppTheme.colors.textMuted,
     flex: 1,
+    ...AppTheme.typography.labelSm,
+  },
+  removedRow: {
+    alignItems: 'center',
+    backgroundColor: AppTheme.colors.surfaceSubtle,
+    borderRadius: AppTheme.radius.sm,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    minHeight: 44,
+    paddingHorizontal: AppTheme.spacing.md,
+    paddingVertical: AppTheme.spacing.sm,
+    gap: AppTheme.spacing.md,
+  },
+  removedText: {
+    color: AppTheme.colors.textMuted,
+    flex: 1,
+    textDecorationLine: 'line-through',
     ...AppTheme.typography.labelSm,
   },
   removeButton: {

--- a/frontend/utils/battlePlayerSide.test.ts
+++ b/frontend/utils/battlePlayerSide.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Character } from '@/api/characters';
+import { computePlayerTotal, reconcilePlayerParticipants } from '@/utils/battlePlayerSide';
+
+const characters: Character[] = [
+  { id: 'character-1', roomId: 'room-1', userId: 'user-1', nickname: 'Alice', avatar: 0, level: 4, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
+  { id: 'character-2', roomId: 'room-1', userId: 'user-2', nickname: 'Bob', avatar: 1, level: 2, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
+  { id: 'character-3', roomId: 'room-1', userId: 'user-3', nickname: 'Cora', avatar: 2, level: 7, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
+];
+
+describe('battlePlayerSide', () => {
+  it('returns all selected characters as active when they are resolved', () => {
+    expect(reconcilePlayerParticipants(['character-2', 'character-1'], characters)).toEqual({
+      active: [
+        { id: 'character-2', character: characters[1] },
+        { id: 'character-1', character: characters[0] },
+      ],
+      removed: [],
+    });
+  });
+
+  it('preserves order and collects removed ids when some characters are missing', () => {
+    expect(reconcilePlayerParticipants(['character-3', 'missing-1', 'character-1', 'missing-2'], characters)).toEqual({
+      active: [
+        { id: 'character-3', character: characters[2] },
+        { id: 'character-1', character: characters[0] },
+      ],
+      removed: ['missing-1', 'missing-2'],
+    });
+  });
+
+  it('handles empty character ids', () => {
+    expect(reconcilePlayerParticipants([], characters)).toEqual({ active: [], removed: [] });
+  });
+
+  it('deduplicates selected ids defensively', () => {
+    expect(reconcilePlayerParticipants(['character-1', 'character-1', 'missing-1', 'missing-1'], characters)).toEqual({
+      active: [{ id: 'character-1', character: characters[0] }],
+      removed: ['missing-1'],
+    });
+  });
+
+  it('computes player totals from active levels and signed bonuses only', () => {
+    const reconciled = reconcilePlayerParticipants(['character-1', 'missing-1', 'character-2'], characters);
+
+    expect(computePlayerTotal(reconciled.active, [
+      { id: 'bonus-1', value: 5 },
+      { id: 'bonus-2', value: -2 },
+    ])).toBe(9);
+  });
+});

--- a/frontend/utils/battlePlayerSide.test.ts
+++ b/frontend/utils/battlePlayerSide.test.ts
@@ -49,4 +49,18 @@ describe('battlePlayerSide', () => {
       { id: 'bonus-2', value: -2 },
     ])).toBe(9);
   });
+
+  it('treats non-finite levels and bonus values as zero so a stray NaN/null cannot invert the comparison label', () => {
+    const corruptedCharacter = { ...characters[0], level: Number.NaN } as Character;
+    const total = computePlayerTotal(
+      [{ character: corruptedCharacter }, { character: characters[1] }],
+      [
+        { id: 'bonus-1', value: Number.NaN },
+        { id: 'bonus-2', value: 3 },
+      ],
+    );
+
+    expect(Number.isFinite(total)).toBe(true);
+    expect(total).toBe(5);
+  });
 });

--- a/frontend/utils/battlePlayerSide.ts
+++ b/frontend/utils/battlePlayerSide.ts
@@ -38,7 +38,13 @@ export function reconcilePlayerParticipants(
 }
 
 export function computePlayerTotal(active: Pick<ActivePlayerParticipant, 'character'>[], bonuses: BonusItem[]): number {
-  const characterLevelTotal = active.reduce((total, participant) => total + participant.character.level, 0);
-  const bonusTotal = bonuses.reduce((total, bonus) => total + bonus.value, 0);
+  const characterLevelTotal = active.reduce(
+    (total, participant) => total + (Number.isFinite(participant.character.level) ? participant.character.level : 0),
+    0,
+  );
+  const bonusTotal = bonuses.reduce(
+    (total, bonus) => total + (Number.isFinite(bonus.value) ? bonus.value : 0),
+    0,
+  );
   return characterLevelTotal + bonusTotal;
 }

--- a/frontend/utils/battlePlayerSide.ts
+++ b/frontend/utils/battlePlayerSide.ts
@@ -1,0 +1,44 @@
+import type { BonusItem } from '@/api/battles';
+import type { Character } from '@/api/characters';
+
+export interface ActivePlayerParticipant {
+  id: string;
+  character: Character;
+}
+
+export interface ReconciledPlayerParticipants {
+  active: ActivePlayerParticipant[];
+  removed: string[];
+}
+
+export function reconcilePlayerParticipants(
+  characterIds: string[],
+  roomCharacters: Character[]
+): ReconciledPlayerParticipants {
+  const charactersById = new Map(roomCharacters.map((character) => [character.id, character]));
+  const seenCharacterIds = new Set<string>();
+  const active: ActivePlayerParticipant[] = [];
+  const removed: string[] = [];
+
+  for (const id of characterIds) {
+    if (seenCharacterIds.has(id)) {
+      continue;
+    }
+
+    seenCharacterIds.add(id);
+    const character = charactersById.get(id);
+    if (character) {
+      active.push({ id, character });
+    } else {
+      removed.push(id);
+    }
+  }
+
+  return { active, removed };
+}
+
+export function computePlayerTotal(active: Pick<ActivePlayerParticipant, 'character'>[], bonuses: BonusItem[]): number {
+  const characterLevelTotal = active.reduce((total, participant) => total + participant.character.level, 0);
+  const bonusTotal = bonuses.reduce((total, bonus) => total + bonus.value, 0);
+  return characterLevelTotal + bonusTotal;
+}


### PR DESCRIPTION
## Summary

Implements Story 5.5 realtime battle updates from character changes.

- Adds a pure player-side reconciliation helper for active vs removed battle participants.
- Updates the Battle View to derive participant rows and player totals from current room characters on every render.
- Renders deleted participants as muted struck-through tombstones while retaining draft/persisted `characterIds` until an explicit save.
- Adds helper, component, and route tests for participant updates, tombstones, non-participant no-ops, remount consistency, and coverage-floor tracking.
- Updates the BMAD story record and sprint status to review after manual smoke passed.

## Validation

- `npm run tsc`
- `npm run lint` (passes with one existing warning in `frontend/app/munchkin/modal-change-caracter.tsx`)
- `npm run test:coverage` (156 unit/component/hook tests, 49 route tests, 84.31% line coverage)
- Local two-client manual smoke passed, confirmed 2026-05-20

## Notes

No backend, infrastructure, realtime transport, `useRoomBattle`, or `useRoomWebSocket` changes.