### PR TITLE
[codex] Include character power in battle totals

### DIFF
--- a/_bmad-output/implementation-artifacts/5-3-manage-battle-state.md
+++ b/_bmad-output/implementation-artifacts/5-3-manage-battle-state.md
@@ -172,10 +172,14 @@ realtime flow).
   type MonsterItem = { id: string; name: string; level: number }
   ```
 - **Effective strength (AC1, architecture "Effective strength calculation"):**
-  - Player = `Σ(level of room characters whose id ∈ playerSide.characterIds)` + `Σ(playerSide.bonuses[].value)`
+  - Player = `Σ(level + power of room characters whose id ∈ playerSide.characterIds)` + `Σ(playerSide.bonuses[].value)`.
+    Dev note, 2026-05-20: PR #94 corrected the implementation and tests so
+    battle participants contribute their full character strength (`level + power`),
+    not level alone. Participant rows display this combined contribution as
+    `Power <sum>` rather than separate Level and Power labels.
   - Monster = `Σ(monsterSide.monsters[].level)` + `Σ(monsterSide.bonuses[].value)`
   - The battle persists only `characterIds` (a snapshot of IDs) — **not** character
-    levels. Levels are resolved client-side from the room's current characters
+    levels or power. Level and power are resolved client-side from the room's current characters
     (`useRoomCharacters`). This is intentional: ADR-9 (battle retains original
     `characterIds`; no backend cascade); live reconciliation of character edits is
     Story 5.5, not 5.3.

--- a/frontend/__tests__/app/munchkin/[roomNumber]/(battle)/index.test.tsx
+++ b/frontend/__tests__/app/munchkin/[roomNumber]/(battle)/index.test.tsx
@@ -224,6 +224,27 @@ describe('Battle view', () => {
     expect(screen.getByTestId('battle-comparison-container').getAttribute('style')).toContain(hexToRgbStyleValue(borderColor));
   });
 
+  it('includes character power in the player-side battle total', async () => {
+    const { default: BattleView } = await import('../../../../../app/munchkin/[roomNumber]/(battle)');
+    mockCharactersState.current = {
+      ...mockCharactersState.current,
+      characters: [
+        { ...mockCharactersState.current.characters[0], level: 2, power: 4 },
+        mockCharactersState.current.characters[1],
+      ],
+    };
+    mockBattleState.current.battle = {
+      ...mockBattleState.current.battle!,
+      playerSide: { characterIds: ['character-1'], bonuses: [] },
+      monsterSide: { monsters: [{ id: 'monster-1', name: 'Fungeater', level: 5 }], bonuses: [] },
+    };
+
+    render(<BattleView />);
+
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('6');
+    expect(screen.getByTestId('battle-comparison-label').textContent).toBe('Players ahead');
+  });
+
   it('renders error and empty states', async () => {
     const { default: BattleView } = await import('../../../../../app/munchkin/[roomNumber]/(battle)');
 
@@ -396,7 +417,7 @@ describe('Battle view', () => {
     };
 
     const view = render(<BattleView />);
-    expect(screen.getByText('Alice · Level 4')).toBeTruthy();
+    expect(screen.getByText('Alice · Power 4')).toBeTruthy();
     expect(screen.getByTestId('battle-players-total').textContent).toBe('5');
     expect(screen.getByTestId('save-battle').getAttribute('aria-disabled')).toBe('true');
 
@@ -409,7 +430,7 @@ describe('Battle view', () => {
     };
     view.rerender(<BattleView />);
 
-    expect(screen.getByText('Alice Prime · Level 9')).toBeTruthy();
+    expect(screen.getByText('Alice Prime · Power 9')).toBeTruthy();
     expect(screen.getByTestId('battle-players-total').textContent).toBe('10');
     expect(screen.getByTestId('save-battle').getAttribute('aria-disabled')).toBe('true');
     expect(mockBattleActions.patch).not.toHaveBeenCalled();
@@ -432,7 +453,7 @@ describe('Battle view', () => {
     };
     view.rerender(<BattleView />);
 
-    expect(screen.getByText('Alice · Level 4')).toBeTruthy();
+    expect(screen.getByText('Alice · Power 4')).toBeTruthy();
     expect(screen.getByTestId('battle-participant-removed').textContent).toContain('Removed character');
     expect(screen.queryByText(/character-2/)).toBeNull();
     expect(screen.getByTestId('battle-players-total').textContent).toBe('4');
@@ -506,8 +527,8 @@ describe('Battle view', () => {
 
     const view = render(<BattleView />);
 
-    expect(screen.getByText('Alice Latest · Level 6')).toBeTruthy();
-    expect(screen.queryByText('Alice · Level 4')).toBeNull();
+    expect(screen.getByText('Alice Latest · Power 6')).toBeTruthy();
+    expect(screen.queryByText('Alice · Power 4')).toBeNull();
     expect(screen.getAllByTestId('battle-participant-active')).toHaveLength(1);
     expect(screen.getAllByTestId('battle-participant-removed')).toHaveLength(1);
     expect(screen.getByTestId('battle-players-total').textContent).toBe('6');

--- a/frontend/components/munchkin/BattleSidePanel.test.tsx
+++ b/frontend/components/munchkin/BattleSidePanel.test.tsx
@@ -6,8 +6,8 @@ import BattleSidePanel from '@/components/munchkin/BattleSidePanel';
 import { AppTheme } from '@/constants/theme';
 
 const characters = [
-  { id: 'character-1', roomId: 'room-1', userId: 'user-1', nickname: 'Alice', avatar: 0, level: 4, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
-  { id: 'character-2', roomId: 'room-1', userId: 'user-2', nickname: 'Bob', avatar: 1, level: 2, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
+  { id: 'character-1', roomId: 'room-1', userId: 'user-1', nickname: 'Alice', avatar: 0, level: 4, power: 6, class: [], race: [], gender: [], color: '#FFFFFF' },
+  { id: 'character-2', roomId: 'room-1', userId: 'user-2', nickname: 'Bob', avatar: 1, level: 2, power: 3, class: [], race: [], gender: [], color: '#FFFFFF' },
 ];
 
 describe('BattleSidePanel', () => {
@@ -24,7 +24,7 @@ describe('BattleSidePanel', () => {
         side="players"
         title="Player Side"
         toneColor={AppTheme.colors.accent}
-        total={4}
+        total={10}
         onAddBonus={vi.fn()}
         onAddCharacter={onAddCharacter}
         onRemoveBonus={vi.fn()}
@@ -52,7 +52,7 @@ describe('BattleSidePanel', () => {
         side="players"
         title="Player Side"
         toneColor={AppTheme.colors.accent}
-        total={4}
+        total={10}
         onAddBonus={vi.fn()}
         onAddCharacter={vi.fn()}
         onRemoveBonus={vi.fn()}
@@ -60,14 +60,14 @@ describe('BattleSidePanel', () => {
       />
     );
 
-    expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice · Level 4');
+    expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice · Power 10');
     expect(screen.getByTestId('battle-participant-removed').textContent).toContain('Removed character');
     expect(screen.queryByText(/character-removed/)).toBeNull();
     expect(screen.getByLabelText('character-removed - removed from room')).toBeTruthy();
     expect(screen.getByLabelText('Drop removed character from draft')).toBeTruthy();
     expect(screen.getByTestId('discard-removed-character-character-removed')).toBeTruthy();
     expect(screen.queryByTestId('remove-character-character-removed')).toBeNull();
-    expect(screen.getByTestId('battle-players-total').textContent).toBe('4');
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('10');
     expect(screen.queryByText('Unavailable · character-removed')).toBeNull();
   });
 
@@ -81,7 +81,7 @@ describe('BattleSidePanel', () => {
         side="players"
         title="Player Side"
         toneColor={AppTheme.colors.accent}
-        total={4}
+        total={10}
         onAddBonus={vi.fn()}
         onAddCharacter={vi.fn()}
         onRemoveBonus={vi.fn()}
@@ -89,10 +89,10 @@ describe('BattleSidePanel', () => {
       />
     );
 
-    expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice · Level 4');
+    expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice · Power 10');
 
     const updatedCharacters = [
-      { ...characters[0], nickname: 'Alice Updated', level: 8 },
+      { ...characters[0], nickname: 'Alice Updated', level: 8, power: 9 },
       characters[1],
     ];
     rerender(
@@ -104,7 +104,7 @@ describe('BattleSidePanel', () => {
         side="players"
         title="Player Side"
         toneColor={AppTheme.colors.accent}
-        total={8}
+        total={17}
         onAddBonus={vi.fn()}
         onAddCharacter={vi.fn()}
         onRemoveBonus={vi.fn()}
@@ -112,9 +112,9 @@ describe('BattleSidePanel', () => {
       />
     );
 
-    expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice Updated · Level 8');
-    expect(screen.getByTestId('battle-players-total').textContent).toBe('8');
-    expect(screen.queryByText('Bob · Level 2')).toBeNull();
+    expect(screen.getByTestId('battle-participant-active').textContent).toContain('Alice Updated · Power 17');
+    expect(screen.getByTestId('battle-players-total').textContent).toBe('17');
+    expect(screen.queryByText('Bob · Power 5')).toBeNull();
   });
 
   it('opens a Figma-inspired dialog to add monsters and displays total', () => {

--- a/frontend/components/munchkin/BattleSidePanel.tsx
+++ b/frontend/components/munchkin/BattleSidePanel.tsx
@@ -102,7 +102,7 @@ function BattleSidePanel({
           <Text style={styles.sectionTitle}>Characters</Text>
           {selectedParticipants.map(({ id, character }) => (
             <View key={id} style={styles.row} testID="battle-participant-active">
-              <Text style={styles.rowText}>{character.nickname} · Level {character.level}</Text>
+              <Text style={styles.rowText}>{character.nickname} · Power {character.level + character.power}</Text>
               <TouchableOpacity
                 accessibilityLabel={`Remove ${character.nickname}`}
                 accessibilityRole="button"

--- a/frontend/utils/battlePlayerSide.test.ts
+++ b/frontend/utils/battlePlayerSide.test.ts
@@ -4,9 +4,9 @@ import type { Character } from '@/api/characters';
 import { computePlayerTotal, reconcilePlayerParticipants } from '@/utils/battlePlayerSide';
 
 const characters: Character[] = [
-  { id: 'character-1', roomId: 'room-1', userId: 'user-1', nickname: 'Alice', avatar: 0, level: 4, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
-  { id: 'character-2', roomId: 'room-1', userId: 'user-2', nickname: 'Bob', avatar: 1, level: 2, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
-  { id: 'character-3', roomId: 'room-1', userId: 'user-3', nickname: 'Cora', avatar: 2, level: 7, power: 0, class: [], race: [], gender: [], color: '#FFFFFF' },
+  { id: 'character-1', roomId: 'room-1', userId: 'user-1', nickname: 'Alice', avatar: 0, level: 4, power: 6, class: [], race: [], gender: [], color: '#FFFFFF' },
+  { id: 'character-2', roomId: 'room-1', userId: 'user-2', nickname: 'Bob', avatar: 1, level: 2, power: 3, class: [], race: [], gender: [], color: '#FFFFFF' },
+  { id: 'character-3', roomId: 'room-1', userId: 'user-3', nickname: 'Cora', avatar: 2, level: 7, power: 8, class: [], race: [], gender: [], color: '#FFFFFF' },
 ];
 
 describe('battlePlayerSide', () => {
@@ -41,17 +41,17 @@ describe('battlePlayerSide', () => {
     });
   });
 
-  it('computes player totals from active levels and signed bonuses only', () => {
+  it('computes player totals from active level, power, and signed bonuses only', () => {
     const reconciled = reconcilePlayerParticipants(['character-1', 'missing-1', 'character-2'], characters);
 
     expect(computePlayerTotal(reconciled.active, [
       { id: 'bonus-1', value: 5 },
       { id: 'bonus-2', value: -2 },
-    ])).toBe(9);
+    ])).toBe(18);
   });
 
-  it('treats non-finite levels and bonus values as zero so a stray NaN/null cannot invert the comparison label', () => {
-    const corruptedCharacter = { ...characters[0], level: Number.NaN } as Character;
+  it('treats non-finite levels, powers, and bonus values as zero so a stray NaN/null cannot invert the comparison label', () => {
+    const corruptedCharacter = { ...characters[0], level: Number.NaN, power: Number.NaN } as Character;
     const total = computePlayerTotal(
       [{ character: corruptedCharacter }, { character: characters[1] }],
       [
@@ -61,6 +61,6 @@ describe('battlePlayerSide', () => {
     );
 
     expect(Number.isFinite(total)).toBe(true);
-    expect(total).toBe(5);
+    expect(total).toBe(8);
   });
 });

--- a/frontend/utils/battlePlayerSide.ts
+++ b/frontend/utils/battlePlayerSide.ts
@@ -38,13 +38,17 @@ export function reconcilePlayerParticipants(
 }
 
 export function computePlayerTotal(active: Pick<ActivePlayerParticipant, 'character'>[], bonuses: BonusItem[]): number {
-  const characterLevelTotal = active.reduce(
-    (total, participant) => total + (Number.isFinite(participant.character.level) ? participant.character.level : 0),
+  const characterTotal = active.reduce(
+    (total, participant) => {
+      const level = Number.isFinite(participant.character.level) ? participant.character.level : 0;
+      const power = Number.isFinite(participant.character.power) ? participant.character.power : 0;
+      return total + level + power;
+    },
     0,
   );
   const bonusTotal = bonuses.reduce(
     (total, bonus) => total + (Number.isFinite(bonus.value) ? bonus.value : 0),
     0,
   );
-  return characterLevelTotal + bonusTotal;
+  return characterTotal + bonusTotal;
 }


### PR DESCRIPTION
## Summary

- Adds each battle participant's character `level + power` to the player-side total.
- Shows participant rows as `Power <sum>` so the displayed label matches the battle contribution.
- Extends utility, panel, and battle route tests for the combined Power behavior.

## Impact

Characters added to a battle now contribute their full combat strength instead of only their level. Battle comparisons and displayed player totals reflect the same calculation.

## Validation

- `npm run test:unit -- utils/battlePlayerSide.test.ts components/munchkin/BattleSidePanel.test.tsx`
- `npm run test:unit -- components/munchkin/BattleSidePanel.test.tsx`
- `npm run test:room-route -- '__tests__/app/munchkin/[roomNumber]/(battle)/index.test.tsx'`