### PR TITLE
[codex] Implement story 6.2 log service

### DIFF
--- a/_bmad-output/implementation-artifacts/6-2-published-events-are-stored-and-readable-in-room-history.md
+++ b/_bmad-output/implementation-artifacts/6-2-published-events-are-stored-and-readable-in-room-history.md
@@ -1,6 +1,6 @@
 # Story 6.2: Published Events Are Stored and Readable in Room History
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -277,3 +277,13 @@ GPT-5 Codex
 ### Change Log
 
 - 2026-05-20: Implemented story 6.2 log-service persistence/read skeleton, tests, workspace wiring, infra wiring, and docs.
+
+### Review Findings
+
+_Code review 2026-05-21 (commit b89714f) — 3 adversarial layers (Blind Hunter, Edge Case Hunter, Acceptance Auditor). All 7 ACs satisfied; the items below are robustness gaps._
+
+- [x] [Review][Patch] SNS batch aborts on first persist failure [backend/log-service/src/subscriber.ts] — In `handler`, parse failures are caught (warn + continue) but a thrown error from `persistLogEvent` (transient Mongo error, validation, duplicate) is unguarded: it aborts the loop, rejects the handler, and SNS redelivers the whole batch — re-persisting already-written records (no idempotency key → duplicates) and skipping later records. AC5 is satisfied for parse failures only. Decision (2026-05-21): resolved to catch + warn + continue — wrap each `persistLogEvent` in try/catch, `console.warn` the failure, keep processing the batch (matches the existing parse-failure pattern; accepts at-most-once on a transient Mongo failure).
+- [x] [Review][Patch] parseLogEvent drops valid events on an unparseable occurredAt [backend/log-service/src/service.ts] — A present-but-malformed timestamp string (e.g. `"yesterday"`, `"2026-13-99"`) makes `new Date()` Invalid and the `Number.isNaN` check returns `null`, discarding an otherwise-supported event. The Dev Notes mapping rule ends the fallback chain in `new Date().toISOString()` — intent is that a bad/missing timestamp never drops the event. Fix: fall back to current time on an unparseable value instead of returning `null`.
+- [x] [Review][Patch] Redis subscriber callback has no error handling [backend/log-service/src/index.ts] — The async message callback passed to `subscriber.subscribe()` is not awaited/caught by node-redis. A throw inside (`connectToMongo` or `persistLogEvent` rejection) becomes an unhandled promise rejection — the event is lost silently and the process can crash. Redis pub/sub has no redelivery, so the fix is to wrap the callback body in try/catch with a `console.error`/`warn` (consistent with the project's "do not swallow operational errors / try-catch at I/O boundaries" rule).
+- [x] [Review][Defer] connectToMongo does not reconnect after a dropped connection [backend/log-service/src/db.ts] — deferred, pre-existing — The singleton caches `connectionPromise` and never clears it; after a transient Mongo disconnect (`readyState` 0/2/3) it awaits the already-resolved promise and returns without reconnecting. `db.ts` was copied verbatim from `room-notifications-service`/`battle-service` per Task 1; the limitation is a repo-wide pre-existing pattern, not introduced here.
+- [x] [Review][Defer] morgan('dev') used on the deployed logReader path [backend/log-service/src/app.ts] — deferred, pre-existing — `buildLogApp` mounts the dev-only `morgan` formatter, which is the same app used by `lambda-read.ts` in production (verbose colored CloudWatch logs). Task 5 instructed mirroring `battle-service`'s app structure, so this is a propagated repo-wide convention rather than a defect unique to this story.

--- a/_bmad-output/implementation-artifacts/6-2-published-events-are-stored-and-readable-in-room-history.md
+++ b/_bmad-output/implementation-artifacts/6-2-published-events-are-stored-and-readable-in-room-history.md
@@ -1,6 +1,6 @@
 # Story 6.2: Published Events Are Stored and Readable in Room History
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -24,61 +24,61 @@ so that history entries are available when I open the room history view.
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Scaffold `backend/log-service/` package (AC: 1, 7)**
-  - [ ] Create `backend/log-service/` scaffolded from `room-notifications-service` (SNS-subscriber shape) **plus** the HTTP bits from `battle-service` (the read API). Files: `package.json`, `tsconfig.json`, `Dockerfile`, `.env.example`, `src/{db.ts,subscriber.ts,service.ts,app.ts,lambda-read.ts,index.ts}`, `src/models/LogEvent.ts`, `src/routes/logs.ts`, plus co-located `*.test.ts` files (see Task 6).
-  - [ ] `tsconfig.json`: copy verbatim from `room-notifications-service/tsconfig.json` (`module`/`moduleResolution`: `NodeNext`, `strict: false`, `target: ES2022`). Do **not** introduce frontend strictness ([Source: _bmad-output/project-context.md] language rules).
-  - [ ] `package.json`: model on `battle-service/package.json` (needs Express read API). Deps: `mongoose ^8.19.1`, `redis ^5.8.2`, `express ^5.1.0`, `@codegenie/serverless-express ^4.17.1`, `cors`, `morgan`, `dotenv`, `tsx`; devDeps `@types/*`, `typescript ^5.9.2`. **Do NOT add `@aws-sdk/client-sns`** — the writer *consumes* SNS via the Lambda trigger; it never publishes (no SNS client needed).
-  - [ ] `Dockerfile`: copy `room-notifications-service/Dockerfile`, change `EXPOSE 8084` → `EXPOSE 8087`.
-  - [ ] `db.ts`: copy verbatim from `room-notifications-service/src/db.ts` / `battle-service/src/db.ts` (identical singleton `connectToMongo` pattern — do not reinvent).
-  - [ ] `.env.example`: `LOG_MONGO_URI`, `LOG_TOPIC_ARN`, `ROOM_LOG_EVENTS_CHANNEL`, `REDIS_URL`, `PORT` (see Dev Notes “Env var contract”).
+- [x] **Task 1 — Scaffold `backend/log-service/` package (AC: 1, 7)**
+  - [x] Create `backend/log-service/` scaffolded from `room-notifications-service` (SNS-subscriber shape) **plus** the HTTP bits from `battle-service` (the read API). Files: `package.json`, `tsconfig.json`, `Dockerfile`, `.env.example`, `src/{db.ts,subscriber.ts,service.ts,app.ts,lambda-read.ts,index.ts}`, `src/models/LogEvent.ts`, `src/routes/logs.ts`, plus co-located `*.test.ts` files (see Task 6).
+  - [x] `tsconfig.json`: copy verbatim from `room-notifications-service/tsconfig.json` (`module`/`moduleResolution`: `NodeNext`, `strict: false`, `target: ES2022`). Do **not** introduce frontend strictness ([Source: _bmad-output/project-context.md] language rules).
+  - [x] `package.json`: model on `battle-service/package.json` (needs Express read API). Deps: `mongoose ^8.19.1`, `redis ^5.8.2`, `express ^5.1.0`, `@codegenie/serverless-express ^4.17.1`, `cors`, `morgan`, `dotenv`, `tsx`; devDeps `@types/*`, `typescript ^5.9.2`. **Do NOT add `@aws-sdk/client-sns`** — the writer *consumes* SNS via the Lambda trigger; it never publishes (no SNS client needed).
+  - [x] `Dockerfile`: copy `room-notifications-service/Dockerfile`, change `EXPOSE 8084` → `EXPOSE 8087`.
+  - [x] `db.ts`: copy verbatim from `room-notifications-service/src/db.ts` / `battle-service/src/db.ts` (identical singleton `connectToMongo` pattern — do not reinvent).
+  - [x] `.env.example`: `LOG_MONGO_URI`, `LOG_TOPIC_ARN`, `ROOM_LOG_EVENTS_CHANNEL`, `REDIS_URL`, `PORT` (see Dev Notes “Env var contract”).
 
-- [ ] **Task 2 — `LogEvent` Mongoose model (AC: 2, 7)**
-  - [ ] `src/models/LogEvent.ts` mirroring `battle-service/src/models/Battle.ts` conventions. Schema fields (camelCase — [Source: architecture/implementation-patterns-consistency-rules.md#Database / Mongoose]):
+- [x] **Task 2 — `LogEvent` Mongoose model (AC: 2, 7)**
+  - [x] `src/models/LogEvent.ts` mirroring `battle-service/src/models/Battle.ts` conventions. Schema fields (camelCase — [Source: architecture/implementation-patterns-consistency-rules.md#Database / Mongoose]):
     - `roomId: { type: String, required: true }`
     - `eventType: { type: String, required: true, enum: [<the 6 supported types>] }`
     - `actorId: { type: String, required: true }`
     - `summary: { type: String, required: true }`
     - `payload: { type: mongoose.Schema.Types.Mixed, required: true }` (raw event for Story 6.7 drill-in; `mongoose` is imported from `../db` exactly as `Battle.ts` does)
     - `occurredAt: { type: Date, required: true }`
-  - [ ] Schema options: `{ timestamps: true, toJSON: { virtuals: true, transform: (_doc, ret) => { delete ret._id; delete ret.__v; } } }` — **never** manually define `createdAt`/`updatedAt`; `_id` is always aliased to `id` in responses ([Source: architecture/implementation-patterns-consistency-rules.md#Enforcement Summary]).
-  - [ ] Index: `logEventSchema.index({ roomId: 1, _id: -1 });` — the compound cursor-pagination index ([Source: architecture/core-architectural-decisions.md#Log Schema, ADR-7]). Define it **here** (model is created here); Story 6.4 consumes it for `GET /logs` and must not need to add it.
-  - [ ] Collection name resolves to `logevents` via `mongoose.model<LogEventDocument>('LogEvent', schema)` (Mongoose default lowercased pluralization — matches architecture’s `logevents`; do not override `collection`).
+  - [x] Schema options: `{ timestamps: true, toJSON: { virtuals: true, transform: (_doc, ret) => { delete ret._id; delete ret.__v; } } }` — **never** manually define `createdAt`/`updatedAt`; `_id` is always aliased to `id` in responses ([Source: architecture/implementation-patterns-consistency-rules.md#Enforcement Summary]).
+  - [x] Index: `logEventSchema.index({ roomId: 1, _id: -1 });` — the compound cursor-pagination index ([Source: architecture/core-architectural-decisions.md#Log Schema, ADR-7]). Define it **here** (model is created here); Story 6.4 consumes it for `GET /logs` and must not need to add it.
+  - [x] Collection name resolves to `logevents` via `mongoose.model<LogEventDocument>('LogEvent', schema)` (Mongoose default lowercased pluralization — matches architecture’s `logevents`; do not override `collection`).
 
-- [ ] **Task 3 — Parse + map + summary logic in `service.ts` (AC: 2, 3, 4)**
-  - [ ] Export `parseLogEvent(payload: unknown): LogEventInput | null` — accepts a JSON string or object (string → `JSON.parse` in try/catch → recurse; on parse failure return `null`). Mirror the defensive style of `room-notifications-service/src/app.ts` `parseNotificationEvent` (guard `null`/non-object, trim, validate against an `EVENT_TYPES` `Set`, return `null` on any miss — never throw).
-  - [ ] Resolve `eventType` from the Story 6.1 superset payload: prefer canonical `eventType`, fall back to legacy `event`. Reject (return `null`) if not in the supported `Set` of 6 types → satisfies AC 3 “unsupported ignored”.
-  - [ ] Resolve `roomId` (required, trimmed), `actorId` (prefer canonical `actorId`; fall back to `event_body.characterId` for character events / `battleId` for battle events), `occurredAt` (prefer canonical `occurredAt`; fall back to `emittedAt`; fall back to `new Date().toISOString()`). Return `null` if `roomId` or `actorId` is empty.
-  - [ ] Export `buildSummary(input): string` — pure, deterministic, **no I/O** (AC 4). Character events use Story 6.1 display context `character: { id, name, avatarId, color }` (+ `changes` map for `character_updated`). Battle events use the battle display context defined in Story 6.3 (`name`, `result`, character names). Use safe fallbacks when optional fields are absent (e.g., name → `actorId`). See Dev Notes “Summary rules” for exact strings.
-  - [ ] Export `persistLogEvent(input): Promise<void>` calling `LogEvent.create({...})` with the mapped fields + the **raw original payload object** stored in `payload`. Keep `app.ts`-style structured `console.info` logging around the write.
-  - [ ] **Do not** mock or call any other service. Summary must render with zero outbound HTTP (ADR-11) — all data comes from the payload that Story 6.1/6.3 enriched.
+- [x] **Task 3 — Parse + map + summary logic in `service.ts` (AC: 2, 3, 4)**
+  - [x] Export `parseLogEvent(payload: unknown): LogEventInput | null` — accepts a JSON string or object (string → `JSON.parse` in try/catch → recurse; on parse failure return `null`). Mirror the defensive style of `room-notifications-service/src/app.ts` `parseNotificationEvent` (guard `null`/non-object, trim, validate against an `EVENT_TYPES` `Set`, return `null` on any miss — never throw).
+  - [x] Resolve `eventType` from the Story 6.1 superset payload: prefer canonical `eventType`, fall back to legacy `event`. Reject (return `null`) if not in the supported `Set` of 6 types → satisfies AC 3 “unsupported ignored”.
+  - [x] Resolve `roomId` (required, trimmed), `actorId` (prefer canonical `actorId`; fall back to `event_body.characterId` for character events / `battleId` for battle events), `occurredAt` (prefer canonical `occurredAt`; fall back to `emittedAt`; fall back to `new Date().toISOString()`). Return `null` if `roomId` or `actorId` is empty.
+  - [x] Export `buildSummary(input): string` — pure, deterministic, **no I/O** (AC 4). Character events use Story 6.1 display context `character: { id, name, avatarId, color }` (+ `changes` map for `character_updated`). Battle events use the battle display context defined in Story 6.3 (`name`, `result`, character names). Use safe fallbacks when optional fields are absent (e.g., name → `actorId`). See Dev Notes “Summary rules” for exact strings.
+  - [x] Export `persistLogEvent(input): Promise<void>` calling `LogEvent.create({...})` with the mapped fields + the **raw original payload object** stored in `payload`. Keep `app.ts`-style structured `console.info` logging around the write.
+  - [x] **Do not** mock or call any other service. Summary must render with zero outbound HTTP (ADR-11) — all data comes from the payload that Story 6.1/6.3 enriched.
 
-- [ ] **Task 4 — `logWriter` entrypoints: SNS Lambda (`subscriber.ts`) + local Redis (`index.ts`) (AC: 1, 5, 6)**
-  - [ ] `src/subscriber.ts`: export `handler` (SNS → result). At **module load** read `process.env.LOG_TOPIC_ARN`; if absent/empty, **throw** an explicit `Error('LOG_TOPIC_ARN is required for log-service logWriter')` (fail-fast, AC 1) — contrast Story 6.1’s `console.warn`+continue; do **not** copy the degraded pattern. Reuse the exact `parseSnsRecords` shape from `room-notifications-service/src/lambda.ts` (`event.Records[].Sns.Message`). For each message: `parseLogEvent` → if `null`, `console.warn('log.sns.invalid_event')` and `continue` (AC 3/5); else `await persistLogEvent(...)`. `await connectToMongo(process.env.LOG_MONGO_URI || 'mongodb://localhost:27017/munch_log_service')` once per invocation before writes (same ordering as `room-notifications-service` handler). Return `{ statusCode: 200, body: JSON.stringify({ processed: n }) }`.
-  - [ ] `src/index.ts`: local entry. `dotenv.config()`. Run **both** the Redis subscriber and the HTTP read server concurrently — `await Promise.all([startSubscriber(), startHttpServer()])` ([Source: architecture/project-structure-boundaries.md] log-service `index.ts`). Subscriber: `createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' })`, `subscribe(process.env.ROOM_LOG_EVENTS_CHANNEL || 'room-log-events', handler)` reusing the **same** `parseLogEvent`/`persistLogEvent` (no logic duplication, AC 6). Connect Mongo before persisting. `start().catch(err => { console.error(...); process.exit(1); })` (mirror `room-notifications-service/src/index.ts`).
-  - [ ] `index.ts` is coverage-excluded — keep it thin orchestration only; all testable logic lives in `service.ts`/`subscriber.ts`.
+- [x] **Task 4 — `logWriter` entrypoints: SNS Lambda (`subscriber.ts`) + local Redis (`index.ts`) (AC: 1, 5, 6)**
+  - [x] `src/subscriber.ts`: export `handler` (SNS → result). At **module load** read `process.env.LOG_TOPIC_ARN`; if absent/empty, **throw** an explicit `Error('LOG_TOPIC_ARN is required for log-service logWriter')` (fail-fast, AC 1) — contrast Story 6.1’s `console.warn`+continue; do **not** copy the degraded pattern. Reuse the exact `parseSnsRecords` shape from `room-notifications-service/src/lambda.ts` (`event.Records[].Sns.Message`). For each message: `parseLogEvent` → if `null`, `console.warn('log.sns.invalid_event')` and `continue` (AC 3/5); else `await persistLogEvent(...)`. `await connectToMongo(process.env.LOG_MONGO_URI || 'mongodb://localhost:27017/munch_log_service')` once per invocation before writes (same ordering as `room-notifications-service` handler). Return `{ statusCode: 200, body: JSON.stringify({ processed: n }) }`.
+  - [x] `src/index.ts`: local entry. `dotenv.config()`. Run **both** the Redis subscriber and the HTTP read server concurrently — `await Promise.all([startSubscriber(), startHttpServer()])` ([Source: architecture/project-structure-boundaries.md] log-service `index.ts`). Subscriber: `createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' })`, `subscribe(process.env.ROOM_LOG_EVENTS_CHANNEL || 'room-log-events', handler)` reusing the **same** `parseLogEvent`/`persistLogEvent` (no logic duplication, AC 6). Connect Mongo before persisting. `start().catch(err => { console.error(...); process.exit(1); })` (mirror `room-notifications-service/src/index.ts`).
+  - [x] `index.ts` is coverage-excluded — keep it thin orchestration only; all testable logic lives in `service.ts`/`subscriber.ts`.
 
-- [ ] **Task 5 — Minimal deployable `logReader` skeleton (AC: 1) — DO NOT build the 6.4 contract**
-  - [ ] `src/app.ts`: Express app factory `buildLogApp({ routePrefix })` mirroring `battle-service/src/app.ts`/`service.ts` structure (cors, morgan, json, router mounted under `ROUTE_PREFIX`). Mount `src/routes/logs.ts`.
-  - [ ] `src/routes/logs.ts`: an Express router exposing `GET /logs` that, **for this story**, returns an empty array `[]` with `200` for a present `roomId` and `400 { message }` for a missing/blank `roomId`. Add an inline `// Story 6.4: cursor pagination + roomId-filtered query + GET /logs/:logId implemented here` seam comment. **Do not** implement pagination, `before`/`limit`, `_id` cursor, real Mongo querying, or `/logs/:logId` — that is Story 6.4’s ACs and tests. Keep this file tiny so it does not drag the 70% coverage floor.
-  - [ ] `src/lambda-read.ts`: HTTP API Gateway entry mirroring `battle-service/src/lambda.ts` (`serverlessExpress({ app })`, `connectToMongo` before `server(event, context)`, `ROUTE_PREFIX`). Export `handler`.
+- [x] **Task 5 — Minimal deployable `logReader` skeleton (AC: 1) — DO NOT build the 6.4 contract**
+  - [x] `src/app.ts`: Express app factory `buildLogApp({ routePrefix })` mirroring `battle-service/src/app.ts`/`service.ts` structure (cors, morgan, json, router mounted under `ROUTE_PREFIX`). Mount `src/routes/logs.ts`.
+  - [x] `src/routes/logs.ts`: an Express router exposing `GET /logs` that, **for this story**, returns an empty array `[]` with `200` for a present `roomId` and `400 { message }` for a missing/blank `roomId`. Add an inline `// Story 6.4: cursor pagination + roomId-filtered query + GET /logs/:logId implemented here` seam comment. **Do not** implement pagination, `before`/`limit`, `_id` cursor, real Mongo querying, or `/logs/:logId` — that is Story 6.4’s ACs and tests. Keep this file tiny so it does not drag the 70% coverage floor.
+  - [x] `src/lambda-read.ts`: HTTP API Gateway entry mirroring `battle-service/src/lambda.ts` (`serverlessExpress({ app })`, `connectToMongo` before `server(event, context)`, `ROUTE_PREFIX`). Export `handler`.
 
-- [ ] **Task 6 — Tests (AC: 2, 3, 4, 5, 6, 7)**
-  - [ ] `src/db.test.ts`: copy the proven `room-notifications-service/src/db.test.ts` (mongoose-mocked: skip-when-connected, in-flight reuse, reset-after-failure).
-  - [ ] `src/service.test.ts`: mock `./models/LogEvent` via `vi.mock('./models/LogEvent', ...)` (pattern from `battle-service/src/service.test.ts` mocking `./models/Battle`). Assert: (a) each of the 6 supported types maps to a correct `LogEvent.create` call (roomId/eventType/actorId/occurredAt/payload exact); (b) `character_updated` `summary` includes every changed field as `prev → next` derived from `changes` (the data Story 6.6 renders originates here); (c) unsupported type (`battle_updated`) and malformed payload → `parseLogEvent` returns `null` and `LogEvent.create` is **not** called (AC 3); (d) `buildSummary` with missing optional fields falls back without throwing (AC 4); (e) string-vs-object payload both parse.
-  - [ ] `src/subscriber.test.ts`: follow the `vi.hoisted` + `vi.mock('./db')` + `vi.mock('./service')` + `delete process.env.*` + `await import('./subscriber.js')` pattern from `room-notifications-service/src/lambda.test.ts`. Cases: missing `LOG_TOPIC_ARN` → importing/handler **throws** (AC 1); valid multi-record batch with one invalid record → only valid records persisted, `processed` count correct, no throw (AC 5); `connectToMongo` invoked with the resolved URI.
-  - [ ] `src/routes/logs.test.ts` (or `app.test.ts`): minimal — `GET /logs?roomId=X` → `200 []`; missing `roomId` → `400 { message }`. (Skeleton-level only; 6.4 expands.)
-  - [ ] Run the gate from repo `backend/`: `cd backend && npm test` then `npm run test:coverage` (Vitest 3.2.4, v8, 70% line floor — do not lower). Confirm `log-service` suites actually appear in output (proves Task 7 wiring).
+- [x] **Task 6 — Tests (AC: 2, 3, 4, 5, 6, 7)**
+  - [x] `src/db.test.ts`: copy the proven `room-notifications-service/src/db.test.ts` (mongoose-mocked: skip-when-connected, in-flight reuse, reset-after-failure).
+  - [x] `src/service.test.ts`: mock `./models/LogEvent` via `vi.mock('./models/LogEvent', ...)` (pattern from `battle-service/src/service.test.ts` mocking `./models/Battle`). Assert: (a) each of the 6 supported types maps to a correct `LogEvent.create` call (roomId/eventType/actorId/occurredAt/payload exact); (b) `character_updated` `summary` includes every changed field as `prev → next` derived from `changes` (the data Story 6.6 renders originates here); (c) unsupported type (`battle_updated`) and malformed payload → `parseLogEvent` returns `null` and `LogEvent.create` is **not** called (AC 3); (d) `buildSummary` with missing optional fields falls back without throwing (AC 4); (e) string-vs-object payload both parse.
+  - [x] `src/subscriber.test.ts`: follow the `vi.hoisted` + `vi.mock('./db')` + `vi.mock('./service')` + `delete process.env.*` + `await import('./subscriber.js')` pattern from `room-notifications-service/src/lambda.test.ts`. Cases: missing `LOG_TOPIC_ARN` → importing/handler **throws** (AC 1); valid multi-record batch with one invalid record → only valid records persisted, `processed` count correct, no throw (AC 5); `connectToMongo` invoked with the resolved URI.
+  - [x] `src/routes/logs.test.ts` (or `app.test.ts`): minimal — `GET /logs?roomId=X` → `200 []`; missing `roomId` → `400 { message }`. (Skeleton-level only; 6.4 expands.)
+  - [x] Run the gate from repo `backend/`: `cd backend && npm test` then `npm run test:coverage` (Vitest 3.2.4, v8, 70% line floor — do not lower). Confirm `log-service` suites actually appear in output (proves Task 7 wiring).
 
-- [ ] **Task 7 — Register `log-service` in workspace, test, and lint wiring (AC: 7) — easy-to-miss, do first-class**
-  - [ ] `backend/package.json`: add `"log-service"` to `workspaces`; extend `dev` and `start` `concurrently` chains and the `typecheck` chain with a `-w log-service` entry mirroring `battle-service`.
-  - [ ] `backend/vitest.config.ts`: add `'log-service/src/**/*.test.ts'` to `test.include` **and** `'log-service/src/**/*.ts'` to `coverage.include`. Without this, log-service tests silently never run and the coverage gate ignores them entirely (the existing `**/models/**/*.ts` and `**/index.ts` excludes already apply globally — keep them).
+- [x] **Task 7 — Register `log-service` in workspace, test, and lint wiring (AC: 7) — easy-to-miss, do first-class**
+  - [x] `backend/package.json`: add `"log-service"` to `workspaces`; extend `dev` and `start` `concurrently` chains and the `typecheck` chain with a `-w log-service` entry mirroring `battle-service`.
+  - [x] `backend/vitest.config.ts`: add `'log-service/src/**/*.test.ts'` to `test.include` **and** `'log-service/src/**/*.ts'` to `coverage.include`. Without this, log-service tests silently never run and the coverage gate ignores them entirely (the existing `**/models/**/*.ts` and `**/index.ts` excludes already apply globally — keep them).
 
-- [ ] **Task 8 — Infra wiring + docs (AC: 1, 6)**
-  - [ ] `backend/sam/template.yaml`: add (a) Parameter `LogMongoUri`; (b) `LogEventsTopic` (`AWS::SNS::Topic`, `TopicName: !Sub ${AWS::StackName}-log-events`) mirroring `RoomCharacterEventsTopic`; (c) `LogWriterFunction` (`CodeUri: ../log-service`, `Handler: subscriber.handler`, `Events: LogEvent: { Type: SNS, Properties: { Topic: !Ref LogEventsTopic } }`, env `LOG_MONGO_URI: !Ref LogMongoUri` + `LOG_TOPIC_ARN: !Ref LogEventsTopic`, esbuild `EntryPoints: [src/subscriber.ts]`) mirroring `RoomNotificationsFunction`’s SNS-event pattern (SAM auto-creates the subscription + invoke permission — no explicit `sns:Subscribe` IAM needed); (d) `LogReaderFunction` (`Handler: lambda-read.handler`, HttpApi events `GET /logs` and `GET /logs/{logId}`, env `LOG_MONGO_URI` + `ROUTE_PREFIX`, esbuild `EntryPoints: [src/lambda-read.ts]`) mirroring `BattleServiceFunction`; (e) **close Story 6.1’s deferred infra item**: add `LOG_TOPIC_ARN: !Ref LogEventsTopic` to `CharacterServiceFunction` env and a `sns:Publish` statement on `!Ref LogEventsTopic` to `CharacterServiceRole` Policies (additive to `PublishRoomCharacterEvents`). The dangling-`!Ref` risk that 6.1 called out is now resolved because `LogEventsTopic` exists in the same template. **Leave `battle-service`’s `LOG_TOPIC_ARN`/IAM to Story 6.3** (its natural owner) — note this in Completion Notes.
-  - [ ] `backend/docker-compose.local.yml`: add `log-service` (build `./log-service`, port `8087:8087`, env `PORT: 8087`, `LOG_MONGO_URI: mongodb://mongo-log:27017/munch_log_service`, `REDIS_URL: redis://redis:6379`, `ROOM_LOG_EVENTS_CHANNEL: room-log-events`, `depends_on: [mongo-log, redis]`); add `mongo-log` (`image: mongo:7`, `27025:27017`, volume `mongo-log-data`); add `mongo-log-data` to `volumes:`; add `log-service` to `nginx.depends_on`. Also add `ROOM_LOG_EVENTS_CHANNEL: room-log-events` to the existing `character-service` env block so the local fan-out from Story 6.1 lands on the channel this subscriber listens to (idempotent if 6.1 already added it).
-  - [ ] `backend/nginx/nginx.conf`: add `upstream log_service { server log-service:8087; }` and a `location /logs { ... }` block mirroring the `/battles`/`/characters` proxy block (copy headers/OPTIONS handling exactly).
-  - [ ] `backend/.env.example`: add `LOG_SERVICE_PORT=8087`, `LOG_MONGO_URI=mongodb://localhost:27025/munch_log_service`, `LOG_SERVICE_URL=http://localhost:8087`, `ROOM_LOG_EVENTS_CHANNEL=room-log-events`.
-  - [ ] `backend/README.md`: add `log-service` to the services list and add `/logs -> log-service` to the nginx proxy list (docs-in-same-change rule, [Source: _bmad-output/project-context.md]).
+- [x] **Task 8 — Infra wiring + docs (AC: 1, 6)**
+  - [x] `backend/sam/template.yaml`: add (a) Parameter `LogMongoUri`; (b) `LogEventsTopic` (`AWS::SNS::Topic`, `TopicName: !Sub ${AWS::StackName}-log-events`) mirroring `RoomCharacterEventsTopic`; (c) `LogWriterFunction` (`CodeUri: ../log-service`, `Handler: subscriber.handler`, `Events: LogEvent: { Type: SNS, Properties: { Topic: !Ref LogEventsTopic } }`, env `LOG_MONGO_URI: !Ref LogMongoUri` + `LOG_TOPIC_ARN: !Ref LogEventsTopic`, esbuild `EntryPoints: [src/subscriber.ts]`) mirroring `RoomNotificationsFunction`’s SNS-event pattern (SAM auto-creates the subscription + invoke permission — no explicit `sns:Subscribe` IAM needed); (d) `LogReaderFunction` (`Handler: lambda-read.handler`, HttpApi events `GET /logs` and `GET /logs/{logId}`, env `LOG_MONGO_URI` + `ROUTE_PREFIX`, esbuild `EntryPoints: [src/lambda-read.ts]`) mirroring `BattleServiceFunction`; (e) **close Story 6.1’s deferred infra item**: add `LOG_TOPIC_ARN: !Ref LogEventsTopic` to `CharacterServiceFunction` env and a `sns:Publish` statement on `!Ref LogEventsTopic` to `CharacterServiceRole` Policies (additive to `PublishRoomCharacterEvents`). The dangling-`!Ref` risk that 6.1 called out is now resolved because `LogEventsTopic` exists in the same template. **Leave `battle-service`’s `LOG_TOPIC_ARN`/IAM to Story 6.3** (its natural owner) — note this in Completion Notes.
+  - [x] `backend/docker-compose.local.yml`: add `log-service` (build `./log-service`, port `8087:8087`, env `PORT: 8087`, `LOG_MONGO_URI: mongodb://mongo-log:27017/munch_log_service`, `REDIS_URL: redis://redis:6379`, `ROOM_LOG_EVENTS_CHANNEL: room-log-events`, `depends_on: [mongo-log, redis]`); add `mongo-log` (`image: mongo:7`, `27025:27017`, volume `mongo-log-data`); add `mongo-log-data` to `volumes:`; add `log-service` to `nginx.depends_on`. Also add `ROOM_LOG_EVENTS_CHANNEL: room-log-events` to the existing `character-service` env block so the local fan-out from Story 6.1 lands on the channel this subscriber listens to (idempotent if 6.1 already added it).
+  - [x] `backend/nginx/nginx.conf`: add `upstream log_service { server log-service:8087; }` and a `location /logs { ... }` block mirroring the `/battles`/`/characters` proxy block (copy headers/OPTIONS handling exactly).
+  - [x] `backend/.env.example`: add `LOG_SERVICE_PORT=8087`, `LOG_MONGO_URI=mongodb://localhost:27025/munch_log_service`, `LOG_SERVICE_URL=http://localhost:8087`, `ROOM_LOG_EVENTS_CHANNEL=room-log-events`.
+  - [x] `backend/README.md`: add `log-service` to the services list and add `/logs -> log-service` to the nginx proxy list (docs-in-same-change rule, [Source: _bmad-output/project-context.md]).
 
 ## Dev Notes
 
@@ -225,8 +225,55 @@ Note: in cloud the SNS trigger delivers events regardless, but AC 1 still requir
 
 ### Agent Model Used
 
+GPT-5 Codex
+
 ### Debug Log References
+
+- `cd backend && npm install`
+- `cd backend && npm test -- log-service/src`
+- `cd backend && npm run typecheck -w log-service`
+- `cd backend && npm test`
+- `cd backend && npm run typecheck`
+- `cd backend && npm run test:coverage`
 
 ### Completion Notes List
 
+- Implemented `backend/log-service` with SNS `logWriter`, local Redis subscriber, `LogEvent` model, pure parse/map/summary logic, and a minimal deployable `logReader` skeleton.
+- Persisted supported `character_*` and battle lifecycle events with `eventType`, `actorId`, `summary`, raw `payload`, and `occurredAt`; unsupported or malformed events are skipped with a warning and do not fail batches.
+- Preserved documented variances: epic `type`/`createdAt` wording is implemented as architecture-authoritative `eventType` plus Mongoose timestamps; local log channel uses `ROOM_LOG_EVENTS_CHANNEL=room-log-events`; subscriber Redis URL is `REDIS_URL`.
+- Added SAM/local/nginx/docs wiring for log-service and closed Story 6.1's deferred character-service log topic env/IAM wiring. Battle-service `LOG_TOPIC_ARN`/IAM remains intentionally owned by Story 6.3.
+- Added and ran log-service unit/route/lambda tests plus full backend tests, typecheck, and coverage. Coverage completed at 85.76% lines overall and 91.43% lines for `log-service/src`.
+
 ### File List
+
+- _bmad-output/implementation-artifacts/6-2-published-events-are-stored-and-readable-in-room-history.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+- backend/.env.example
+- backend/README.md
+- backend/docker-compose.local.yml
+- backend/log-service/.env.example
+- backend/log-service/Dockerfile
+- backend/log-service/package.json
+- backend/log-service/src/app.ts
+- backend/log-service/src/db.test.ts
+- backend/log-service/src/db.ts
+- backend/log-service/src/index.ts
+- backend/log-service/src/lambda-read.test.ts
+- backend/log-service/src/lambda-read.ts
+- backend/log-service/src/models/LogEvent.ts
+- backend/log-service/src/routes/logs.test.ts
+- backend/log-service/src/routes/logs.ts
+- backend/log-service/src/service.test.ts
+- backend/log-service/src/service.ts
+- backend/log-service/src/subscriber.test.ts
+- backend/log-service/src/subscriber.ts
+- backend/log-service/tsconfig.json
+- backend/nginx/nginx.conf
+- backend/package-lock.json
+- backend/package.json
+- backend/sam/template.yaml
+- backend/vitest.config.ts
+
+### Change Log
+
+- 2026-05-20: Implemented story 6.2 log-service persistence/read skeleton, tests, workspace wiring, infra wiring, and docs.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,3 +1,8 @@
+## Deferred from: code review of 6-2-published-events-are-stored-and-readable-in-room-history (2026-05-21)
+
+- `connectToMongo` does not reconnect after a dropped connection — the singleton caches `connectionPromise` and never clears it; after a transient Mongo disconnect (`readyState` 0/2/3) it awaits the already-resolved promise and returns without reconnecting, so subsequent `LogEvent.create` calls fail. `db.ts` was copied verbatim from `room-notifications-service`/`battle-service` per Task 1 — repo-wide pre-existing pattern. [backend/log-service/src/db.ts]
+- `morgan('dev')` used on the deployed logReader path — `buildLogApp` mounts the dev-only `morgan` formatter, used by `lambda-read.ts` in production (verbose colored CloudWatch logs). Task 5 instructed mirroring `battle-service`'s app structure, so this is a propagated repo-wide convention. [backend/log-service/src/app.ts]
+
 ## Deferred from: code review of 6-1-character-events-are-published-for-room-history (2026-05-20)
 
 - PATCH does not validate `level`/`power`/`class`/`race`/`gender`/`userId` — pre-existing input-validation gap; only `name`/`avatarId`/`color` are validated, so clients can persist arbitrary types and ship them through `changes`. [backend/character-service/src/app.ts:292, 300-304]

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-26T17:42:48Z
-# last_updated: 2026-05-20T22:01:00Z
+# last_updated: 2026-05-20T22:25:00Z
 # project: munch-helper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-20T17:45:00Z
+last_updated: 2026-05-20T22:25:00Z
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -90,7 +90,7 @@ development_status:
 
   epic-6: in-progress
   6-1-character-events-are-published-for-room-history: done
-  6-2-published-events-are-stored-and-readable-in-room-history: ready-for-dev
+  6-2-published-events-are-stored-and-readable-in-room-history: review
   6-3-battle-lifecycle-events-are-published-for-room-history: ready-for-dev
   6-4-room-history-api-returns-paginated-events: ready-for-dev
   6-5-room-history-loads-in-the-app: ready-for-dev

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-26T17:42:48Z
-# last_updated: 2026-05-20T22:25:00Z
+# last_updated: 2026-05-21
 # project: munch-helper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-26T17:42:48Z
-last_updated: 2026-05-20T22:25:00Z
+last_updated: 2026-05-21
 project: munch-helper
 project_key: NOKEY
 tracking_system: file-system
@@ -90,7 +90,7 @@ development_status:
 
   epic-6: in-progress
   6-1-character-events-are-published-for-room-history: done
-  6-2-published-events-are-stored-and-readable-in-room-history: review
+  6-2-published-events-are-stored-and-readable-in-room-history: done
   6-3-battle-lifecycle-events-are-published-for-room-history: ready-for-dev
   6-4-room-history-api-returns-paginated-events: ready-for-dev
   6-5-room-history-loads-in-the-app: ready-for-dev

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,17 +3,21 @@ ROOM_SERVICE_PORT=8083
 CHARACTER_SERVICE_PORT=8084
 ROOM_NOTIFICATIONS_SERVICE_PORT=8085
 PORT=8086
+LOG_SERVICE_PORT=8087
 
 USER_MONGO_URI=mongodb://localhost:27021/munch_user_service
 ROOM_MONGO_URI=mongodb://localhost:27022/munch_room_service
 CHARACTER_MONGO_URI=mongodb://localhost:27023/munch_character_service
 BATTLE_MONGO_URI=mongodb://localhost:27024/munch_battle_service
+LOG_MONGO_URI=mongodb://localhost:27025/munch_log_service
 
 USER_SERVICE_URL=http://localhost:8082
 ROOM_SERVICE_URL=http://localhost:8083
 CHARACTER_SERVICE_URL=http://localhost:8084
 ROOM_NOTIFICATIONS_SERVICE_URL=http://localhost:8085
 BATTLE_SERVICE_URL=http://localhost:8086
+LOG_SERVICE_URL=http://localhost:8087
 
 
 CHARACTER_CALL_TIMEOUT_MS=2000
+ROOM_LOG_EVENTS_CHANNEL=room-log-events

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,7 @@ This backend is split into local microservices under `backend`:
 - `character-service`
 - `battle-service`
 - `room-notifications-service`
+- `log-service`
 
 ## Scope
 
@@ -17,6 +18,7 @@ Implemented in this phase:
 - Room management (`POST /rooms`, `POST /rooms/associations`)
 - Character management (`GET /characters?roomId=...`, `POST /characters`, `PATCH /characters/:characterId`, `DELETE /characters/:characterId`)
 - Battle management (`GET /battles?roomId=...&status=active`, `POST /battles`, `PATCH /battles/:id`)
+- Room history log persistence and reader skeleton (`GET /logs?roomId=...`)
 - Room service synchronous call to character service on create/join flow.
 - Room notifications over WebSocket (`character_created`, `character_updated`, `character_deleted`).
 - Character events are also published to the room-history log target when `LOG_TOPIC_ARN` (Lambda) or `ROOM_LOG_EVENTS_CHANNEL` (local Redis, default `room-log-events`) is configured.
@@ -51,14 +53,15 @@ Nginx runs on `http://localhost:8080` by default and proxies:
 - `/rooms` -> `room-service`
 - `/characters` -> `character-service`
 - `/battles` -> `battle-service`
+- `/logs` -> `log-service`
 - `/ws` -> `room-notifications-service`
 
 Room notifications are available through `ws://localhost:8080/ws?roomId=<RoomId>&userId=<UserId>`.
-The notifications container is also exposed directly on `ws://localhost:8084/ws?roomId=<RoomId>&userId=<UserId>` for debugging.
+The notifications container is also exposed directly on `ws://localhost:8085/ws?roomId=<RoomId>&userId=<UserId>` for debugging.
 
-## AWS SAM option (user/room/character services on Lambda)
+## AWS SAM option (backend services on Lambda)
 
-This repository includes an optional SAM-based flow for deploying `user-service`, `room-service`, and `character-service` to AWS Lambda.
+This repository includes an optional SAM-based flow for deploying the backend services to AWS Lambda.
 
 Prerequisites:
 
@@ -93,6 +96,7 @@ Notes:
 	- `mongodb://host.docker.internal:27022/munch_room_service`
 	- `mongodb://host.docker.internal:27023/munch_character_service`
 	- `mongodb://host.docker.internal:27024/munch_battle_service`
+	- `mongodb://host.docker.internal:27025/munch_log_service`
 - Room-to-character service call URL defaults to `http://host.docker.internal:3000` for local SAM.
 - `sam/samconfig.toml` contains default stack and parameter values. Override `UserMongoUri` if needed.
 

--- a/backend/docker-compose.local.yml
+++ b/backend/docker-compose.local.yml
@@ -12,6 +12,7 @@ services:
       - character-service
       - battle-service
       - room-notifications-service
+      - log-service
 
   user-service:
     build:
@@ -84,6 +85,21 @@ services:
     depends_on:
       - redis
 
+  log-service:
+    build:
+      context: ./log-service
+    container_name: munch-log-service
+    ports:
+      - "8087:8087"
+    environment:
+      PORT: 8087
+      LOG_MONGO_URI: mongodb://mongo-log:27017/munch_log_service
+      REDIS_URL: redis://redis:6379
+      ROOM_LOG_EVENTS_CHANNEL: room-log-events
+    depends_on:
+      - mongo-log
+      - redis
+
   redis:
     image: redis:7-alpine
     container_name: munch-redis
@@ -122,8 +138,17 @@ services:
     volumes:
       - mongo-battle-data:/data/db
 
+  mongo-log:
+    image: mongo:7
+    container_name: munch-mongo-log
+    ports:
+      - "27025:27017"
+    volumes:
+      - mongo-log-data:/data/db
+
 volumes:
   mongo-user-data:
   mongo-room-data:
   mongo-character-data:
   mongo-battle-data:
+  mongo-log-data:

--- a/backend/log-service/.env.example
+++ b/backend/log-service/.env.example
@@ -1,0 +1,5 @@
+LOG_MONGO_URI=mongodb://localhost:27025/munch_log_service
+LOG_TOPIC_ARN=
+ROOM_LOG_EVENTS_CHANNEL=room-log-events
+REDIS_URL=redis://localhost:6379
+PORT=8087

--- a/backend/log-service/Dockerfile
+++ b/backend/log-service/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY src ./src
+
+EXPOSE 8087
+
+CMD ["npm", "start"]

--- a/backend/log-service/package.json
+++ b/backend/log-service/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "log-service",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev": "tsx watch src/index.ts",
+    "start:lambda": "tsx src/lambda-read.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@codegenie/serverless-express": "^4.17.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.6.1",
+    "express": "^5.1.0",
+    "mongoose": "^8.19.1",
+    "morgan": "^1.10.1",
+    "redis": "^5.8.2",
+    "tsx": "^4.20.5"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.3",
+    "@types/morgan": "^1.9.10",
+    "@types/node": "^24.3.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/backend/log-service/src/app.ts
+++ b/backend/log-service/src/app.ts
@@ -1,0 +1,54 @@
+import cors from 'cors';
+import express, { NextFunction, Request, Response } from 'express';
+import morgan from 'morgan';
+import { logsRouter } from './routes/logs';
+
+interface BuildLogAppOptions {
+  routePrefix?: string;
+}
+
+const normalizeRoutePrefix = (value: string | undefined): string => {
+  if (!value) {
+    return '/';
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '/') {
+    return '/';
+  }
+
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const withoutTrailingSlash = withLeadingSlash.replace(/\/+$/, '');
+  return withoutTrailingSlash || '/';
+};
+
+export function buildLogApp(options: BuildLogAppOptions = {}) {
+  const app = express();
+  const routePrefix = normalizeRoutePrefix(options.routePrefix);
+
+  console.info('[log-service] app initialized', {
+    routePrefix
+  });
+
+  app.use(cors());
+  app.use(morgan('dev'));
+  app.use(express.json());
+
+  if (routePrefix !== '/') {
+    app.use(routePrefix, logsRouter);
+  } else {
+    app.use(logsRouter);
+  }
+
+  app.use((error: unknown, _request: Request, response: Response, _next: NextFunction) => {
+    if (error instanceof SyntaxError) {
+      response.status(400).json({ message: 'Invalid JSON body' });
+      return;
+    }
+
+    console.error('[log-service] unexpected error', error);
+    response.status(502).json({ message: 'Unexpected error' });
+  });
+
+  return app;
+}

--- a/backend/log-service/src/db.test.ts
+++ b/backend/log-service/src/db.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockMongoose = {
+  connection: {
+    readyState: 0,
+  },
+  connect: vi.fn(),
+};
+
+vi.mock('mongoose', () => ({
+  default: mockMongoose,
+}));
+
+describe('log-service db', () => {
+  beforeEach(() => {
+    mockMongoose.connection.readyState = 0;
+    mockMongoose.connect.mockReset();
+    vi.resetModules();
+  });
+
+  it('skips connecting when mongoose is already connected', async () => {
+    mockMongoose.connection.readyState = 1;
+    const { connectToMongo } = await import('./db.js');
+
+    await connectToMongo('mongodb://example/logs');
+
+    expect(mockMongoose.connect).not.toHaveBeenCalled();
+  });
+
+  it('reuses the same in-flight connection promise', async () => {
+    let resolveConnection: (() => void) | undefined;
+    mockMongoose.connect.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveConnection = () => resolve(mockMongoose as never);
+    }));
+
+    const { connectToMongo } = await import('./db.js');
+
+    const first = connectToMongo('mongodb://example/logs');
+    const second = connectToMongo('mongodb://example/logs');
+    resolveConnection?.();
+
+    await Promise.all([first, second]);
+
+    expect(mockMongoose.connect).toHaveBeenCalledTimes(1);
+    expect(mockMongoose.connect).toHaveBeenCalledWith('mongodb://example/logs');
+  });
+
+  it('resets the cached promise after a failed connection attempt', async () => {
+    mockMongoose.connect
+      .mockRejectedValueOnce(new Error('first failure'))
+      .mockResolvedValueOnce(mockMongoose as never);
+
+    const { connectToMongo } = await import('./db.js');
+
+    await expect(connectToMongo('mongodb://example/logs')).rejects.toThrow('first failure');
+    await expect(connectToMongo('mongodb://example/logs')).resolves.toBeUndefined();
+
+    expect(mockMongoose.connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/log-service/src/db.ts
+++ b/backend/log-service/src/db.ts
@@ -1,0 +1,20 @@
+import mongoose from 'mongoose';
+
+let connectionPromise: Promise<typeof mongoose> | null = null;
+
+export async function connectToMongo(mongoUri: string): Promise<void> {
+  if (mongoose.connection.readyState === 1) {
+    return;
+  }
+
+  if (!connectionPromise) {
+    connectionPromise = mongoose.connect(mongoUri).catch((error) => {
+      connectionPromise = null;
+      throw error;
+    });
+  }
+
+  await connectionPromise;
+}
+
+export { mongoose };

--- a/backend/log-service/src/index.ts
+++ b/backend/log-service/src/index.ts
@@ -1,0 +1,66 @@
+import dotenv from 'dotenv';
+import { createClient } from 'redis';
+import { buildLogApp } from './app';
+import { connectToMongo } from './db';
+import { parseLogEvent, persistLogEvent } from './service';
+
+dotenv.config();
+
+const app = buildLogApp();
+const port = Number(process.env.PORT || 8087);
+const mongoUri = process.env.LOG_MONGO_URI || 'mongodb://localhost:27025/munch_log_service';
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const eventsChannel = process.env.ROOM_LOG_EVENTS_CHANNEL || 'room-log-events';
+
+const startHttpServer = async (): Promise<void> => {
+  await connectToMongo(mongoUri);
+  await new Promise<void>((resolve) => {
+    app.listen(port, () => {
+      console.log(`log-service listening on :${port}`);
+      resolve();
+    });
+  });
+};
+
+const startSubscriber = async (): Promise<void> => {
+  const subscriber = createClient({ url: redisUrl });
+  subscriber.on('error', (error) => {
+    console.error('[log-service] redis client error', {
+      channel: eventsChannel,
+      redisUrl,
+      error
+    });
+  });
+
+  await subscriber.connect();
+  await subscriber.subscribe(eventsChannel, async (message) => {
+    console.info('[log-service] local event received', {
+      channel: eventsChannel
+    });
+
+    const parsedEvent = parseLogEvent(message);
+    if (!parsedEvent) {
+      console.warn('log.redis.invalid_event', {
+        channel: eventsChannel
+      });
+      return;
+    }
+
+    await connectToMongo(mongoUri);
+    await persistLogEvent(parsedEvent);
+  });
+
+  console.info('[log-service] subscribed to Redis channel', {
+    channel: eventsChannel,
+    redisUrl
+  });
+};
+
+const start = async (): Promise<void> => {
+  await Promise.all([startSubscriber(), startHttpServer()]);
+};
+
+start().catch((error: unknown) => {
+  console.error('Failed to start log-service', error);
+  process.exit(1);
+});

--- a/backend/log-service/src/index.ts
+++ b/backend/log-service/src/index.ts
@@ -34,20 +34,27 @@ const startSubscriber = async (): Promise<void> => {
 
   await subscriber.connect();
   await subscriber.subscribe(eventsChannel, async (message) => {
-    console.info('[log-service] local event received', {
-      channel: eventsChannel
-    });
-
-    const parsedEvent = parseLogEvent(message);
-    if (!parsedEvent) {
-      console.warn('log.redis.invalid_event', {
+    try {
+      console.info('[log-service] local event received', {
         channel: eventsChannel
       });
-      return;
-    }
 
-    await connectToMongo(mongoUri);
-    await persistLogEvent(parsedEvent);
+      const parsedEvent = parseLogEvent(message);
+      if (!parsedEvent) {
+        console.warn('log.redis.invalid_event', {
+          channel: eventsChannel
+        });
+        return;
+      }
+
+      await connectToMongo(mongoUri);
+      await persistLogEvent(parsedEvent);
+    } catch (error) {
+      console.error('[log-service] failed to process local event', {
+        channel: eventsChannel,
+        error
+      });
+    }
   });
 
   console.info('[log-service] subscribed to Redis channel', {

--- a/backend/log-service/src/lambda-read.test.ts
+++ b/backend/log-service/src/lambda-read.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockConnectToMongo, mockBuildLogApp, mockServerFactory, mockServerHandler } = vi.hoisted(() => ({
+  mockConnectToMongo: vi.fn(),
+  mockBuildLogApp: vi.fn(() => 'log-app'),
+  mockServerHandler: vi.fn(),
+  mockServerFactory: vi.fn(),
+}));
+
+vi.mock('./db', () => ({
+  connectToMongo: mockConnectToMongo,
+}));
+
+vi.mock('./app', () => ({
+  buildLogApp: mockBuildLogApp,
+}));
+
+vi.mock('@codegenie/serverless-express', () => ({
+  default: mockServerFactory,
+}));
+
+describe('log-service read lambda', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockConnectToMongo.mockReset();
+    mockBuildLogApp.mockReset();
+    mockBuildLogApp.mockReturnValue('log-app');
+    mockServerHandler.mockReset();
+    mockServerFactory.mockReset();
+    mockServerFactory.mockReturnValue(mockServerHandler);
+    delete process.env.ROUTE_PREFIX;
+    delete process.env.LOG_MONGO_URI;
+  });
+
+  it('connects to log Mongo before handling HTTP events', async () => {
+    mockServerHandler.mockResolvedValueOnce({ statusCode: 200, body: 'ok' });
+    const { handler } = await import('./lambda-read.js');
+
+    await expect(handler({ rawPath: '/logs' }, {})).resolves.toEqual({ statusCode: 200, body: 'ok' });
+    expect(mockConnectToMongo).toHaveBeenCalledWith('mongodb://localhost:27025/munch_log_service');
+    expect(mockServerHandler).toHaveBeenCalledWith({ rawPath: '/logs' }, {});
+  });
+
+  it('boots with route prefix and configured mongo URI', async () => {
+    process.env.ROUTE_PREFIX = '/prod';
+    process.env.LOG_MONGO_URI = 'mongodb://mongo/logs';
+    mockServerHandler.mockResolvedValueOnce({ statusCode: 200 });
+
+    const { handler } = await import('./lambda-read.js');
+    await handler({ path: '/logs' }, {});
+
+    expect(mockBuildLogApp).toHaveBeenCalledWith({ routePrefix: '/prod' });
+    expect(mockConnectToMongo).toHaveBeenCalledWith('mongodb://mongo/logs');
+  });
+});

--- a/backend/log-service/src/lambda-read.ts
+++ b/backend/log-service/src/lambda-read.ts
@@ -1,0 +1,21 @@
+import serverlessExpress from '@codegenie/serverless-express';
+import { buildLogApp } from './app';
+import { connectToMongo } from './db';
+
+const routePrefix = process.env.ROUTE_PREFIX || '/';
+const app = buildLogApp({ routePrefix });
+const mongoUri = process.env.LOG_MONGO_URI || 'mongodb://localhost:27025/munch_log_service';
+
+console.info('[log-service] lambda reader bootstrap config', {
+  routePrefix,
+  mongoUri
+});
+
+const server = serverlessExpress({ app });
+
+export const handler = async (event: unknown, context: unknown) => {
+  console.info('[log-service] lambda reader invocation started');
+  await connectToMongo(mongoUri);
+  console.info('[log-service] lambda reader mongo connection ready');
+  return server(event, context);
+};

--- a/backend/log-service/src/models/LogEvent.ts
+++ b/backend/log-service/src/models/LogEvent.ts
@@ -1,0 +1,56 @@
+import { mongoose } from '../db';
+
+export type LogEventType =
+  | 'character_created'
+  | 'character_updated'
+  | 'character_deleted'
+  | 'battle_started'
+  | 'battle_concluded'
+  | 'battle_discarded';
+
+export interface LogEventDocument {
+  roomId: string;
+  eventType: LogEventType;
+  actorId: string;
+  summary: string;
+  payload: Record<string, unknown>;
+  occurredAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const logEventSchema = new mongoose.Schema<LogEventDocument>(
+  {
+    roomId: { type: String, required: true },
+    eventType: {
+      type: String,
+      required: true,
+      enum: [
+        'character_created',
+        'character_updated',
+        'character_deleted',
+        'battle_started',
+        'battle_concluded',
+        'battle_discarded'
+      ]
+    },
+    actorId: { type: String, required: true },
+    summary: { type: String, required: true },
+    payload: { type: mongoose.Schema.Types.Mixed, required: true },
+    occurredAt: { type: Date, required: true }
+  },
+  {
+    timestamps: true,
+    toJSON: {
+      virtuals: true,
+      transform: (_doc, ret) => {
+        delete ret._id;
+        delete ret.__v;
+      }
+    }
+  }
+);
+
+logEventSchema.index({ roomId: 1, _id: -1 });
+
+export const LogEvent = mongoose.model<LogEventDocument>('LogEvent', logEventSchema);

--- a/backend/log-service/src/routes/logs.test.ts
+++ b/backend/log-service/src/routes/logs.test.ts
@@ -1,0 +1,29 @@
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { buildLogApp } from '../app';
+
+describe('log-service logs routes', () => {
+  it('returns an empty history skeleton for a present roomId', async () => {
+    const response = await request(buildLogApp()).get('/logs').query({ roomId: 'room-1' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
+  });
+
+  it('returns 400 when roomId is missing or blank', async () => {
+    const missingResponse = await request(buildLogApp()).get('/logs');
+    const blankResponse = await request(buildLogApp()).get('/logs').query({ roomId: ' ' });
+
+    expect(missingResponse.status).toBe(400);
+    expect(missingResponse.body).toEqual({ message: 'roomId is required' });
+    expect(blankResponse.status).toBe(400);
+    expect(blankResponse.body).toEqual({ message: 'roomId is required' });
+  });
+
+  it('mounts under a route prefix', async () => {
+    const response = await request(buildLogApp({ routePrefix: '/prod' })).get('/prod/logs').query({ roomId: 'room-1' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
+  });
+});

--- a/backend/log-service/src/routes/logs.ts
+++ b/backend/log-service/src/routes/logs.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+
+export const logsRouter = Router();
+
+logsRouter.get('/logs', (request, response) => {
+  const roomId = typeof request.query.roomId === 'string' ? request.query.roomId.trim() : '';
+  if (!roomId) {
+    response.status(400).json({ message: 'roomId is required' });
+    return;
+  }
+
+  // Story 6.4: cursor pagination + roomId-filtered query + GET /logs/:logId implemented here.
+  response.status(200).json([]);
+});

--- a/backend/log-service/src/service.test.ts
+++ b/backend/log-service/src/service.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockLogEventCreate } = vi.hoisted(() => ({
+  mockLogEventCreate: vi.fn(),
+}));
+
+vi.mock('./models/LogEvent', () => ({
+  LogEvent: {
+    create: mockLogEventCreate,
+  },
+}));
+
+describe('log-service service', () => {
+  beforeEach(() => {
+    mockLogEventCreate.mockReset();
+    vi.useRealTimers();
+  });
+
+  it('maps and persists each supported event type', async () => {
+    const { parseLogEvent, persistLogEvent } = await import('./service.js');
+    const payloads = [
+      {
+        eventType: 'character_created',
+        roomId: ' room-1 ',
+        actorId: 'char-1',
+        occurredAt: '2026-05-20T10:00:00.000Z',
+        character: { id: 'char-1', name: 'Ada', avatarId: 1, color: '#fff' },
+      },
+      {
+        eventType: 'character_updated',
+        roomId: 'room-1',
+        actorId: 'char-1',
+        occurredAt: '2026-05-20T10:01:00.000Z',
+        character: { id: 'char-1', name: 'Ada', avatarId: 1, color: '#fff' },
+        changes: { level: { prev: 1, next: 2 } },
+      },
+      {
+        eventType: 'character_deleted',
+        roomId: 'room-1',
+        actorId: 'char-1',
+        occurredAt: '2026-05-20T10:02:00.000Z',
+        character: { id: 'char-1', name: 'Ada', avatarId: 1, color: '#fff' },
+      },
+      {
+        eventType: 'battle_started',
+        roomId: 'room-1',
+        actorId: 'battle-1',
+        occurredAt: '2026-05-20T10:03:00.000Z',
+        name: 'Door',
+      },
+      {
+        eventType: 'battle_concluded',
+        roomId: 'room-1',
+        actorId: 'battle-1',
+        occurredAt: '2026-05-20T10:04:00.000Z',
+        name: 'Door',
+        result: 'players_win',
+      },
+      {
+        eventType: 'battle_discarded',
+        roomId: 'room-1',
+        actorId: 'battle-1',
+        occurredAt: '2026-05-20T10:05:00.000Z',
+        name: 'Door',
+      },
+    ];
+
+    for (const payload of payloads) {
+      const parsed = parseLogEvent(payload);
+      expect(parsed).toEqual(expect.objectContaining({
+        roomId: 'room-1',
+        eventType: payload.eventType,
+        actorId: payload.actorId,
+        payload,
+      }));
+      await persistLogEvent(parsed!);
+    }
+
+    expect(mockLogEventCreate).toHaveBeenCalledTimes(6);
+    expect(mockLogEventCreate).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      roomId: 'room-1',
+      eventType: 'character_created',
+      actorId: 'char-1',
+      summary: 'Ada created',
+      payload: payloads[0],
+      occurredAt: new Date('2026-05-20T10:00:00.000Z'),
+    }));
+    expect(mockLogEventCreate).toHaveBeenNthCalledWith(5, expect.objectContaining({
+      eventType: 'battle_concluded',
+      summary: "Battle 'Door' concluded — players_win",
+    }));
+  });
+
+  it('uses legacy payload fields and parses JSON strings', async () => {
+    const { parseLogEvent } = await import('./service.js');
+
+    const parsed = parseLogEvent(JSON.stringify({
+      event: 'character_created',
+      roomId: 'room-legacy',
+      event_body: { characterId: 'char-legacy' },
+      emittedAt: '2026-05-20T11:00:00.000Z',
+    }));
+
+    expect(parsed).toEqual(expect.objectContaining({
+      roomId: 'room-legacy',
+      eventType: 'character_created',
+      actorId: 'char-legacy',
+      occurredAt: new Date('2026-05-20T11:00:00.000Z'),
+      summary: 'char-legacy created',
+    }));
+  });
+
+  it('falls back to the current time for missing occurredAt', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'));
+    const { parseLogEvent } = await import('./service.js');
+
+    const parsed = parseLogEvent({
+      eventType: 'battle_started',
+      roomId: 'room-1',
+      event_body: { battleId: 'battle-1' },
+    });
+
+    expect(parsed?.occurredAt).toEqual(new Date('2026-05-20T12:00:00.000Z'));
+  });
+
+  it('renders character change summaries with every changed field', async () => {
+    const { parseLogEvent } = await import('./service.js');
+
+    const parsed = parseLogEvent({
+      eventType: 'character_updated',
+      roomId: 'room-1',
+      actorId: 'char-1',
+      character: { id: 'char-1', name: 'Ada', avatarId: 1, color: '#fff' },
+      changes: {
+        level: { prev: 3, next: 4 },
+        name: { prev: 'Ada', next: 'Ada Prime' },
+      },
+    });
+
+    expect(parsed?.summary).toBe('Ada updated: level 3 → 4, name Ada → Ada Prime');
+  });
+
+  it('skips unsupported and malformed payloads without writing', async () => {
+    const { parseLogEvent, persistLogEvent } = await import('./service.js');
+
+    expect(parseLogEvent({ eventType: 'battle_updated', roomId: 'room-1', actorId: 'battle-1' })).toBeNull();
+    expect(parseLogEvent({ eventType: 'character_created', actorId: 'char-1' })).toBeNull();
+    expect(parseLogEvent('{bad json')).toBeNull();
+    expect(parseLogEvent(null)).toBeNull();
+
+    expect(mockLogEventCreate).not.toHaveBeenCalled();
+    await expect(persistLogEvent({
+      roomId: 'room-1',
+      eventType: 'character_created',
+      actorId: 'char-1',
+      summary: 'Ada created',
+      payload: {},
+      occurredAt: new Date('2026-05-20T10:00:00.000Z'),
+    })).resolves.toBeUndefined();
+  });
+
+  it('builds summaries with missing optional fields without throwing', async () => {
+    const { buildSummary } = await import('./service.js');
+
+    expect(buildSummary({ eventType: 'character_updated', actorId: 'char-1', payload: {} })).toBe('char-1 updated');
+    expect(buildSummary({ eventType: 'battle_started', actorId: 'battle-1', payload: {} })).toBe('Battle started');
+    expect(buildSummary({ eventType: 'battle_discarded', actorId: 'battle-1', payload: { battle: { name: 'Side Door' } } }))
+      .toBe("Battle 'Side Door' discarded");
+  });
+});

--- a/backend/log-service/src/service.test.ts
+++ b/backend/log-service/src/service.test.ts
@@ -124,6 +124,23 @@ describe('log-service service', () => {
     expect(parsed?.occurredAt).toEqual(new Date('2026-05-20T12:00:00.000Z'));
   });
 
+  it('falls back to the current time when occurredAt is unparseable', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-20T12:00:00.000Z'));
+    const { parseLogEvent } = await import('./service.js');
+
+    const parsed = parseLogEvent({
+      eventType: 'character_created',
+      roomId: 'room-1',
+      actorId: 'char-1',
+      occurredAt: 'not-a-real-date',
+      character: { id: 'char-1', name: 'Ada', avatarId: 1, color: '#fff' },
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.occurredAt).toEqual(new Date('2026-05-20T12:00:00.000Z'));
+  });
+
   it('renders character change summaries with every changed field', async () => {
     const { parseLogEvent } = await import('./service.js');
 

--- a/backend/log-service/src/service.ts
+++ b/backend/log-service/src/service.ts
@@ -139,10 +139,8 @@ export function parseLogEvent(payload: unknown): LogEventInput | null {
   }
 
   const occurredAtValue = trimString(payload.occurredAt) || trimString(payload.emittedAt) || new Date().toISOString();
-  const occurredAt = new Date(occurredAtValue);
-  if (Number.isNaN(occurredAt.getTime())) {
-    return null;
-  }
+  const parsedOccurredAt = new Date(occurredAtValue);
+  const occurredAt = Number.isNaN(parsedOccurredAt.getTime()) ? new Date() : parsedOccurredAt;
 
   const baseInput = {
     roomId,

--- a/backend/log-service/src/service.ts
+++ b/backend/log-service/src/service.ts
@@ -1,0 +1,182 @@
+import { LogEvent, type LogEventType } from './models/LogEvent';
+
+export interface LogEventInput {
+  roomId: string;
+  eventType: LogEventType;
+  actorId: string;
+  summary: string;
+  payload: Record<string, unknown>;
+  occurredAt: Date;
+}
+
+export const SUPPORTED_LOG_EVENT_TYPES: LogEventType[] = [
+  'character_created',
+  'character_updated',
+  'character_deleted',
+  'battle_started',
+  'battle_concluded',
+  'battle_discarded'
+];
+
+const supportedLogEventTypes = new Set<string>(SUPPORTED_LOG_EVENT_TYPES);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const trimString = (value: unknown): string => typeof value === 'string' ? value.trim() : '';
+
+const readNestedString = (value: unknown, key: string): string => {
+  if (!isPlainObject(value)) {
+    return '';
+  }
+  return trimString(value[key]);
+};
+
+const isLogEventType = (value: string): value is LogEventType => supportedLogEventTypes.has(value);
+
+const isCharacterEvent = (eventType: LogEventType): boolean => eventType.startsWith('character_');
+
+const formatValue = (value: unknown): string => {
+  if (value === null) {
+    return 'null';
+  }
+  if (value === undefined) {
+    return 'none';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value);
+};
+
+const getCharacterName = (payload: Record<string, unknown>, actorId: string): string => {
+  const character = payload.character;
+  const name = readNestedString(character, 'name');
+  return name || actorId;
+};
+
+const getBattleName = (payload: Record<string, unknown>): string => {
+  const directName = trimString(payload.name);
+  if (directName) {
+    return directName;
+  }
+  return readNestedString(payload.battle, 'name');
+};
+
+const getBattleResult = (payload: Record<string, unknown>): string => {
+  const directResult = trimString(payload.result);
+  if (directResult) {
+    return directResult;
+  }
+  return readNestedString(payload.battle, 'result');
+};
+
+const battleLabel = (payload: Record<string, unknown>): string => {
+  const name = getBattleName(payload);
+  return name ? `Battle '${name}'` : 'Battle';
+};
+
+export function buildSummary(input: Pick<LogEventInput, 'actorId' | 'eventType' | 'payload'>): string {
+  const { actorId, eventType, payload } = input;
+
+  switch (eventType) {
+    case 'character_created':
+      return `${getCharacterName(payload, actorId)} created`;
+    case 'character_deleted':
+      return `${getCharacterName(payload, actorId)} removed`;
+    case 'character_updated': {
+      const changes = isPlainObject(payload.changes) ? payload.changes : {};
+      const changedList = Object.entries(changes)
+        .flatMap(([field, value]) => {
+          if (!isPlainObject(value)) {
+            return [];
+          }
+          return [`${field} ${formatValue(value.prev)} → ${formatValue(value.next)}`];
+        })
+        .join(', ');
+      const name = getCharacterName(payload, actorId);
+      return changedList ? `${name} updated: ${changedList}` : `${name} updated`;
+    }
+    case 'battle_started':
+      return `${battleLabel(payload)} started`;
+    case 'battle_concluded': {
+      const result = getBattleResult(payload);
+      return `${battleLabel(payload)} concluded${result ? ` — ${result}` : ''}`;
+    }
+    case 'battle_discarded':
+      return `${battleLabel(payload)} discarded`;
+    default:
+      return `${eventType} event`;
+  }
+}
+
+export function parseLogEvent(payload: unknown): LogEventInput | null {
+  if (typeof payload === 'string') {
+    try {
+      return parseLogEvent(JSON.parse(payload));
+    } catch {
+      return null;
+    }
+  }
+
+  if (!isPlainObject(payload)) {
+    return null;
+  }
+
+  const eventTypeValue = trimString(payload.eventType) || trimString(payload.event);
+  if (!isLogEventType(eventTypeValue)) {
+    return null;
+  }
+
+  const roomId = trimString(payload.roomId);
+  const eventBody = payload.event_body;
+  const actorId = trimString(payload.actorId)
+    || (isCharacterEvent(eventTypeValue) ? readNestedString(eventBody, 'characterId') : readNestedString(eventBody, 'battleId'))
+    || trimString(payload.battleId);
+
+  if (!roomId || !actorId) {
+    return null;
+  }
+
+  const occurredAtValue = trimString(payload.occurredAt) || trimString(payload.emittedAt) || new Date().toISOString();
+  const occurredAt = new Date(occurredAtValue);
+  if (Number.isNaN(occurredAt.getTime())) {
+    return null;
+  }
+
+  const baseInput = {
+    roomId,
+    eventType: eventTypeValue,
+    actorId,
+    payload,
+    occurredAt
+  };
+
+  return {
+    ...baseInput,
+    summary: buildSummary(baseInput)
+  };
+}
+
+export async function persistLogEvent(input: LogEventInput): Promise<void> {
+  console.info('log-service.event.persisting', {
+    eventType: input.eventType,
+    roomId: input.roomId,
+    actorId: input.actorId
+  });
+
+  await LogEvent.create({
+    roomId: input.roomId,
+    eventType: input.eventType,
+    actorId: input.actorId,
+    summary: input.summary,
+    payload: input.payload,
+    occurredAt: input.occurredAt
+  });
+
+  console.info('log-service.event.persisted', {
+    eventType: input.eventType,
+    roomId: input.roomId,
+    actorId: input.actorId
+  });
+}

--- a/backend/log-service/src/subscriber.test.ts
+++ b/backend/log-service/src/subscriber.test.ts
@@ -60,6 +60,36 @@ describe('log-service subscriber', () => {
     expect(response).toEqual({ statusCode: 200, body: JSON.stringify({ processed: 2 }) });
   });
 
+  it('continues the batch when a record fails to persist', async () => {
+    process.env.LOG_TOPIC_ARN = 'arn:aws:sns:log-topic';
+    const firstParsed = {
+      roomId: 'room-1',
+      eventType: 'character_created',
+      actorId: 'char-1',
+      summary: 'Ada created',
+      payload: {},
+      occurredAt: new Date('2026-05-20T10:00:00.000Z'),
+    };
+    const secondParsed = { ...firstParsed, actorId: 'char-2' };
+    mockParseLogEvent
+      .mockReturnValueOnce(firstParsed)
+      .mockReturnValueOnce(secondParsed);
+    mockPersistLogEvent
+      .mockRejectedValueOnce(new Error('mongo write failed'))
+      .mockResolvedValueOnce(undefined);
+
+    const { handler } = await import('./subscriber.js');
+    const response = await handler({
+      Records: [
+        { Sns: { Message: 'fails' } },
+        { Sns: { Message: 'succeeds' } },
+      ],
+    });
+
+    expect(mockPersistLogEvent).toHaveBeenCalledTimes(2);
+    expect(response).toEqual({ statusCode: 200, body: JSON.stringify({ processed: 1 }) });
+  });
+
   it('connects to the configured log Mongo URI', async () => {
     process.env.LOG_TOPIC_ARN = 'arn:aws:sns:log-topic';
     process.env.LOG_MONGO_URI = 'mongodb://mongo/logs';

--- a/backend/log-service/src/subscriber.test.ts
+++ b/backend/log-service/src/subscriber.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockConnectToMongo, mockParseLogEvent, mockPersistLogEvent } = vi.hoisted(() => ({
+  mockConnectToMongo: vi.fn(),
+  mockParseLogEvent: vi.fn(),
+  mockPersistLogEvent: vi.fn(),
+}));
+
+vi.mock('./db', () => ({
+  connectToMongo: mockConnectToMongo,
+}));
+
+vi.mock('./service', () => ({
+  parseLogEvent: mockParseLogEvent,
+  persistLogEvent: mockPersistLogEvent,
+}));
+
+describe('log-service subscriber', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockConnectToMongo.mockReset();
+    mockParseLogEvent.mockReset();
+    mockPersistLogEvent.mockReset();
+    delete process.env.LOG_TOPIC_ARN;
+    delete process.env.LOG_MONGO_URI;
+  });
+
+  it('fails fast when LOG_TOPIC_ARN is missing', async () => {
+    await expect(import('./subscriber.js')).rejects.toThrow('LOG_TOPIC_ARN is required for log-service logWriter');
+  });
+
+  it('persists valid records and skips invalid records in the same batch', async () => {
+    process.env.LOG_TOPIC_ARN = 'arn:aws:sns:log-topic';
+    const validParsed = {
+      roomId: 'room-1',
+      eventType: 'character_created',
+      actorId: 'char-1',
+      summary: 'Ada created',
+      payload: {},
+      occurredAt: new Date('2026-05-20T10:00:00.000Z'),
+    };
+    mockParseLogEvent
+      .mockReturnValueOnce(validParsed)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({ ...validParsed, actorId: 'battle-1', eventType: 'battle_started' });
+
+    const { handler } = await import('./subscriber.js');
+    const response = await handler({
+      Records: [
+        { Sns: { Message: 'valid-1' } },
+        { Sns: { Message: 'invalid' } },
+        { Sns: { Message: 'valid-2' } },
+      ],
+    });
+
+    expect(mockConnectToMongo).toHaveBeenCalledWith('mongodb://localhost:27017/munch_log_service');
+    expect(mockParseLogEvent).toHaveBeenCalledTimes(3);
+    expect(mockPersistLogEvent).toHaveBeenCalledTimes(2);
+    expect(mockPersistLogEvent).toHaveBeenNthCalledWith(1, validParsed);
+    expect(response).toEqual({ statusCode: 200, body: JSON.stringify({ processed: 2 }) });
+  });
+
+  it('connects to the configured log Mongo URI', async () => {
+    process.env.LOG_TOPIC_ARN = 'arn:aws:sns:log-topic';
+    process.env.LOG_MONGO_URI = 'mongodb://mongo/logs';
+    mockParseLogEvent.mockReturnValue(null);
+
+    const { handler } = await import('./subscriber.js');
+    await handler({ Records: [{ Sns: { Message: 'invalid' } }] });
+
+    expect(mockConnectToMongo).toHaveBeenCalledWith('mongodb://mongo/logs');
+  });
+});

--- a/backend/log-service/src/subscriber.ts
+++ b/backend/log-service/src/subscriber.ts
@@ -1,0 +1,47 @@
+import { connectToMongo } from './db';
+import { parseLogEvent, persistLogEvent } from './service';
+
+const mongoUri = process.env.LOG_MONGO_URI || 'mongodb://localhost:27017/munch_log_service';
+const topicArn = process.env.LOG_TOPIC_ARN;
+
+if (!topicArn || !topicArn.trim()) {
+  throw new Error('LOG_TOPIC_ARN is required for log-service logWriter');
+}
+
+const parseSnsRecords = (event: unknown): string[] => {
+  const data = event as { Records?: Array<{ Sns?: { Message?: string } }> };
+  if (!Array.isArray(data?.Records)) {
+    return [];
+  }
+
+  return data.Records.map((record) => record?.Sns?.Message).filter((message): message is string => typeof message === 'string');
+};
+
+export const handler = async (event: unknown) => {
+  const messages = parseSnsRecords(event);
+  console.info('log.sns.received', {
+    messageCount: messages.length,
+    topicArn
+  });
+
+  await connectToMongo(mongoUri);
+
+  let processed = 0;
+  for (const message of messages) {
+    const parsed = parseLogEvent(message);
+    if (!parsed) {
+      console.warn('log.sns.invalid_event', {
+        message
+      });
+      continue;
+    }
+
+    await persistLogEvent(parsed);
+    processed += 1;
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ processed })
+  };
+};

--- a/backend/log-service/src/subscriber.ts
+++ b/backend/log-service/src/subscriber.ts
@@ -36,8 +36,17 @@ export const handler = async (event: unknown) => {
       continue;
     }
 
-    await persistLogEvent(parsed);
-    processed += 1;
+    try {
+      await persistLogEvent(parsed);
+      processed += 1;
+    } catch (error) {
+      console.warn('log.sns.persist_failed', {
+        eventType: parsed.eventType,
+        roomId: parsed.roomId,
+        actorId: parsed.actorId,
+        error
+      });
+    }
   }
 
   return {

--- a/backend/log-service/tsconfig.json
+++ b/backend/log-service/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/backend/nginx/nginx.conf
+++ b/backend/nginx/nginx.conf
@@ -26,6 +26,10 @@ http {
     server battle-service:8086;
   }
 
+  upstream log_service {
+    server log-service:8087;
+  }
+
   upstream room_notifications_service {
     server room-notifications-service:8085;
   }
@@ -139,6 +143,31 @@ http {
       add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, PATCH, DELETE, OPTIONS' always;
       add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept' always;
       proxy_pass http://battle_service;
+    }
+
+    location /logs {
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept';
+        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Content-Type' 'text/plain; charset=utf-8';
+        add_header 'Content-Length' 0;
+        return 204;
+      }
+
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_hide_header Access-Control-Allow-Origin;
+      proxy_hide_header Access-Control-Allow-Methods;
+      proxy_hide_header Access-Control-Allow-Headers;
+      proxy_hide_header Access-Control-Allow-Credentials;
+      add_header 'Access-Control-Allow-Origin' '*' always;
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, PATCH, DELETE, OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept' always;
+      proxy_pass http://log_service;
     }
 
     location /ws {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,8 @@
         "room-service",
         "character-service",
         "battle-service",
-        "room-notifications-service"
+        "room-notifications-service",
+        "log-service"
       ],
       "devDependencies": {
         "@types/supertest": "^6.0.3",
@@ -94,6 +95,43 @@
       }
     },
     "character-service/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "log-service": {
+      "version": "0.1.0",
+      "dependencies": {
+        "@codegenie/serverless-express": "^4.17.1",
+        "cors": "^2.8.5",
+        "dotenv": "^16.6.1",
+        "express": "^5.1.0",
+        "mongoose": "^8.19.1",
+        "morgan": "^1.10.1",
+        "redis": "^5.8.2",
+        "tsx": "^4.20.5"
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.19",
+        "@types/express": "^5.0.3",
+        "@types/morgan": "^1.9.10",
+        "@types/node": "^24.3.0",
+        "typescript": "^5.9.2"
+      }
+    },
+    "log-service/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "log-service/node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
@@ -4097,6 +4135,10 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/log-service": {
+      "resolved": "log-service",
+      "link": true
     },
     "node_modules/loupe": {
       "version": "3.2.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,14 +7,15 @@
     "room-service",
     "character-service",
     "battle-service",
-    "room-notifications-service"
+    "room-notifications-service",
+    "log-service"
   ],
   "scripts": {
-    "dev": "concurrently -n user,room,character,battle,notifications -c green,yellow,magenta,red,blue \"npm run dev -w user-service\" \"npm run dev -w room-service\" \"npm run dev -w character-service\" \"npm run dev -w battle-service\" \"npm run dev -w room-notifications-service\"",
-    "start": "concurrently -n user,room,character,battle,notifications -c green,yellow,magenta,red,blue \"npm run start -w user-service\" \"npm run start -w room-service\" \"npm run start -w character-service\" \"npm run start -w battle-service\" \"npm run start -w room-notifications-service\"",
+    "dev": "concurrently -n user,room,character,battle,notifications,log -c green,yellow,magenta,red,blue,cyan \"npm run dev -w user-service\" \"npm run dev -w room-service\" \"npm run dev -w character-service\" \"npm run dev -w battle-service\" \"npm run dev -w room-notifications-service\" \"npm run dev -w log-service\"",
+    "start": "concurrently -n user,room,character,battle,notifications,log -c green,yellow,magenta,red,blue,cyan \"npm run start -w user-service\" \"npm run start -w room-service\" \"npm run start -w character-service\" \"npm run start -w battle-service\" \"npm run start -w room-notifications-service\" \"npm run start -w log-service\"",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "npm run typecheck -w user-service && npm run typecheck -w room-service && npm run typecheck -w character-service && npm run typecheck -w battle-service && npm run typecheck -w room-notifications-service",
+    "typecheck": "npm run typecheck -w user-service && npm run typecheck -w room-service && npm run typecheck -w character-service && npm run typecheck -w battle-service && npm run typecheck -w room-notifications-service && npm run typecheck -w log-service",
     "sam:build": "sam build --template-file sam/template.yaml",
     "sam:local:api": "sam local start-api --template-file sam/template.yaml --parameter-overrides UserMongoUri=\"mongodb://host.docker.internal:27021/munch_user_service\" RoomMongoUri=\"mongodb://host.docker.internal:27022/munch_room_service\" CharacterMongoUri=\"mongodb://host.docker.internal:27023/munch_character_service\" BattleMongoUri=\"mongodb://host.docker.internal:27024/munch_battle_service\" CharacterServiceUrl=\"http://host.docker.internal:3000\" CharacterCallTimeoutMs=\"2000\"",
     "sam:invoke:user:health": "sam local invoke UserServiceFunction --template-file sam/template.yaml --parameter-overrides UserMongoUri=\"mongodb://host.docker.internal:27021/munch_user_service\" RoomMongoUri=\"mongodb://host.docker.internal:27022/munch_room_service\" CharacterMongoUri=\"mongodb://host.docker.internal:27023/munch_character_service\" BattleMongoUri=\"mongodb://host.docker.internal:27024/munch_battle_service\" CharacterServiceUrl=\"http://host.docker.internal:3000\" CharacterCallTimeoutMs=\"2000\" -e sam/events/user-get-health.json",

--- a/backend/sam/template.yaml
+++ b/backend/sam/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: "Munch Helper backend SAM template (user, room, character, battle, and room notification services)"
+Description: "Munch Helper backend SAM template (user, room, character, battle, room notification, and log services)"
 
 Parameters:
   UserMongoUri:
@@ -23,6 +23,10 @@ Parameters:
     Type: String
     Default: mongodb+srv://sandbox.4ty9upc.mongodb.net/notifications?authSource=%24external&authMechanism=MONGODB-AWS&appName=Sandbox
     Description: MongoDB connection URI used by room-notifications-service Lambda
+  LogMongoUri:
+    Type: String
+    Default: mongodb+srv://sandbox.4ty9upc.mongodb.net/log?authSource=%24external&authMechanism=MONGODB-AWS&appName=Sandbox
+    Description: MongoDB connection URI used by log-service Lambda
   CharacterServiceUrl:
     Type: String
     Description: Base URL for character-service called by room-service
@@ -113,6 +117,14 @@ Resources:
                 Action:
                   - sns:Publish
                 Resource: !Ref RoomCharacterEventsTopic
+        - PolicyName: PublishLogEvents
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Ref LogEventsTopic
 
   BattleServiceRole:
     Type: AWS::IAM::Role
@@ -168,6 +180,11 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: !Sub ${AWS::StackName}-room-character-events
+
+  LogEventsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub ${AWS::StackName}-log-events
 
   CloudWebSocketApi:
     Type: AWS::ApiGatewayV2::Api
@@ -304,6 +321,7 @@ Resources:
         Variables:
           CHARACTER_MONGO_URI: !Ref CharacterMongoUri
           ROOM_CHARACTER_EVENTS_TOPIC_ARN: !Ref RoomCharacterEventsTopic
+          LOG_TOPIC_ARN: !Ref LogEventsTopic
           ROUTE_PREFIX: !Ref RoutePrefix
       Events:
         CharacterListGet:
@@ -419,6 +437,64 @@ Resources:
         Sourcemap: false
         Format: cjs
 
+  LogWriterFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${AWS::StackName}-log-writer
+      CodeUri: ../log-service
+      Handler: subscriber.handler
+      Environment:
+        Variables:
+          LOG_MONGO_URI: !Ref LogMongoUri
+          LOG_TOPIC_ARN: !Ref LogEventsTopic
+      Events:
+        LogEvent:
+          Type: SNS
+          Properties:
+            Topic: !Ref LogEventsTopic
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/subscriber.ts
+        Minify: true
+        Target: es2022
+        Sourcemap: false
+        Format: cjs
+
+  LogReaderFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${AWS::StackName}-log-reader
+      CodeUri: ../log-service
+      Handler: lambda-read.handler
+      Environment:
+        Variables:
+          LOG_MONGO_URI: !Ref LogMongoUri
+          ROUTE_PREFIX: !Ref RoutePrefix
+      Events:
+        LogListGet:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref CloudHttpApi
+            Path: /logs
+            Method: GET
+        LogReadGet:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref CloudHttpApi
+            Path: /logs/{logId}
+            Method: GET
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/lambda-read.ts
+        Minify: true
+        Target: es2022
+        Sourcemap: false
+        Format: cjs
+
   RoomNotificationsLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -437,3 +513,6 @@ Outputs:
   RoomCharacterEventsTopicArn:
     Description: SNS topic used to fan out room character lifecycle notifications
     Value: !Ref RoomCharacterEventsTopic
+  LogEventsTopicArn:
+    Description: SNS topic used to store room history events
+    Value: !Ref LogEventsTopic

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
       'room-service/src/**/*.test.ts',
       'character-service/src/**/*.test.ts',
       'battle-service/src/**/*.test.ts',
-      'room-notifications-service/src/**/*.test.ts'
+      'room-notifications-service/src/**/*.test.ts',
+      'log-service/src/**/*.test.ts'
     ],
     coverage: {
       provider: 'v8',
@@ -18,7 +19,8 @@ export default defineConfig({
         'room-service/src/**/*.ts',
         'character-service/src/**/*.ts',
         'battle-service/src/**/*.ts',
-        'room-notifications-service/src/**/*.ts'
+        'room-notifications-service/src/**/*.ts',
+        'log-service/src/**/*.ts'
       ],
       exclude: [
         '**/*.test.ts',


### PR DESCRIPTION
## Summary

Implements Story 6.2 by adding the new `log-service` backend package for room-history event persistence and a minimal deployable reader skeleton.

## What changed

- Added `backend/log-service` with the `LogEvent` model, SNS `logWriter`, local Redis subscriber, parse/map/summary/persist logic, and `GET /logs` skeleton.
- Registered log-service in backend workspaces, scripts, Vitest discovery, and coverage includes.
- Wired local Docker Compose, nginx proxying, backend env examples, README docs, and SAM resources for `LogEventsTopic`, `LogWriterFunction`, and `LogReaderFunction`.
- Closed the Story 6.1 deferred character-service log topic env/IAM wiring while leaving battle-service log publishing to Story 6.3.
- Updated BMad story and sprint status to `review`.

## Validation

- `cd backend && npm test -- log-service/src`
- `cd backend && npm test`
- `cd backend && npm run typecheck`
- `cd backend && npm run test:coverage`

Coverage completed at 85.76% lines overall and 91.43% for `log-service/src`.