### PR TITLE
[codex] Fix log-service AWS auth dependency

### DIFF
--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - "backend/**"
       - ".github/workflows/backend-ci-cd.yml"
+  pull_request:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci-cd.yml"
 
 permissions:
   contents: read
@@ -30,6 +34,8 @@ jobs:
           - service: character-service
             has_tests: true
           - service: room-notifications-service
+            has_tests: true
+          - service: log-service
             has_tests: true
 
     defaults:

--- a/_bmad-output/implementation-artifacts/6-2-published-events-are-stored-and-readable-in-room-history.md
+++ b/_bmad-output/implementation-artifacts/6-2-published-events-are-stored-and-readable-in-room-history.md
@@ -235,6 +235,8 @@ GPT-5 Codex
 - `cd backend && npm test`
 - `cd backend && npm run typecheck`
 - `cd backend && npm run test:coverage`
+- `cd backend && npm test -- log-service/src/aws-deployment-dependencies.test.ts`
+- `cd backend && npm run sam:build`
 
 ### Completion Notes List
 
@@ -243,6 +245,7 @@ GPT-5 Codex
 - Preserved documented variances: epic `type`/`createdAt` wording is implemented as architecture-authoritative `eventType` plus Mongoose timestamps; local log channel uses `ROOM_LOG_EVENTS_CHANNEL=room-log-events`; subscriber Redis URL is `REDIS_URL`.
 - Added SAM/local/nginx/docs wiring for log-service and closed Story 6.1's deferred character-service log topic env/IAM wiring. Battle-service `LOG_TOPIC_ARN`/IAM remains intentionally owned by Story 6.3.
 - Added and ran log-service unit/route/lambda tests plus full backend tests, typecheck, and coverage. Coverage completed at 85.76% lines overall and 91.43% lines for `log-service/src`.
+- Post-merge deployment fix: added `aws4` as a production dependency of `log-service` because the deployed SAM Mongo URI uses `authMechanism=MONGODB-AWS`; without it, Mongoose/MongoDB throws `MongoMissingDependencyError` during AWS authentication. Added a deployment dependency regression test that checks every SAM service using a `MONGODB-AWS` Mongo URI declares `aws4`.
 
 ### File List
 
@@ -255,6 +258,7 @@ GPT-5 Codex
 - backend/log-service/Dockerfile
 - backend/log-service/package.json
 - backend/log-service/src/app.ts
+- backend/log-service/src/aws-deployment-dependencies.test.ts
 - backend/log-service/src/db.test.ts
 - backend/log-service/src/db.ts
 - backend/log-service/src/index.ts
@@ -277,6 +281,7 @@ GPT-5 Codex
 ### Change Log
 
 - 2026-05-20: Implemented story 6.2 log-service persistence/read skeleton, tests, workspace wiring, infra wiring, and docs.
+- 2026-05-21: Added missing `aws4` production dependency for log-service AWS Mongo authentication and a SAM dependency guard test to prevent future AWS deployment missing-dependency regressions.
 
 ### Review Findings
 

--- a/backend/log-service/package.json
+++ b/backend/log-service/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@codegenie/serverless-express": "^4.17.1",
+    "aws4": "^1.13.2",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "express": "^5.1.0",

--- a/backend/log-service/src/aws-deployment-dependencies.test.ts
+++ b/backend/log-service/src/aws-deployment-dependencies.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type PackageJson = {
+  name?: string;
+  dependencies?: Record<string, string>;
+};
+
+const backendRoot = path.basename(process.cwd()) === 'log-service'
+  ? path.resolve(process.cwd(), '..')
+  : process.cwd();
+const samTemplatePath = path.join(backendRoot, 'sam/template.yaml');
+const samTemplateDir = path.dirname(samTemplatePath);
+
+function readPackageJson(serviceDir: string): PackageJson {
+  return JSON.parse(readFileSync(path.join(serviceDir, 'package.json'), 'utf8')) as PackageJson;
+}
+
+function findAwsAuthMongoParameters(template: string): Set<string> {
+  const params = new Set<string>();
+  const parameterBlockPattern = /^  (\w+MongoUri):\n([\s\S]*?)(?=^  \w|\nGlobals:)/gm;
+
+  for (const match of template.matchAll(parameterBlockPattern)) {
+    const [, parameterName, block] = match;
+
+    if (block.includes('authMechanism=MONGODB-AWS')) {
+      params.add(parameterName);
+    }
+  }
+
+  return params;
+}
+
+function findServicesUsingAwsAuthMongo(template: string, awsAuthParams: Set<string>): string[] {
+  const services = new Set<string>();
+  const functionBlockPattern = /^  (\w+Function):\n([\s\S]*?)(?=^  \w+:\n|^Outputs:)/gm;
+
+  for (const match of template.matchAll(functionBlockPattern)) {
+    const [, , block] = match;
+    const codeUri = block.match(/^\s+CodeUri:\s+(.+)$/m)?.[1]?.trim();
+
+    if (!codeUri) {
+      continue;
+    }
+
+    const referencedParams = [...block.matchAll(/!Ref\s+(\w+)/g)].map((paramMatch) => paramMatch[1]);
+    const usesAwsAuthMongo = referencedParams.some((param) => awsAuthParams.has(param));
+
+    if (usesAwsAuthMongo) {
+      services.add(path.resolve(samTemplateDir, codeUri));
+    }
+  }
+
+  return [...services].sort();
+}
+
+describe('AWS deployment dependencies', () => {
+  it('declares aws4 for every SAM service using MongoDB AWS authentication', () => {
+    const template = readFileSync(samTemplatePath, 'utf8');
+    const awsAuthParams = findAwsAuthMongoParameters(template);
+    const serviceDirs = findServicesUsingAwsAuthMongo(template, awsAuthParams);
+
+    expect(serviceDirs.length).toBeGreaterThan(0);
+
+    const missingAws4 = serviceDirs
+      .map((serviceDir) => ({ serviceDir, packageJson: readPackageJson(serviceDir) }))
+      .filter(({ packageJson }) => !packageJson.dependencies?.aws4)
+      .map(({ serviceDir, packageJson }) => packageJson.name ?? path.basename(serviceDir));
+
+    expect(missingAws4).toEqual([]);
+  });
+});

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -105,6 +105,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@codegenie/serverless-express": "^4.17.1",
+        "aws4": "^1.13.2",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
         "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- Add `aws4` as a production dependency for `backend/log-service` so MongoDB AWS authentication is available in deployed Lambda bundles.
- Add a Vitest regression guard that checks SAM functions using `MONGODB-AWS` Mongo URIs have `aws4` declared in their service package.
- Update Story 6.2 with the post-merge dependency note, validation commands, and file list entry.

## Root Cause
`log-service` uses the SAM `LogMongoUri` default with `authMechanism=MONGODB-AWS`, but unlike the other Mongo-backed backend services it did not declare MongoDB's optional `aws4` dependency. The deployed `subscriber.js` bundle then failed at runtime with `MongoMissingDependencyError`.

## Validation
- `cd backend && npm test -- log-service/src/aws-deployment-dependencies.test.ts`
- `cd backend && npm test`
- `cd backend && npm run typecheck`
- `cd backend && npm run sam:build`
- Loaded the built `LogWriterFunction` with `LOG_TOPIC_ARN` and an AWS-auth Mongo URI set.