### PR TITLE
[codex] Implement character history event publishing

### DIFF
--- a/_bmad-output/implementation-artifacts/6-1-character-events-are-published-for-room-history.md
+++ b/_bmad-output/implementation-artifacts/6-1-character-events-are-published-for-room-history.md
@@ -1,6 +1,6 @@
 # Story 6.1: Character Events Are Published for Room History
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -20,35 +20,35 @@ so that the group can understand how the session state changed over time.
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Enrich the character event payload contract (AC: 3, 5)**
-  - [ ] In `backend/character-service/src/publisher.ts`, extend `CharacterEventPayload` with an **additive** display-context section. Do NOT rename or remove existing fields (`event`, `roomId`, `event_body.characterId`, `emittedAt`, `correlationId`) — `room-notifications-service` depends on them.
-  - [ ] Add `character: { id: string; name: string; avatarId: number; color: string }`.
-  - [ ] Add optional `changes?: Record<string, { prev: unknown; next: unknown }>` — present **only** for `character_updated`, containing exactly the fields whose value changed.
-  - [ ] Add canonical mirror fields to forward-align with the architecture event contract (these are duplicates of existing data, additive only): `eventType` (= `event`), `actorId` (= `character.id`), `occurredAt` (= `emittedAt`).
-  - [ ] Update `createCharacterEventPayload(...)` to accept the full character snapshot and an optional `changes` map and build the enriched payload. Keep `emittedAt`/`occurredAt` deterministic via `new Date().toISOString()` (existing pattern; fake-timer testable).
-- [ ] **Task 2 — Dual-target fan-out publisher (AC: 1, 4)**
-  - [ ] Introduce a composite/fan-out publisher in `publisher.ts` that wraps an ordered list of leg publishers (notifications leg + log leg) and publishes via `await Promise.allSettled(legs.map(p => p.publish(payload)))`. Each rejected leg is logged with the failing target; no rejection is rethrown.
-  - [ ] Reuse the existing `SnsCharacterEventPublisher` / `RedisCharacterEventPublisher` / `NoopCharacterEventPublisher` classes as legs — do NOT duplicate SNS/Redis client logic.
-  - [ ] The `CharacterEventPublisher` interface (`publish(payload): Promise<void>`) is unchanged; the composite implements the same interface so `app.ts` / `service.ts` wiring stays as-is.
-- [ ] **Task 3 — Capture prev→next for updates (AC: 3)**
-  - [ ] In `backend/character-service/src/app.ts` PATCH handler, obtain the pre-update character so changed-field `prev` values are available. Add `findById(id): Promise<CharacterLike | null>` to `CharacterModelLike` and implement it in `createCharacterModel()` (`backend/character-service/src/service.ts`) mirroring the existing method style (logging + field mapping). Read the character before calling `findByIdAndUpdate`.
-  - [ ] Compute `changes` as only the keys present in the validated `updates` object whose normalized value differs from the pre-update value. Do not include unchanged fields. Do not emit `changes` for create/delete.
-  - [ ] Concurrency note: read-before-update is last-write-wins (consistent with the system's existing concurrency posture); acceptable for display context — do not add locking.
-  - [ ] Pass the post-update character snapshot + `changes` into `createCharacterEventPayload` for `character_updated`; pass the created/deleted character snapshot for `character_created` / `character_deleted`.
-- [ ] **Task 4 — Lambda wiring: notifications + log SNS legs with degraded mode (AC: 1, 2, 4)**
-  - [ ] In `backend/character-service/src/lambda.ts`, build the notifications leg from the existing `ROOM_CHARACTER_EVENTS_TOPIC_ARN` env var (unchanged — see Project Structure Notes) and a new log leg from `LOG_TOPIC_ARN`.
-  - [ ] If `LOG_TOPIC_ARN` is absent/empty: `console.warn` once at bootstrap (degraded — log history will be absent) and use `NoopCharacterEventPublisher` for the log leg. Service must NOT throw or `process.exit`.
-  - [ ] Compose both legs into the fan-out publisher and pass it to `buildCharacterApp`. Keep the existing bootstrap-config `console.info` and add `logTopicArnConfigured: Boolean(process.env.LOG_TOPIC_ARN)`.
-- [ ] **Task 5 — Local server wiring: notifications + log Redis legs with degraded mode (AC: 1, 2, 4)**
-  - [ ] In `backend/character-service/src/index.ts`, keep the existing notifications Redis leg (`CHARACTER_EVENTS_REDIS_URL` + `ROOM_CHARACTER_EVENTS_CHANNEL`, default `room-character-events`). Add a log Redis leg on a new channel env `ROOM_LOG_EVENTS_CHANNEL` (default `room-log-events`) using the same `CHARACTER_EVENTS_REDIS_URL`.
-  - [ ] If `CHARACTER_EVENTS_REDIS_URL` is unset (already the Noop path) OR the log channel cannot be configured, `console.warn` once and use `NoopCharacterEventPublisher` for the log leg. Do not crash.
-  - [ ] Compose both legs into the fan-out publisher; extend the existing bootstrap `console.info` with `logEventsChannel` + `logConfigured`.
-- [ ] **Task 6 — Tests (AC: 1, 2, 3, 4, 5)**
-  - [ ] `publisher.test.ts`: fan-out calls every leg; uses `Promise.allSettled` (assert both legs invoked even when one rejects); a rejecting leg does not cause the composite `publish` to reject; `createCharacterEventPayload` produces the enriched superset incl. `changes` for updates and omits `changes` for create/delete; legacy fields preserved exactly (regression guard for AC 5).
-  - [ ] `lambda.test.ts`: both env vars set → composite with two SNS legs; `LOG_TOPIC_ARN` absent → startup `console.warn` + notifications leg still active + handler still boots and responds (no throw); follow existing `vi.hoisted` mock + `delete process.env.*` reset pattern, and add `delete process.env.LOG_TOPIC_ARN` to `beforeEach`.
-  - [ ] `app.test.ts`: create/delete publish a payload containing `character` display context; update publishes `changes` with correct `prev → next` for changed fields only; a publisher that throws does NOT change the HTTP status (create still `201`, update `200`, delete `204`) — regression guard for AC 4. Inject a spy publisher via the existing `createApp(model, { publisher })` option.
-  - [ ] Add/extend a `findById` test in `service.test.ts` if the existing model-mapping tests assert method coverage there.
-  - [ ] Run backend test + coverage gate: `cd backend/character-service && npm test` (Vitest 3.2.4, v8 coverage, 70% line floor — do not lower).
+- [x] **Task 1 — Enrich the character event payload contract (AC: 3, 5)**
+  - [x] In `backend/character-service/src/publisher.ts`, extend `CharacterEventPayload` with an **additive** display-context section. Do NOT rename or remove existing fields (`event`, `roomId`, `event_body.characterId`, `emittedAt`, `correlationId`) — `room-notifications-service` depends on them.
+  - [x] Add `character: { id: string; name: string; avatarId: number; color: string }`.
+  - [x] Add optional `changes?: Record<string, { prev: unknown; next: unknown }>` — present **only** for `character_updated`, containing exactly the fields whose value changed.
+  - [x] Add canonical mirror fields to forward-align with the architecture event contract (these are duplicates of existing data, additive only): `eventType` (= `event`), `actorId` (= `character.id`), `occurredAt` (= `emittedAt`).
+  - [x] Update `createCharacterEventPayload(...)` to accept the full character snapshot and an optional `changes` map and build the enriched payload. Keep `emittedAt`/`occurredAt` deterministic via `new Date().toISOString()` (existing pattern; fake-timer testable).
+- [x] **Task 2 — Dual-target fan-out publisher (AC: 1, 4)**
+  - [x] Introduce a composite/fan-out publisher in `publisher.ts` that wraps an ordered list of leg publishers (notifications leg + log leg) and publishes via `await Promise.allSettled(legs.map(p => p.publish(payload)))`. Each rejected leg is logged with the failing target; no rejection is rethrown.
+  - [x] Reuse the existing `SnsCharacterEventPublisher` / `RedisCharacterEventPublisher` / `NoopCharacterEventPublisher` classes as legs — do NOT duplicate SNS/Redis client logic.
+  - [x] The `CharacterEventPublisher` interface (`publish(payload): Promise<void>`) is unchanged; the composite implements the same interface so `app.ts` / `service.ts` wiring stays as-is.
+- [x] **Task 3 — Capture prev→next for updates (AC: 3)**
+  - [x] In `backend/character-service/src/app.ts` PATCH handler, obtain the pre-update character so changed-field `prev` values are available. Add `findById(id): Promise<CharacterLike | null>` to `CharacterModelLike` and implement it in `createCharacterModel()` (`backend/character-service/src/service.ts`) mirroring the existing method style (logging + field mapping). Read the character before calling `findByIdAndUpdate`.
+  - [x] Compute `changes` as only the keys present in the validated `updates` object whose normalized value differs from the pre-update value. Do not include unchanged fields. Do not emit `changes` for create/delete.
+  - [x] Concurrency note: read-before-update is last-write-wins (consistent with the system's existing concurrency posture); acceptable for display context — do not add locking.
+  - [x] Pass the post-update character snapshot + `changes` into `createCharacterEventPayload` for `character_updated`; pass the created/deleted character snapshot for `character_created` / `character_deleted`.
+- [x] **Task 4 — Lambda wiring: notifications + log SNS legs with degraded mode (AC: 1, 2, 4)**
+  - [x] In `backend/character-service/src/lambda.ts`, build the notifications leg from the existing `ROOM_CHARACTER_EVENTS_TOPIC_ARN` env var (unchanged — see Project Structure Notes) and a new log leg from `LOG_TOPIC_ARN`.
+  - [x] If `LOG_TOPIC_ARN` is absent/empty: `console.warn` once at bootstrap (degraded — log history will be absent) and use `NoopCharacterEventPublisher` for the log leg. Service must NOT throw or `process.exit`.
+  - [x] Compose both legs into the fan-out publisher and pass it to `buildCharacterApp`. Keep the existing bootstrap-config `console.info` and add `logTopicArnConfigured: Boolean(process.env.LOG_TOPIC_ARN)`.
+- [x] **Task 5 — Local server wiring: notifications + log Redis legs with degraded mode (AC: 1, 2, 4)**
+  - [x] In `backend/character-service/src/index.ts`, keep the existing notifications Redis leg (`CHARACTER_EVENTS_REDIS_URL` + `ROOM_CHARACTER_EVENTS_CHANNEL`, default `room-character-events`). Add a log Redis leg on a new channel env `ROOM_LOG_EVENTS_CHANNEL` (default `room-log-events`) using the same `CHARACTER_EVENTS_REDIS_URL`.
+  - [x] If `CHARACTER_EVENTS_REDIS_URL` is unset (already the Noop path) OR the log channel cannot be configured, `console.warn` once and use `NoopCharacterEventPublisher` for the log leg. Do not crash.
+  - [x] Compose both legs into the fan-out publisher; extend the existing bootstrap `console.info` with `logEventsChannel` + `logConfigured`.
+- [x] **Task 6 — Tests (AC: 1, 2, 3, 4, 5)**
+  - [x] `publisher.test.ts`: fan-out calls every leg; uses `Promise.allSettled` (assert both legs invoked even when one rejects); a rejecting leg does not cause the composite `publish` to reject; `createCharacterEventPayload` produces the enriched superset incl. `changes` for updates and omits `changes` for create/delete; legacy fields preserved exactly (regression guard for AC 5).
+  - [x] `lambda.test.ts`: both env vars set → composite with two SNS legs; `LOG_TOPIC_ARN` absent → startup `console.warn` + notifications leg still active + handler still boots and responds (no throw); follow existing `vi.hoisted` mock + `delete process.env.*` reset pattern, and add `delete process.env.LOG_TOPIC_ARN` to `beforeEach`.
+  - [x] `app.test.ts`: create/delete publish a payload containing `character` display context; update publishes `changes` with correct `prev → next` for changed fields only; a publisher that throws does NOT change the HTTP status (create still `201`, update `200`, delete `204`) — regression guard for AC 4. Inject a spy publisher via the existing `createApp(model, { publisher })` option.
+  - [x] Add/extend a `findById` test in `service.test.ts` if the existing model-mapping tests assert method coverage there.
+  - [x] Run backend test + coverage gate: `cd backend/character-service && npm test` (Vitest 3.2.4, v8 coverage, 70% line floor — do not lower).
 
 ## Dev Notes
 
@@ -150,9 +150,34 @@ Use `Promise.allSettled` over the legs. Never sequential `await publishA; await 
 ## Dev Agent Record
 
 ### Agent Model Used
+GPT-5
 
 ### Debug Log References
+- `npm test -- --run character-service/src/publisher.test.ts character-service/src/app.test.ts character-service/src/lambda.test.ts character-service/src/service.test.ts` — passed (19 tests).
+- `npm test` from `backend/` — passed (21 files, 140 tests).
+- `npm run typecheck` from `backend/` — passed all backend workspaces.
+- `npm run test:coverage` from `backend/` — passed (all files line coverage 85.2%, above 70% floor).
 
 ### Completion Notes List
+- Added an additive character event payload superset: legacy notification fields are unchanged, canonical mirror fields are present, and create/update/delete events include display-ready character context.
+- Added update diff capture using a read-before-update model call; `changes` contains only normalized fields that actually changed and is emitted only for `character_updated`.
+- Added a reusable fan-out publisher that runs notification and log legs with `Promise.allSettled`, logs failed legs, and never propagates publish failures into request handling.
+- Wired Lambda to publish to existing `ROOM_CHARACTER_EVENTS_TOPIC_ARN` plus optional `LOG_TOPIC_ARN`; missing `LOG_TOPIC_ARN` warns once and degrades to a noop log leg.
+- Wired local character-service startup to publish notifications and log events through Redis, adding `ROOM_LOG_EVENTS_CHANNEL` with default `room-log-events`; missing Redis warns once and degrades to noop log publishing.
+- Updated backend local docs/config for the new room-history log channel. SAM/IAM `LOG_TOPIC_ARN` wiring remains deferred to Story 6.2 when the log topic resource exists, avoiding dangling infra references.
 
 ### File List
+- backend/README.md
+- backend/character-service/src/app.test.ts
+- backend/character-service/src/app.ts
+- backend/character-service/src/index.ts
+- backend/character-service/src/lambda.test.ts
+- backend/character-service/src/lambda.ts
+- backend/character-service/src/publisher.test.ts
+- backend/character-service/src/publisher.ts
+- backend/character-service/src/service.test.ts
+- backend/character-service/src/service.ts
+- backend/docker-compose.local.yml
+
+### Change Log
+- 2026-05-20 — Implemented Story 6.1 character event fan-out and enriched room-history payloads; added tests, docs, and local env wiring.

--- a/_bmad-output/implementation-artifacts/6-1-character-events-are-published-for-room-history.md
+++ b/_bmad-output/implementation-artifacts/6-1-character-events-are-published-for-room-history.md
@@ -1,6 +1,6 @@
 # Story 6.1: Character Events Are Published for Room History
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -49,6 +49,22 @@ so that the group can understand how the session state changed over time.
   - [x] `app.test.ts`: create/delete publish a payload containing `character` display context; update publishes `changes` with correct `prev → next` for changed fields only; a publisher that throws does NOT change the HTTP status (create still `201`, update `200`, delete `204`) — regression guard for AC 4. Inject a spy publisher via the existing `createApp(model, { publisher })` option.
   - [x] Add/extend a `findById` test in `service.test.ts` if the existing model-mapping tests assert method coverage there.
   - [x] Run backend test + coverage gate: `cd backend/character-service && npm test` (Vitest 3.2.4, v8 coverage, 70% line floor — do not lower).
+
+### Review Findings
+
+- [x] [Review][Patch] Surface per-leg transport in bootstrap log — Composite `publisher.constructor.name` now always logs `'FanoutCharacterEventPublisher'`, hiding which leg is SNS vs Noop. Add `notificationsPublisher`/`logPublisher` constructor names to the bootstrap `console.info`. [backend/character-service/src/lambda.ts:30-35, backend/character-service/src/index.ts:30-37]
+- [x] [Review][Patch] PATCH `findById` errors leak to HTTP 500 — pre-update read is enrichment-only but its throw bypasses the publish swallow and reaches `next(error)`. Wrap in try/catch and degrade to `previousCharacter = null`. [backend/character-service/src/app.ts:327]
+- [x] [Review][Patch] Fan-out swallows only async rejections, not sync throws — `Promise.allSettled(legs.map(l => l.publisher.publish(p)))` rejects the whole composite if any leg's `publish` synchronously throws before returning a promise. Wrap each invocation in `Promise.resolve().then(() => leg.publisher.publish(payload))`. [backend/character-service/src/publisher.ts:38-53]
+- [x] [Review][Patch] `changes.next` uses raw `updates[key]` instead of post-persistence value — trim/normalization asymmetry: `prev` comes from the stored doc but `next` is the request payload, so legacy untrimmed DB values or schema-side normalizers can produce false changes (or miss real ones). Compute `next` via `getComparableCharacterValue(updatedCharacter, key)` symmetrically with `prev`. [backend/character-service/src/app.ts:137-156]
+- [x] [Review][Patch] `mapCharacter` empty-string id fallback hides corrupt docs — `id: character.id || character._id?.toString() || ''` silently emits `event_body.characterId: ''` when both are missing. Throw or reject instead of synthesizing an empty id. [backend/character-service/src/service.ts]
+- [x] [Review][Patch] Whitespace env vars treated as configured — `Boolean(' ')` and similar whitespace strings skip the degraded-mode warning and instantiate broken SNS/Redis clients. Trim before the conditional. [backend/character-service/src/lambda.ts:8-19, backend/character-service/src/index.ts:7-19]
+- [x] [Review][Patch] Local degraded-mode warning misnames the cause — when `CHARACTER_EVENTS_REDIS_URL` is unset, both notifications **and** log legs become Noop, but the warning mentions only "room-history logging is disabled." Reword (or split into two conditionals) to surface that notifications is also disabled. [backend/character-service/src/index.ts:14-16]
+- [x] [Review][Patch] `logConfigured: Boolean(redisUrl)` is a misleading mirror of `redisConfigured` — the log leg's configured-ness should reflect the actual log publisher (e.g., `!(logPublisher instanceof NoopCharacterEventPublisher)`), not the shared Redis URL. [backend/character-service/src/index.ts:36]
+- [x] [Review][Patch] `console.error` spies in app.test.ts are not restored — `vi.spyOn(console, 'error').mockImplementation(...)` in the two "publishing fails" tests leaks across tests in the same file. Add `mockRestore()` or move to `afterEach`. [backend/character-service/src/app.test.ts]
+- [x] [Review][Patch] Publish-failure tests do not assert the publisher was actually called — only HTTP status is checked, so a regression that skipped publishing entirely on the failure path would still pass. Add `expect(publisher.publish).toHaveBeenCalled()`. [backend/character-service/src/app.test.ts]
+- [x] [Review][Defer] PATCH does not validate `level`/`power`/`class`/`race`/`gender`/`userId` — pre-existing input-validation gap; clients can persist arbitrary types and ship them through `changes`. [backend/character-service/src/app.ts:292, 300-304] — deferred, pre-existing
+- [x] [Review][Defer] `RedisCharacterEventPublisher.ensureConnected` does not recover from post-connect disconnects — `isOpen` flips false and the cached `connectPromise` is stale. [backend/character-service/src/publisher.ts:117-134] — deferred, pre-existing
+- [x] [Review][Defer] `correlationId` plumbed through types but never extracted from request headers — published payload has `correlationId: undefined` for every event. [backend/character-service/src/app.ts:267-274, 344-351, 385-391] — deferred, pre-existing
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,3 +1,9 @@
+## Deferred from: code review of 6-1-character-events-are-published-for-room-history (2026-05-20)
+
+- PATCH does not validate `level`/`power`/`class`/`race`/`gender`/`userId` — pre-existing input-validation gap; only `name`/`avatarId`/`color` are validated, so clients can persist arbitrary types and ship them through `changes`. [backend/character-service/src/app.ts:292, 300-304]
+- `RedisCharacterEventPublisher.ensureConnected` does not recover from post-connect disconnects — `isOpen` flips false on error but the cached `connectPromise` is never reset; subsequent publishes silently fail through `Promise.allSettled`. [backend/character-service/src/publisher.ts:117-134]
+- `correlationId` plumbed through `CharacterEventPayload` and `createCharacterEventPayload` but never extracted from request headers (`x-correlation-id`/`x-request-id`) — every event ships with `correlationId: undefined`, leaving downstream consumers with no request trace. [backend/character-service/src/app.ts:267-274, 344-351, 385-391]
+
 ## Deferred from: code review of 5-6-conclude-a-battle (2026-05-20)
 
 - Frontend `apiRequest` retries 5xx on conclude — can surface phantom 409 [frontend/api/battles.ts:82-87]. If a 5xx is delivered after the server committed, the retry returns 409 and the user briefly sees "Battle is not active" before the modal auto-dismisses on the refetch. Worth a follow-up to either skip retries on conclude or special-case the "already-concluded-by-self" race.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-26T17:42:48Z
-# last_updated: 2026-03-26T19:34:57Z
+# last_updated: 2026-05-20T17:45:00Z
 # project: munch-helper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-20T16:30:00Z
+last_updated: 2026-05-20T17:45:00Z
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -89,7 +89,7 @@ development_status:
   epic-5-retrospective: optional
 
   epic-6: in-progress
-  6-1-character-events-are-published-for-room-history: ready-for-dev
+  6-1-character-events-are-published-for-room-history: review
   6-2-published-events-are-stored-and-readable-in-room-history: ready-for-dev
   6-3-battle-lifecycle-events-are-published-for-room-history: ready-for-dev
   6-4-room-history-api-returns-paginated-events: ready-for-dev

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-26T17:42:48Z
-# last_updated: 2026-05-20T17:45:00Z
+# last_updated: 2026-05-20T22:01:00Z
 # project: munch-helper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -89,7 +89,7 @@ development_status:
   epic-5-retrospective: optional
 
   epic-6: in-progress
-  6-1-character-events-are-published-for-room-history: review
+  6-1-character-events-are-published-for-room-history: done
   6-2-published-events-are-stored-and-readable-in-room-history: ready-for-dev
   6-3-battle-lifecycle-events-are-published-for-room-history: ready-for-dev
   6-4-room-history-api-returns-paginated-events: ready-for-dev

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,6 +19,7 @@ Implemented in this phase:
 - Battle management (`GET /battles?roomId=...&status=active`, `POST /battles`, `PATCH /battles/:id`)
 - Room service synchronous call to character service on create/join flow.
 - Room notifications over WebSocket (`character_created`, `character_updated`, `character_deleted`).
+- Character events are also published to the room-history log target when `LOG_TOPIC_ARN` (Lambda) or `ROOM_LOG_EVENTS_CHANNEL` (local Redis, default `room-log-events`) is configured.
 
 Transport by environment:
 

--- a/backend/character-service/src/app.test.ts
+++ b/backend/character-service/src/app.test.ts
@@ -6,10 +6,35 @@ function buildCharacterModel(): CharacterModelLike {
   return {
     find: vi.fn(),
     create: vi.fn(),
+    findById: vi.fn(),
     findByIdAndUpdate: vi.fn(),
     findByIdAndDelete: vi.fn()
   };
 }
+
+const buildCharacter = (overrides: Partial<ReturnType<typeof buildBaseCharacter>> = {}) => ({
+  ...buildBaseCharacter(),
+  ...overrides
+});
+
+const buildBaseCharacter = () => {
+  const now = new Date('2026-03-13T00:00:00.000Z');
+  return {
+    id: 'c1',
+    roomId: 'r1',
+    userId: 'u1',
+    name: 'Hero',
+    avatarId: 1,
+    color: '#AABBCC',
+    level: 1,
+    power: 0,
+    class: '',
+    race: '',
+    gender: '',
+    createdAt: now,
+    updatedAt: now
+  };
+};
 
 describe('character-service app', () => {
   it('lists characters by roomId', async () => {
@@ -45,6 +70,7 @@ describe('character-service app', () => {
 
   it('creates character', async () => {
     const model = buildCharacterModel();
+    const publisher = { publish: vi.fn().mockResolvedValue(undefined) };
     const now = new Date();
     vi.mocked(model.create).mockResolvedValue({
       id: 'c2',
@@ -62,13 +88,37 @@ describe('character-service app', () => {
       updatedAt: now
     });
 
-    const app = createApp(model);
+    const app = createApp(model, { publisher });
     const response = await request(app)
       .post('/characters')
       .send({ roomId: 'r2', userId: 'u2', name: 'Mage', avatarId: 4, color: '#00aaff' });
 
     expect(response.status).toBe(201);
     expect(response.body).toMatchObject({ id: 'c2', roomId: 'r2', name: 'Mage', color: '#00AAFF' });
+    expect(publisher.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'character_created',
+        eventType: 'character_created',
+        roomId: 'r2',
+        event_body: { characterId: 'c2' },
+        actorId: 'c2',
+        character: { id: 'c2', name: 'Mage', avatarId: 4, color: '#00AAFF' }
+      })
+    );
+  });
+
+  it('keeps create response successful when publishing fails', async () => {
+    const model = buildCharacterModel();
+    const publisher = { publish: vi.fn().mockRejectedValue(new Error('publish failed')) };
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(model.create).mockResolvedValue(buildCharacter({ id: 'c2', roomId: 'r2' }));
+
+    const app = createApp(model, { publisher });
+    const response = await request(app)
+      .post('/characters')
+      .send({ roomId: 'r2', userId: 'u2', name: 'Mage', avatarId: 4, color: '#00aaff' });
+
+    expect(response.status).toBe(201);
   });
 
   it('rejects create without color', async () => {
@@ -83,6 +133,7 @@ describe('character-service app', () => {
 
   it('deletes unassociated character', async () => {
     const model = buildCharacterModel();
+    const publisher = { publish: vi.fn().mockResolvedValue(undefined) };
     const now = new Date();
     vi.mocked(model.findByIdAndDelete).mockResolvedValue({
       id: 'c3',
@@ -100,10 +151,20 @@ describe('character-service app', () => {
       updatedAt: now
     });
 
-    const app = createApp(model);
+    const app = createApp(model, { publisher });
     const response = await request(app).delete('/characters/c3');
 
     expect(response.status).toBe(204);
+    expect(publisher.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'character_deleted',
+        eventType: 'character_deleted',
+        roomId: 'r3',
+        event_body: { characterId: 'c3' },
+        actorId: 'c3',
+        character: { id: 'c3', name: 'Rogue', avatarId: 2, color: '#FFFFFF' }
+      })
+    );
   });
 
   it('deletes associated character', async () => {
@@ -129,5 +190,42 @@ describe('character-service app', () => {
     const response = await request(app).delete('/characters/c4');
 
     expect(response.status).toBe(204);
+  });
+
+  it('publishes update changes for changed fields only', async () => {
+    const model = buildCharacterModel();
+    const publisher = { publish: vi.fn().mockResolvedValue(undefined) };
+    vi.mocked(model.findById).mockResolvedValue(buildCharacter({ id: 'c5', name: 'Hero', level: 1, color: '#AABBCC' }));
+    vi.mocked(model.findByIdAndUpdate).mockResolvedValue(buildCharacter({ id: 'c5', name: 'Heroic', level: 2, color: '#AABBCC' }));
+
+    const app = createApp(model, { publisher });
+    const response = await request(app).patch('/characters/c5').send({ name: ' Heroic ', level: 2, color: '#aabbcc' });
+
+    expect(response.status).toBe(200);
+    expect(model.findById).toHaveBeenCalledWith('c5');
+    expect(publisher.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'character_updated',
+        character: { id: 'c5', name: 'Heroic', avatarId: 1, color: '#AABBCC' },
+        changes: {
+          name: { prev: 'Hero', next: 'Heroic' },
+          level: { prev: 1, next: 2 }
+        }
+      })
+    );
+  });
+
+  it('keeps update and delete responses successful when publishing fails', async () => {
+    const model = buildCharacterModel();
+    const publisher = { publish: vi.fn().mockRejectedValue(new Error('publish failed')) };
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(model.findById).mockResolvedValue(buildCharacter({ id: 'c6', level: 1 }));
+    vi.mocked(model.findByIdAndUpdate).mockResolvedValue(buildCharacter({ id: 'c6', level: 2 }));
+    vi.mocked(model.findByIdAndDelete).mockResolvedValue(buildCharacter({ id: 'c6' }));
+
+    const app = createApp(model, { publisher });
+
+    await expect(request(app).patch('/characters/c6').send({ level: 2 })).resolves.toMatchObject({ status: 200 });
+    await expect(request(app).delete('/characters/c6')).resolves.toMatchObject({ status: 204 });
   });
 });

--- a/backend/character-service/src/app.test.ts
+++ b/backend/character-service/src/app.test.ts
@@ -110,7 +110,7 @@ describe('character-service app', () => {
   it('keeps create response successful when publishing fails', async () => {
     const model = buildCharacterModel();
     const publisher = { publish: vi.fn().mockRejectedValue(new Error('publish failed')) };
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     vi.mocked(model.create).mockResolvedValue(buildCharacter({ id: 'c2', roomId: 'r2' }));
 
     const app = createApp(model, { publisher });
@@ -119,6 +119,8 @@ describe('character-service app', () => {
       .send({ roomId: 'r2', userId: 'u2', name: 'Mage', avatarId: 4, color: '#00aaff' });
 
     expect(response.status).toBe(201);
+    expect(publisher.publish).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
   });
 
   it('rejects create without color', async () => {
@@ -218,7 +220,7 @@ describe('character-service app', () => {
   it('keeps update and delete responses successful when publishing fails', async () => {
     const model = buildCharacterModel();
     const publisher = { publish: vi.fn().mockRejectedValue(new Error('publish failed')) };
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     vi.mocked(model.findById).mockResolvedValue(buildCharacter({ id: 'c6', level: 1 }));
     vi.mocked(model.findByIdAndUpdate).mockResolvedValue(buildCharacter({ id: 'c6', level: 2 }));
     vi.mocked(model.findByIdAndDelete).mockResolvedValue(buildCharacter({ id: 'c6' }));
@@ -227,5 +229,7 @@ describe('character-service app', () => {
 
     await expect(request(app).patch('/characters/c6').send({ level: 2 })).resolves.toMatchObject({ status: 200 });
     await expect(request(app).delete('/characters/c6')).resolves.toMatchObject({ status: 204 });
+    expect(publisher.publish).toHaveBeenCalledTimes(2);
+    errorSpy.mockRestore();
   });
 });

--- a/backend/character-service/src/app.ts
+++ b/backend/character-service/src/app.ts
@@ -26,6 +26,7 @@ export interface CharacterLike {
 export interface CharacterModelLike {
   find: (query: { roomId: string }) => { sort: (sortBy: { createdAt: 1 }) => Promise<CharacterLike[]> };
   create: (payload: Omit<CharacterLike, 'id' | 'createdAt' | 'updatedAt'>) => Promise<CharacterLike>;
+  findById: (id: string) => Promise<CharacterLike | null>;
   findByIdAndUpdate: (
     id: string,
     updates: Record<string, unknown>,
@@ -114,6 +115,45 @@ export function createApp(characterModel: CharacterModelLike, options: CreateCha
     createdAt: character.createdAt,
     updatedAt: character.updatedAt
   });
+
+  const toPayloadCharacter = (character: CharacterLike) => {
+    const responseCharacter = toResponseCharacter(character);
+    return {
+      id: responseCharacter.id,
+      name: responseCharacter.name,
+      avatarId: responseCharacter.avatarId,
+      color: responseCharacter.color
+    };
+  };
+
+  const getComparableCharacterValue = (character: CharacterLike, key: string): unknown => {
+    if (key === 'color') {
+      return getCharacterColor(character);
+    }
+
+    return character[key as keyof CharacterLike];
+  };
+
+  const buildCharacterChanges = (
+    previousCharacter: CharacterLike | null,
+    updatedCharacter: CharacterLike,
+    updates: Record<string, unknown>
+  ): Record<string, { prev: unknown; next: unknown }> | undefined => {
+    if (!previousCharacter) {
+      return undefined;
+    }
+
+    const changes = Object.entries(updates).reduce<Record<string, { prev: unknown; next: unknown }>>((result, [key, next]) => {
+      const prev = getComparableCharacterValue(previousCharacter, key);
+      const normalizedNext = key === 'color' ? getCharacterColor(updatedCharacter) : next;
+      if (!Object.is(prev, normalizedNext)) {
+        result[key] = { prev, next: normalizedNext };
+      }
+      return result;
+    }, {});
+
+    return Object.keys(changes).length > 0 ? changes : undefined;
+  };
 
   const toParamString = (value: string | string[] | undefined): string => {
     if (Array.isArray(value)) {
@@ -229,7 +269,7 @@ export function createApp(characterModel: CharacterModelLike, options: CreateCha
           createCharacterEventPayload({
             event: 'character_created',
             roomId: character.roomId,
-            characterId: character.id
+            character: toPayloadCharacter(character)
           })
         );
         console.info('[character-service] character_created event queued', {
@@ -284,6 +324,7 @@ export function createApp(characterModel: CharacterModelLike, options: CreateCha
         updates.color = normalizeHexColor(updates.color);
       }
 
+      const previousCharacter = await characterModel.findById(characterId);
       const character = await characterModel.findByIdAndUpdate(characterId, updates, {
         new: true,
         runValidators: true
@@ -304,7 +345,8 @@ export function createApp(characterModel: CharacterModelLike, options: CreateCha
           createCharacterEventPayload({
             event: 'character_updated',
             roomId: character.roomId,
-            characterId: character.id
+            character: toPayloadCharacter(character),
+            changes: buildCharacterChanges(previousCharacter, character, updates)
           })
         );
         console.info('[character-service] character_updated event queued', {
@@ -344,7 +386,7 @@ export function createApp(characterModel: CharacterModelLike, options: CreateCha
           createCharacterEventPayload({
             event: 'character_deleted',
             roomId: character.roomId,
-            characterId: character.id
+            character: toPayloadCharacter(character)
           })
         );
         console.info('[character-service] character_deleted event queued', {

--- a/backend/character-service/src/app.ts
+++ b/backend/character-service/src/app.ts
@@ -143,11 +143,11 @@ export function createApp(characterModel: CharacterModelLike, options: CreateCha
       return undefined;
     }
 
-    const changes = Object.entries(updates).reduce<Record<string, { prev: unknown; next: unknown }>>((result, [key, next]) => {
+    const changes = Object.keys(updates).reduce<Record<string, { prev: unknown; next: unknown }>>((result, key) => {
       const prev = getComparableCharacterValue(previousCharacter, key);
-      const normalizedNext = key === 'color' ? getCharacterColor(updatedCharacter) : next;
-      if (!Object.is(prev, normalizedNext)) {
-        result[key] = { prev, next: normalizedNext };
+      const next = getComparableCharacterValue(updatedCharacter, key);
+      if (!Object.is(prev, next)) {
+        result[key] = { prev, next };
       }
       return result;
     }, {});
@@ -324,7 +324,16 @@ export function createApp(characterModel: CharacterModelLike, options: CreateCha
         updates.color = normalizeHexColor(updates.color);
       }
 
-      const previousCharacter = await characterModel.findById(characterId);
+      let previousCharacter: CharacterLike | null = null;
+      try {
+        previousCharacter = await characterModel.findById(characterId);
+      } catch (error) {
+        // Pre-update read is enrichment-only (for changes diff); a failure must not abort the update.
+        console.error('[character-service] failed to read previous character for changes diff', {
+          characterId,
+          error
+        });
+      }
       const character = await characterModel.findByIdAndUpdate(characterId, updates, {
         new: true,
         runValidators: true

--- a/backend/character-service/src/index.ts
+++ b/backend/character-service/src/index.ts
@@ -4,7 +4,7 @@ import { FanoutCharacterEventPublisher, NoopCharacterEventPublisher, RedisCharac
 import { buildCharacterApp } from './service';
 
 dotenv.config();
-const redisUrl = process.env.CHARACTER_EVENTS_REDIS_URL;
+const redisUrl = process.env.CHARACTER_EVENTS_REDIS_URL?.trim();
 const eventsChannel = process.env.ROOM_CHARACTER_EVENTS_CHANNEL || 'room-character-events';
 const logEventsChannel = process.env.ROOM_LOG_EVENTS_CHANNEL || 'room-log-events';
 const notificationsPublisher = redisUrl
@@ -15,7 +15,9 @@ const logPublisher = redisUrl
   : new NoopCharacterEventPublisher();
 
 if (!redisUrl) {
-  console.warn('[character-service] CHARACTER_EVENTS_REDIS_URL is not configured; room-history logging is disabled');
+  console.warn(
+    '[character-service] CHARACTER_EVENTS_REDIS_URL is not configured; both notifications publishing and room-history logging are disabled'
+  );
 }
 
 const publisher = new FanoutCharacterEventPublisher([
@@ -30,10 +32,12 @@ console.info('[character-service] local bootstrap config', {
   port,
   mongoUri,
   publisher: publisher.constructor.name,
+  notificationsPublisher: notificationsPublisher.constructor.name,
+  logPublisher: logPublisher.constructor.name,
   eventsChannel,
   redisConfigured: Boolean(redisUrl),
   logEventsChannel,
-  logConfigured: Boolean(redisUrl)
+  logConfigured: !(logPublisher instanceof NoopCharacterEventPublisher)
 });
 
 connectToMongo(mongoUri)

--- a/backend/character-service/src/index.ts
+++ b/backend/character-service/src/index.ts
@@ -1,14 +1,27 @@
 import dotenv from 'dotenv';
 import { connectToMongo } from './db';
-import { NoopCharacterEventPublisher, RedisCharacterEventPublisher } from './publisher';
+import { FanoutCharacterEventPublisher, NoopCharacterEventPublisher, RedisCharacterEventPublisher } from './publisher';
 import { buildCharacterApp } from './service';
 
 dotenv.config();
 const redisUrl = process.env.CHARACTER_EVENTS_REDIS_URL;
 const eventsChannel = process.env.ROOM_CHARACTER_EVENTS_CHANNEL || 'room-character-events';
-const publisher = redisUrl
+const logEventsChannel = process.env.ROOM_LOG_EVENTS_CHANNEL || 'room-log-events';
+const notificationsPublisher = redisUrl
   ? new RedisCharacterEventPublisher(redisUrl, eventsChannel)
   : new NoopCharacterEventPublisher();
+const logPublisher = redisUrl
+  ? new RedisCharacterEventPublisher(redisUrl, logEventsChannel)
+  : new NoopCharacterEventPublisher();
+
+if (!redisUrl) {
+  console.warn('[character-service] CHARACTER_EVENTS_REDIS_URL is not configured; room-history logging is disabled');
+}
+
+const publisher = new FanoutCharacterEventPublisher([
+  { target: 'notifications', publisher: notificationsPublisher },
+  { target: 'log', publisher: logPublisher }
+]);
 const app = buildCharacterApp({ publisher });
 const port = Number(process.env.CHARACTER_SERVICE_PORT || 8083);
 const mongoUri = process.env.CHARACTER_MONGO_URI || 'mongodb://localhost:27017/munch_character_service';
@@ -18,7 +31,9 @@ console.info('[character-service] local bootstrap config', {
   mongoUri,
   publisher: publisher.constructor.name,
   eventsChannel,
-  redisConfigured: Boolean(redisUrl)
+  redisConfigured: Boolean(redisUrl),
+  logEventsChannel,
+  logConfigured: Boolean(redisUrl)
 });
 
 connectToMongo(mongoUri)

--- a/backend/character-service/src/lambda.test.ts
+++ b/backend/character-service/src/lambda.test.ts
@@ -16,6 +16,9 @@ vi.mock('./service', () => ({
 }));
 
 vi.mock('./publisher', () => ({
+  FanoutCharacterEventPublisher: class FanoutCharacterEventPublisher {
+    constructor(public legs: unknown[]) { }
+  },
   NoopCharacterEventPublisher: class NoopCharacterEventPublisher { },
   SnsCharacterEventPublisher: class SnsCharacterEventPublisher {
     constructor(public client: unknown, public topicArn: string) { }
@@ -44,12 +47,14 @@ describe('character-service lambda', () => {
     delete process.env.ROUTE_PREFIX;
     delete process.env.CHARACTER_MONGO_URI;
     delete process.env.ROOM_CHARACTER_EVENTS_TOPIC_ARN;
+    delete process.env.LOG_TOPIC_ARN;
   });
 
-  it('boots the lambda with sns publishing when a topic arn is configured', async () => {
+  it('boots the lambda with sns publishing for notifications and logs when topic arns are configured', async () => {
     process.env.ROUTE_PREFIX = '/prod';
     process.env.CHARACTER_MONGO_URI = 'mongodb://mongo/character';
     process.env.ROOM_CHARACTER_EVENTS_TOPIC_ARN = 'arn:aws:sns:topic';
+    process.env.LOG_TOPIC_ARN = 'arn:aws:sns:log-topic';
     mockServerHandler.mockResolvedValueOnce({ statusCode: 200 });
 
     const { handler } = await import('./lambda.js');
@@ -57,10 +62,51 @@ describe('character-service lambda', () => {
 
     expect(mockBuildCharacterApp).toHaveBeenCalledWith({
       routePrefix: '/prod',
-      publisher: expect.objectContaining({ topicArn: 'arn:aws:sns:topic' }),
+      publisher: expect.objectContaining({
+        legs: [
+          expect.objectContaining({
+            target: 'notifications',
+            publisher: expect.objectContaining({ topicArn: 'arn:aws:sns:topic' }),
+          }),
+          expect.objectContaining({
+            target: 'log',
+            publisher: expect.objectContaining({ topicArn: 'arn:aws:sns:log-topic' }),
+          }),
+        ],
+      }),
     });
     expect(mockConnectToMongo).toHaveBeenCalledWith('mongodb://mongo/character');
     expect(mockServerHandler).toHaveBeenCalledWith({ path: '/characters' }, { requestId: 'ctx' });
     expect(response).toEqual({ statusCode: 200 });
+  });
+
+  it('boots with a noop log publisher and warns when LOG_TOPIC_ARN is absent', async () => {
+    process.env.ROOM_CHARACTER_EVENTS_TOPIC_ARN = 'arn:aws:sns:topic';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockServerHandler.mockResolvedValueOnce({ statusCode: 200 });
+
+    const { handler } = await import('./lambda.js');
+    const response = await handler({ path: '/health' }, {});
+
+    expect(warn).toHaveBeenCalledWith(
+      '[character-service] LOG_TOPIC_ARN is not configured; room-history logging is disabled'
+    );
+    expect(mockBuildCharacterApp).toHaveBeenCalledWith({
+      routePrefix: '/',
+      publisher: expect.objectContaining({
+        legs: [
+          expect.objectContaining({
+            target: 'notifications',
+            publisher: expect.objectContaining({ topicArn: 'arn:aws:sns:topic' }),
+          }),
+          expect.objectContaining({
+            target: 'log',
+            publisher: expect.any(Object),
+          }),
+        ],
+      }),
+    });
+    expect(response).toEqual({ statusCode: 200 });
+    warn.mockRestore();
   });
 });

--- a/backend/character-service/src/lambda.ts
+++ b/backend/character-service/src/lambda.ts
@@ -1,14 +1,27 @@
 import { SNSClient } from '@aws-sdk/client-sns';
 import serverlessExpress from '@codegenie/serverless-express';
 import { connectToMongo } from './db';
-import { NoopCharacterEventPublisher, SnsCharacterEventPublisher } from './publisher';
+import { FanoutCharacterEventPublisher, NoopCharacterEventPublisher, SnsCharacterEventPublisher } from './publisher';
 import { buildCharacterApp } from './service';
 
 const routePrefix = process.env.ROUTE_PREFIX || '/';
 const topicArn = process.env.ROOM_CHARACTER_EVENTS_TOPIC_ARN;
-const publisher = topicArn
+const logTopicArn = process.env.LOG_TOPIC_ARN;
+const notificationsPublisher = topicArn
   ? new SnsCharacterEventPublisher(new SNSClient({}), topicArn)
   : new NoopCharacterEventPublisher();
+const logPublisher = logTopicArn
+  ? new SnsCharacterEventPublisher(new SNSClient({}), logTopicArn)
+  : new NoopCharacterEventPublisher();
+
+if (!logTopicArn) {
+  console.warn('[character-service] LOG_TOPIC_ARN is not configured; room-history logging is disabled');
+}
+
+const publisher = new FanoutCharacterEventPublisher([
+  { target: 'notifications', publisher: notificationsPublisher },
+  { target: 'log', publisher: logPublisher }
+]);
 const app = buildCharacterApp({ routePrefix, publisher });
 const mongoUri = process.env.CHARACTER_MONGO_URI || 'mongodb://localhost:27017/munch_character_service';
 
@@ -16,7 +29,8 @@ console.info('[character-service] lambda bootstrap config', {
   routePrefix,
   mongoUri,
   publisher: publisher.constructor.name,
-  topicArnConfigured: Boolean(topicArn)
+  topicArnConfigured: Boolean(topicArn),
+  logTopicArnConfigured: Boolean(logTopicArn)
 });
 
 const server = serverlessExpress({ app });

--- a/backend/character-service/src/lambda.ts
+++ b/backend/character-service/src/lambda.ts
@@ -5,8 +5,8 @@ import { FanoutCharacterEventPublisher, NoopCharacterEventPublisher, SnsCharacte
 import { buildCharacterApp } from './service';
 
 const routePrefix = process.env.ROUTE_PREFIX || '/';
-const topicArn = process.env.ROOM_CHARACTER_EVENTS_TOPIC_ARN;
-const logTopicArn = process.env.LOG_TOPIC_ARN;
+const topicArn = process.env.ROOM_CHARACTER_EVENTS_TOPIC_ARN?.trim();
+const logTopicArn = process.env.LOG_TOPIC_ARN?.trim();
 const notificationsPublisher = topicArn
   ? new SnsCharacterEventPublisher(new SNSClient({}), topicArn)
   : new NoopCharacterEventPublisher();
@@ -29,6 +29,8 @@ console.info('[character-service] lambda bootstrap config', {
   routePrefix,
   mongoUri,
   publisher: publisher.constructor.name,
+  notificationsPublisher: notificationsPublisher.constructor.name,
+  logPublisher: logPublisher.constructor.name,
   topicArnConfigured: Boolean(topicArn),
   logTopicArnConfigured: Boolean(logTopicArn)
 });

--- a/backend/character-service/src/publisher.test.ts
+++ b/backend/character-service/src/publisher.test.ts
@@ -20,6 +20,7 @@ vi.mock('redis', () => ({
 
 import {
   createCharacterEventPayload,
+  FanoutCharacterEventPublisher,
   NoopCharacterEventPublisher,
   RedisCharacterEventPublisher,
   SnsCharacterEventPublisher,
@@ -34,28 +35,106 @@ describe('character publisher', () => {
     mockCreateClient.mockClear();
   });
 
-  it('creates a serialized character event payload', () => {
+  it('creates an enriched serialized character event payload', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-13T00:00:00.000Z'));
 
     const payload = createCharacterEventPayload({
       event: 'character_created',
       roomId: 'ROOM01',
-      characterId: 'char-1',
+      character: {
+        id: 'char-1',
+        name: 'Thief',
+        avatarId: 3,
+        color: '#AABBCC',
+      },
       correlationId: 'corr-1',
     });
 
     expect(payload).toEqual({
       event: 'character_created',
+      eventType: 'character_created',
       roomId: 'ROOM01',
       event_body: {
         characterId: 'char-1',
       },
+      actorId: 'char-1',
       emittedAt: '2026-03-13T00:00:00.000Z',
+      occurredAt: '2026-03-13T00:00:00.000Z',
       correlationId: 'corr-1',
+      character: {
+        id: 'char-1',
+        name: 'Thief',
+        avatarId: 3,
+        color: '#AABBCC',
+      },
     });
 
     vi.useRealTimers();
+  });
+
+  it('adds update changes and omits changes for create/delete payloads', () => {
+    const updated = createCharacterEventPayload({
+      event: 'character_updated',
+      roomId: 'ROOM01',
+      character: {
+        id: 'char-1',
+        name: 'Thief',
+        avatarId: 3,
+        color: '#AABBCC',
+      },
+      changes: {
+        level: { prev: 1, next: 2 },
+      },
+    });
+
+    const deleted = createCharacterEventPayload({
+      event: 'character_deleted',
+      roomId: 'ROOM01',
+      character: {
+        id: 'char-1',
+        name: 'Thief',
+        avatarId: 3,
+        color: '#AABBCC',
+      },
+      changes: {
+        level: { prev: 1, next: 2 },
+      },
+    });
+
+    expect(updated.changes).toEqual({ level: { prev: 1, next: 2 } });
+    expect(deleted).not.toHaveProperty('changes');
+  });
+
+  it('fans out to every publisher and swallows rejected legs', async () => {
+    const first = { publish: vi.fn().mockRejectedValue(new Error('sns down')) };
+    const second = { publish: vi.fn().mockResolvedValue(undefined) };
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const publisher = new FanoutCharacterEventPublisher([
+      { target: 'notifications', publisher: first },
+      { target: 'log', publisher: second },
+    ]);
+    const payload = createCharacterEventPayload({
+      event: 'character_updated',
+      roomId: 'ROOM01',
+      character: {
+        id: 'char-1',
+        name: 'Thief',
+        avatarId: 3,
+        color: '#AABBCC',
+      },
+    });
+
+    await expect(publisher.publish(payload)).resolves.toBeUndefined();
+
+    expect(first.publish).toHaveBeenCalledWith(payload);
+    expect(second.publish).toHaveBeenCalledWith(payload);
+    expect(warn).toHaveBeenCalledWith(
+      '[character-events] publisher leg failed',
+      expect.objectContaining({ target: 'notifications', event: 'character_updated', roomId: 'ROOM01' })
+    );
+
+    warn.mockRestore();
   });
 
   it('publishes events to SNS', async () => {
@@ -64,9 +143,13 @@ describe('character publisher', () => {
 
     await publisher.publish({
       event: 'character_updated',
+      eventType: 'character_updated',
       roomId: 'ROOM01',
       event_body: { characterId: 'char-1' },
+      actorId: 'char-1',
       emittedAt: '2026-03-13T00:00:00.000Z',
+      occurredAt: '2026-03-13T00:00:00.000Z',
+      character: { id: 'char-1', name: 'Thief', avatarId: 3, color: '#AABBCC' },
     });
 
     expect(send).toHaveBeenCalledTimes(1);
@@ -74,9 +157,13 @@ describe('character publisher', () => {
       TopicArn: 'arn:aws:sns:topic',
       Message: JSON.stringify({
         event: 'character_updated',
+        eventType: 'character_updated',
         roomId: 'ROOM01',
         event_body: { characterId: 'char-1' },
+        actorId: 'char-1',
         emittedAt: '2026-03-13T00:00:00.000Z',
+        occurredAt: '2026-03-13T00:00:00.000Z',
+        character: { id: 'char-1', name: 'Thief', avatarId: 3, color: '#AABBCC' },
       }),
     });
   });
@@ -90,9 +177,13 @@ describe('character publisher', () => {
     const publisher = new RedisCharacterEventPublisher('redis://localhost:6379', 'room-events');
     const payload = {
       event: 'character_deleted' as const,
+      eventType: 'character_deleted' as const,
       roomId: 'ROOM01',
       event_body: { characterId: 'char-1' },
+      actorId: 'char-1',
       emittedAt: '2026-03-13T00:00:00.000Z',
+      occurredAt: '2026-03-13T00:00:00.000Z',
+      character: { id: 'char-1', name: 'Thief', avatarId: 3, color: '#AABBCC' },
     };
 
     await publisher.publish(payload);
@@ -111,9 +202,13 @@ describe('character publisher', () => {
     await expect(
       publisher.publish({
         event: 'character_created',
+        eventType: 'character_created',
         roomId: 'ROOM01',
         event_body: { characterId: 'char-1' },
+        actorId: 'char-1',
         emittedAt: '2026-03-13T00:00:00.000Z',
+        occurredAt: '2026-03-13T00:00:00.000Z',
+        character: { id: 'char-1', name: 'Thief', avatarId: 3, color: '#AABBCC' },
       })
     ).resolves.toBeUndefined();
   });

--- a/backend/character-service/src/publisher.ts
+++ b/backend/character-service/src/publisher.ts
@@ -11,10 +11,46 @@ export interface CharacterEventPayload {
   };
   emittedAt: string;
   correlationId?: string;
+  eventType: CharacterEventType;
+  actorId: string;
+  occurredAt: string;
+  character: {
+    id: string;
+    name: string;
+    avatarId: number;
+    color: string;
+  };
+  changes?: Record<string, { prev: unknown; next: unknown }>;
 }
 
 export interface CharacterEventPublisher {
   publish: (payload: CharacterEventPayload) => Promise<void>;
+}
+
+export interface CharacterEventPublisherLeg {
+  target: string;
+  publisher: CharacterEventPublisher;
+}
+
+export class FanoutCharacterEventPublisher implements CharacterEventPublisher {
+  constructor(public readonly legs: CharacterEventPublisherLeg[]) { }
+
+  async publish(payload: CharacterEventPayload): Promise<void> {
+    const results = await Promise.allSettled(this.legs.map((leg) => leg.publisher.publish(payload)));
+
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        console.error('[character-events] publisher leg failed', {
+          target: this.legs[index]?.target || 'unknown',
+          event: payload.event,
+          roomId: payload.roomId,
+          characterId: payload.event_body.characterId,
+          correlationId: payload.correlationId,
+          error: result.reason
+        });
+      }
+    });
+  }
 }
 
 export class NoopCharacterEventPublisher implements CharacterEventPublisher {
@@ -120,14 +156,33 @@ export class RedisCharacterEventPublisher implements CharacterEventPublisher {
 export const createCharacterEventPayload = (input: {
   event: CharacterEventType;
   roomId: string;
-  characterId: string;
+  character: {
+    id: string;
+    name: string;
+    avatarId: number;
+    color: string;
+  };
+  changes?: Record<string, { prev: unknown; next: unknown }>;
   correlationId?: string;
-}): CharacterEventPayload => ({
-  event: input.event,
-  roomId: input.roomId,
-  event_body: {
-    characterId: input.characterId
-  },
-  emittedAt: new Date().toISOString(),
-  correlationId: input.correlationId
-});
+}): CharacterEventPayload => {
+  const emittedAt = new Date().toISOString();
+  const payload: CharacterEventPayload = {
+    event: input.event,
+    roomId: input.roomId,
+    event_body: {
+      characterId: input.character.id
+    },
+    emittedAt,
+    correlationId: input.correlationId,
+    eventType: input.event,
+    actorId: input.character.id,
+    occurredAt: emittedAt,
+    character: input.character
+  };
+
+  if (input.event === 'character_updated' && input.changes) {
+    payload.changes = input.changes;
+  }
+
+  return payload;
+};

--- a/backend/character-service/src/publisher.ts
+++ b/backend/character-service/src/publisher.ts
@@ -36,7 +36,9 @@ export class FanoutCharacterEventPublisher implements CharacterEventPublisher {
   constructor(public readonly legs: CharacterEventPublisherLeg[]) { }
 
   async publish(payload: CharacterEventPayload): Promise<void> {
-    const results = await Promise.allSettled(this.legs.map((leg) => leg.publisher.publish(payload)));
+    const results = await Promise.allSettled(
+      this.legs.map((leg) => Promise.resolve().then(() => leg.publisher.publish(payload)))
+    );
 
     results.forEach((result, index) => {
       if (result.status === 'rejected') {

--- a/backend/character-service/src/service.test.ts
+++ b/backend/character-service/src/service.test.ts
@@ -5,6 +5,7 @@ const { mockCreateApp, mockCharacter } = vi.hoisted(() => ({
   mockCharacter: {
     find: vi.fn(),
     create: vi.fn(),
+    findById: vi.fn(),
     findByIdAndUpdate: vi.fn(),
     findByIdAndDelete: vi.fn(),
   },
@@ -25,6 +26,7 @@ describe('character-service service', () => {
     mockCreateApp.mockClear();
     mockCharacter.find.mockReset();
     mockCharacter.create.mockReset();
+    mockCharacter.findById.mockReset();
     mockCharacter.findByIdAndUpdate.mockReset();
     mockCharacter.findByIdAndDelete.mockReset();
   });
@@ -78,12 +80,15 @@ describe('character-service service', () => {
       updatedAt,
     };
     mockCharacter.create.mockResolvedValueOnce(mappedCharacter);
+    mockCharacter.findById.mockResolvedValueOnce(mappedCharacter).mockResolvedValueOnce(null);
     mockCharacter.findByIdAndUpdate.mockResolvedValueOnce(mappedCharacter).mockResolvedValueOnce(null);
     mockCharacter.findByIdAndDelete.mockResolvedValueOnce(mappedCharacter).mockResolvedValueOnce(null);
 
     const model = createCharacterModel();
 
     await expect(model.create({ roomId: 'room-1', name: 'Mage', avatarId: 2, color: '#123456' } as never)).resolves.toEqual(mappedCharacter);
+    await expect(model.findById('char-1')).resolves.toEqual(mappedCharacter);
+    await expect(model.findById('char-2')).resolves.toBeNull();
     await expect(model.findByIdAndUpdate('char-1', { name: 'Mage+' }, { new: true, runValidators: true } as never)).resolves.toEqual(mappedCharacter);
     await expect(model.findByIdAndUpdate('char-2', {}, { new: true, runValidators: true } as never)).resolves.toBeNull();
     await expect(model.findByIdAndDelete('char-1')).resolves.toEqual(mappedCharacter);
@@ -99,6 +104,7 @@ describe('character-service service', () => {
       expect.objectContaining({
         find: expect.any(Function),
         create: expect.any(Function),
+        findById: expect.any(Function),
         findByIdAndUpdate: expect.any(Function),
         findByIdAndDelete: expect.any(Function),
       }),

--- a/backend/character-service/src/service.ts
+++ b/backend/character-service/src/service.ts
@@ -1,4 +1,4 @@
-import { createApp, type CharacterModelLike } from './app';
+import { createApp, type CharacterLike, type CharacterModelLike } from './app';
 import { Character } from './models/Character';
 import { type CharacterEventPublisher } from './publisher';
 
@@ -7,6 +7,27 @@ interface BuildCharacterAppOptions {
   publisher?: CharacterEventPublisher;
 }
 
+type CharacterDocumentLike = Omit<CharacterLike, 'id'> & {
+  id?: string;
+  _id?: { toString: () => string };
+};
+
+const mapCharacter = (character: CharacterDocumentLike): CharacterLike => ({
+  id: character.id || character._id?.toString() || '',
+  roomId: character.roomId,
+  userId: character.userId,
+  name: character.name,
+  avatarId: character.avatarId,
+  color: character.color,
+  level: character.level,
+  power: character.power,
+  class: character.class,
+  race: character.race,
+  gender: character.gender,
+  createdAt: character.createdAt,
+  updatedAt: character.updatedAt
+});
+
 export function createCharacterModel(): CharacterModelLike {
   return {
     find: (query) => ({
@@ -14,21 +35,7 @@ export function createCharacterModel(): CharacterModelLike {
         console.info('[character-service] db find characters', { query, sortBy });
         const characters = await Character.find(query).sort(sortBy);
         console.info('[character-service] db find characters success', { count: characters.length });
-        return characters.map((character) => ({
-          id: character.id,
-          roomId: character.roomId,
-          userId: character.userId,
-          name: character.name,
-          avatarId: character.avatarId,
-          color: character.color,
-          level: character.level,
-          power: character.power,
-          class: character.class,
-          race: character.race,
-          gender: character.gender,
-          createdAt: character.createdAt,
-          updatedAt: character.updatedAt
-        }));
+        return characters.map(mapCharacter);
       }
     }),
     create: async (payload) => {
@@ -43,21 +50,20 @@ export function createCharacterModel(): CharacterModelLike {
         characterId: character.id,
         roomId: character.roomId
       });
-      return {
-        id: character.id,
-        roomId: character.roomId,
-        userId: character.userId,
-        name: character.name,
-        avatarId: character.avatarId,
-        color: character.color,
-        level: character.level,
-        power: character.power,
-        class: character.class,
-        race: character.race,
-        gender: character.gender,
-        createdAt: character.createdAt,
-        updatedAt: character.updatedAt
-      };
+      return mapCharacter(character);
+    },
+    findById: async (id) => {
+      console.info('[character-service] db find character by id', { characterId: id });
+      const character = await Character.findById(id);
+      if (!character) {
+        console.info('[character-service] db find character by id not found', { characterId: id });
+        return null;
+      }
+      console.info('[character-service] db find character by id success', {
+        characterId: character.id,
+        roomId: character.roomId
+      });
+      return mapCharacter(character);
     },
     findByIdAndUpdate: async (id, updates, options) => {
       console.info('[character-service] db update character', {
@@ -73,21 +79,7 @@ export function createCharacterModel(): CharacterModelLike {
         characterId: character.id,
         roomId: character.roomId
       });
-      return {
-        id: character.id,
-        roomId: character.roomId,
-        userId: character.userId,
-        name: character.name,
-        avatarId: character.avatarId,
-        color: character.color,
-        level: character.level,
-        power: character.power,
-        class: character.class,
-        race: character.race,
-        gender: character.gender,
-        createdAt: character.createdAt,
-        updatedAt: character.updatedAt
-      };
+      return mapCharacter(character);
     },
     findByIdAndDelete: async (id) => {
       console.info('[character-service] db delete character', { characterId: id });
@@ -100,21 +92,7 @@ export function createCharacterModel(): CharacterModelLike {
         characterId: character.id,
         roomId: character.roomId
       });
-      return {
-        id: character.id,
-        roomId: character.roomId,
-        userId: character.userId,
-        name: character.name,
-        avatarId: character.avatarId,
-        color: character.color,
-        level: character.level,
-        power: character.power,
-        class: character.class,
-        race: character.race,
-        gender: character.gender,
-        createdAt: character.createdAt,
-        updatedAt: character.updatedAt
-      };
+      return mapCharacter(character);
     }
   };
 }

--- a/backend/character-service/src/service.ts
+++ b/backend/character-service/src/service.ts
@@ -12,21 +12,27 @@ type CharacterDocumentLike = Omit<CharacterLike, 'id'> & {
   _id?: { toString: () => string };
 };
 
-const mapCharacter = (character: CharacterDocumentLike): CharacterLike => ({
-  id: character.id || character._id?.toString() || '',
-  roomId: character.roomId,
-  userId: character.userId,
-  name: character.name,
-  avatarId: character.avatarId,
-  color: character.color,
-  level: character.level,
-  power: character.power,
-  class: character.class,
-  race: character.race,
-  gender: character.gender,
-  createdAt: character.createdAt,
-  updatedAt: character.updatedAt
-});
+const mapCharacter = (character: CharacterDocumentLike): CharacterLike => {
+  const id = character.id || character._id?.toString();
+  if (!id) {
+    throw new Error('[character-service] character document is missing both id and _id');
+  }
+  return {
+    id,
+    roomId: character.roomId,
+    userId: character.userId,
+    name: character.name,
+    avatarId: character.avatarId,
+    color: character.color,
+    level: character.level,
+    power: character.power,
+    class: character.class,
+    race: character.race,
+    gender: character.gender,
+    createdAt: character.createdAt,
+    updatedAt: character.updatedAt
+  };
+};
 
 export function createCharacterModel(): CharacterModelLike {
   return {

--- a/backend/docker-compose.local.yml
+++ b/backend/docker-compose.local.yml
@@ -51,6 +51,7 @@ services:
       CHARACTER_MONGO_URI: mongodb://mongo-character:27017/munch_character_service
       CHARACTER_EVENTS_REDIS_URL: redis://redis:6379
       ROOM_CHARACTER_EVENTS_CHANNEL: room-character-events
+      ROOM_LOG_EVENTS_CHANNEL: room-log-events
     depends_on:
       - mongo-character
       - redis


### PR DESCRIPTION
## Summary

Implements Story 6.1: character lifecycle events now publish to both the existing realtime notifications target and the new room-history log target.

Changes include:
- enriched additive character event payloads with legacy notification fields preserved
- canonical mirror fields plus display-ready character context and update-only `changes`
- dual-leg fan-out publisher using `Promise.allSettled`
- Lambda `LOG_TOPIC_ARN` degraded-mode wiring
- local Redis `ROOM_LOG_EVENTS_CHANNEL` wiring
- tests for fan-out, payload shape, route publish behavior, Lambda bootstrapping, and model mapping
- Story 6.1 and sprint status moved to `review`

## Validation

- `npm test` from `backend/` — 140 tests passed
- `npm run typecheck` from `backend/` — passed all backend workspaces
- `npm run test:coverage` from `backend/` — passed, all-files line coverage 85.2% against the 70% floor

## Notes

SAM/IAM `LOG_TOPIC_ARN` infra wiring is intentionally deferred to Story 6.2, when the log topic resource exists, to avoid dangling CloudFormation references.