### PR TITLE
[codex] Implement battle history lifecycle publishing

### DIFF
--- a/_bmad-output/implementation-artifacts/6-3-battle-lifecycle-events-are-published-for-room-history.md
+++ b/_bmad-output/implementation-artifacts/6-3-battle-lifecycle-events-are-published-for-room-history.md
@@ -1,6 +1,6 @@
 # Story 6.3: Battle Lifecycle Events Are Published for Room History
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -28,50 +28,50 @@ so that the group has a durable record of battle outcomes during the session.
 
 ## Tasks / Subtasks
 
-- [ ] **Task 0 — Verify prerequisites before any edits (blocking gate)**
-  - [ ] Confirm `battle-service/src/app.ts` (or `routes/battles.ts` if Epic 5 extracted routes) exposes the create, `POST /battles/:id/conclude`, `DELETE /battles/:id` (discard), and `PATCH /battles/:id` handlers, and that each already publishes its event to the notifications target via an injected `BattleEventPublisher`.
-  - [ ] Confirm `publisher.ts` already has working `SnsBattleEventPublisher` + `RedisBattleEventPublisher` (notifications leg) wired in `lambda.ts` (`NOTIFICATIONS_TOPIC_ARN` / Epic 5's notifications topic env) and `index.ts` (Redis), mirroring `character-service`.
-  - [ ] If any of the above is missing → **STOP**. Record in Completion Notes that Story 6.3 is blocked on Epic 5 (Stories 5.3/5.4/5.6/5.7) and do not proceed. Do not build Epic 5 scope here.
+- [x] **Task 0 — Verify prerequisites before any edits (blocking gate)**
+  - [x] Confirm `battle-service/src/app.ts` (or `routes/battles.ts` if Epic 5 extracted routes) exposes the create, `POST /battles/:id/conclude`, `DELETE /battles/:id` (discard), and `PATCH /battles/:id` handlers, and that each already publishes its event to the notifications target via an injected `BattleEventPublisher`.
+  - [x] Confirm `publisher.ts` already has working `SnsBattleEventPublisher` + `RedisBattleEventPublisher` (notifications leg) wired in `lambda.ts` (`NOTIFICATIONS_TOPIC_ARN` / Epic 5's notifications topic env) and `index.ts` (Redis), mirroring `character-service`.
+  - [x] If any of the above is missing → **STOP**. Record in Completion Notes that Story 6.3 is blocked on Epic 5 (Stories 5.3/5.4/5.6/5.7) and do not proceed. Do not build Epic 5 scope here.
 
-- [ ] **Task 1 — Enrich the battle event payload contract (AC: 3, 5, 6)**
-  - [ ] In `backend/battle-service/src/publisher.ts`, extend `BattleEventPayload` with an **additive** display-context section. Do **NOT** rename or remove any field the notifications consumer (`room-notifications-service`, wired by Epic 5) already reads (`event`, `roomId`, `battleId`, `emittedAt`, and any other Epic-5-established field) — additive only.
-  - [ ] Add canonical mirror fields to forward-align with the architecture event contract (duplicates of existing data, additive): `eventType` (= `event`), `actorId` (= `battleId`), `occurredAt` (= `emittedAt`) ([Source: architecture/implementation-patterns-consistency-rules.md#Event Payload Contract]).
-  - [ ] Add a `battle` display-context object: `{ id: string; name: string; status: 'active' | 'concluded' | 'discarded'; result: 'players_win' | 'monster_wins' | null; playerSide: { characterIds: string[]; bonuses: BonusItem[] }; monsterSide: { monsters: MonsterItem[]; bonuses: BonusItem[] } }`. This is the battle snapshot at the moment of the lifecycle event — the raw context Story 6.7 drill-in renders, and the source for Story 6.2's `buildSummary` battle branch (`battle.name`, `battle.result`).
-  - [ ] Add typed payload creators mirroring the existing `createBattleStartedEventPayload`: extend it to carry the full battle snapshot, and add `createBattleConcludedEventPayload` and `createBattleDiscardedEventPayload` (and `createBattleUpdatedEventPayload` if Epic 5 did not already add it). Each accepts the post-transition `BattleLike` snapshot and builds the enriched superset. Keep `emittedAt`/`occurredAt` deterministic via `new Date().toISOString()` (existing pattern; fake-timer testable).
-  - [ ] Reuse the existing `BonusItem` / `MonsterItem` types from `app.ts` — do not redefine them in `publisher.ts`; import the shared types so the snapshot shape cannot drift from the model.
+- [x] **Task 1 — Enrich the battle event payload contract (AC: 3, 5, 6)**
+  - [x] In `backend/battle-service/src/publisher.ts`, extend `BattleEventPayload` with an **additive** display-context section. Do **NOT** rename or remove any field the notifications consumer (`room-notifications-service`, wired by Epic 5) already reads (`event`, `roomId`, `battleId`, `emittedAt`, and any other Epic-5-established field) — additive only.
+  - [x] Add canonical mirror fields to forward-align with the architecture event contract (duplicates of existing data, additive): `eventType` (= `event`), `actorId` (= `battleId`), `occurredAt` (= `emittedAt`) ([Source: architecture/implementation-patterns-consistency-rules.md#Event Payload Contract]).
+  - [x] Add a `battle` display-context object: `{ id: string; name: string; status: 'active' | 'concluded' | 'discarded'; result: 'players_win' | 'monster_wins' | null; playerSide: { characterIds: string[]; bonuses: BonusItem[] }; monsterSide: { monsters: MonsterItem[]; bonuses: BonusItem[] } }`. This is the battle snapshot at the moment of the lifecycle event — the raw context Story 6.7 drill-in renders, and the source for Story 6.2's `buildSummary` battle branch (`battle.name`, `battle.result`).
+  - [x] Add typed payload creators mirroring the existing `createBattleStartedEventPayload`: extend it to carry the full battle snapshot, and add `createBattleConcludedEventPayload` and `createBattleDiscardedEventPayload` (and `createBattleUpdatedEventPayload` if Epic 5 did not already add it). Each accepts the post-transition `BattleLike` snapshot and builds the enriched superset. Keep `emittedAt`/`occurredAt` deterministic via `new Date().toISOString()` (existing pattern; fake-timer testable).
+  - [x] Reuse the existing `BonusItem` / `MonsterItem` types from `app.ts` — do not redefine them in `publisher.ts`; import the shared types so the snapshot shape cannot drift from the model.
 
-- [ ] **Task 2 — Event-type-aware dual-target fan-out publisher (AC: 1, 4, 5)**
-  - [ ] Introduce a composite/fan-out publisher in `publisher.ts` that wraps an ordered list of leg publishers (notifications leg + log leg) and publishes via `await Promise.allSettled(legs.map(p => p.publish(payload)))`. Each rejected leg is logged with the failing target; no rejection is rethrown (AC 4).
-  - [ ] **Event-type routing rule (battle-specific, differs from Story 6.1):** the **log leg must be skipped for `battle_updated`** (AC 5 / ADR-5). Lifecycle events (`battle_started`, `battle_concluded`, `battle_discarded`) fan out to **both** legs; `battle_updated` goes to the **notifications leg only**. Implement this as a single rule inside the composite (e.g., the log leg is a no-op/short-circuit when `payload.eventType !==` one of the three lifecycle types) so call sites stay unaware of routing — never duplicate the decision at each route handler.
-  - [ ] Reuse the existing/Epic-5 `SnsBattleEventPublisher` / `RedisBattleEventPublisher` / `NoopBattleEventPublisher` classes as legs — do **NOT** duplicate SNS/Redis client logic. The `BattleEventPublisher` interface (`publish(payload): Promise<void>`) is unchanged; the composite implements the same interface so `app.ts` / `service.ts` wiring stays as-is (still `options.publisher`).
+- [x] **Task 2 — Event-type-aware dual-target fan-out publisher (AC: 1, 4, 5)**
+  - [x] Introduce a composite/fan-out publisher in `publisher.ts` that wraps an ordered list of leg publishers (notifications leg + log leg) and publishes via `await Promise.allSettled(legs.map(p => p.publish(payload)))`. Each rejected leg is logged with the failing target; no rejection is rethrown (AC 4).
+  - [x] **Event-type routing rule (battle-specific, differs from Story 6.1):** the **log leg must be skipped for `battle_updated`** (AC 5 / ADR-5). Lifecycle events (`battle_started`, `battle_concluded`, `battle_discarded`) fan out to **both** legs; `battle_updated` goes to the **notifications leg only**. Implement this as a single rule inside the composite (e.g., the log leg is a no-op/short-circuit when `payload.eventType !==` one of the three lifecycle types) so call sites stay unaware of routing — never duplicate the decision at each route handler.
+  - [x] Reuse the existing/Epic-5 `SnsBattleEventPublisher` / `RedisBattleEventPublisher` / `NoopBattleEventPublisher` classes as legs — do **NOT** duplicate SNS/Redis client logic. The `BattleEventPublisher` interface (`publish(payload): Promise<void>`) is unchanged; the composite implements the same interface so `app.ts` / `service.ts` wiring stays as-is (still `options.publisher`).
 
-- [ ] **Task 3 — Pass the battle snapshot into payload creation at each lifecycle call site (AC: 3, 5)**
-  - [ ] In the create handler (`POST /battles`), pass the created `BattleLike` snapshot into the (now snapshot-aware) `createBattleStartedEventPayload`.
-  - [ ] In the conclude handler (`POST /battles/:id/conclude`, Epic 5 / Story 5.6), pass the post-conclude `BattleLike` snapshot (status `concluded`, the chosen `result`, `concludedAt`) into `createBattleConcludedEventPayload`.
-  - [ ] In the discard handler (`DELETE /battles/:id`, Epic 5 / Story 5.7), pass the post-discard `BattleLike` snapshot (status `discarded`) into `createBattleDiscardedEventPayload`.
-  - [ ] In the PATCH handler (`PATCH /battles/:id`, Epic 5 / Story 5.3), continue publishing `battle_updated` via the same injected publisher — the composite's routing rule (Task 2) ensures it never reaches the log leg. **Do not add a separate publisher or special-case the route.**
-  - [ ] Preserve the existing per-call-site `try/catch` that logs and **swallows** publish errors (already present at the `battle_started` call site in `app.ts`; replicate the same swallow at the conclude/discard/patch call sites if Epic 5 has not). This swallow is the AC 4 request-flow guarantee — a publish failure must never change the HTTP status (`201` create / `200` conclude / `200`/`204` discard / `200` patch).
+- [x] **Task 3 — Pass the battle snapshot into payload creation at each lifecycle call site (AC: 3, 5)**
+  - [x] In the create handler (`POST /battles`), pass the created `BattleLike` snapshot into the (now snapshot-aware) `createBattleStartedEventPayload`.
+  - [x] In the conclude handler (`POST /battles/:id/conclude`, Epic 5 / Story 5.6), pass the post-conclude `BattleLike` snapshot (status `concluded`, the chosen `result`, `concludedAt`) into `createBattleConcludedEventPayload`.
+  - [x] In the discard handler (`DELETE /battles/:id`, Epic 5 / Story 5.7), pass the post-discard `BattleLike` snapshot (status `discarded`) into `createBattleDiscardedEventPayload`.
+  - [x] In the PATCH handler (`PATCH /battles/:id`, Epic 5 / Story 5.3), continue publishing `battle_updated` via the same injected publisher — the composite's routing rule (Task 2) ensures it never reaches the log leg. **Do not add a separate publisher or special-case the route.**
+  - [x] Preserve the existing per-call-site `try/catch` that logs and **swallows** publish errors (already present at the `battle_started` call site in `app.ts`; replicate the same swallow at the conclude/discard/patch call sites if Epic 5 has not). This swallow is the AC 4 request-flow guarantee — a publish failure must never change the HTTP status (`201` create / `200` conclude / `200`/`204` discard / `200` patch).
 
-- [ ] **Task 4 — Lambda wiring: notifications + log SNS legs with degraded mode (AC: 1, 2, 4)**
-  - [ ] In `backend/battle-service/src/lambda.ts`, build the notifications leg from Epic 5's existing notifications topic env var (use the exact env name Epic 5 wired — do **not** rename it; see Project Structure Notes) and a new log leg from `LOG_TOPIC_ARN`.
-  - [ ] If `LOG_TOPIC_ARN` is absent/empty: `console.warn` **once** at bootstrap ("degraded — battle log history will be absent") and use `NoopBattleEventPublisher` for the log leg. The service must **NOT** throw or `process.exit` (ADR-12; contrast log-service's fail-fast subscriber in Story 6.2 — publishers degrade, subscribers hard-fail).
-  - [ ] Compose both legs into the event-type-aware fan-out publisher and pass it to `buildBattleApp({ routePrefix, publisher })`. Extend the existing `[battle-service] lambda bootstrap config` `console.info` with `logTopicArnConfigured: Boolean(process.env.LOG_TOPIC_ARN)` and the resolved publisher class name (follow the `character-service/src/lambda.ts` pattern exactly).
+- [x] **Task 4 — Lambda wiring: notifications + log SNS legs with degraded mode (AC: 1, 2, 4)**
+  - [x] In `backend/battle-service/src/lambda.ts`, build the notifications leg from Epic 5's existing notifications topic env var (use the exact env name Epic 5 wired — do **not** rename it; see Project Structure Notes) and a new log leg from `LOG_TOPIC_ARN`.
+  - [x] If `LOG_TOPIC_ARN` is absent/empty: `console.warn` **once** at bootstrap ("degraded — battle log history will be absent") and use `NoopBattleEventPublisher` for the log leg. The service must **NOT** throw or `process.exit` (ADR-12; contrast log-service's fail-fast subscriber in Story 6.2 — publishers degrade, subscribers hard-fail).
+  - [x] Compose both legs into the event-type-aware fan-out publisher and pass it to `buildBattleApp({ routePrefix, publisher })`. Extend the existing `[battle-service] lambda bootstrap config` `console.info` with `logTopicArnConfigured: Boolean(process.env.LOG_TOPIC_ARN)` and the resolved publisher class name (follow the `character-service/src/lambda.ts` pattern exactly).
 
-- [ ] **Task 5 — Local server wiring: notifications + log Redis legs with degraded mode (AC: 1, 2, 4)**
-  - [ ] In `backend/battle-service/src/index.ts`, keep Epic 5's notifications Redis leg as-is. Add a log Redis leg on a new channel env `ROOM_LOG_EVENTS_CHANNEL` (default `room-log-events`) — **this default must exactly match Story 6.1's publisher channel and Story 6.2's `logWriter` subscriber channel** (cross-service contract; do not invent a new name).
-  - [ ] If the Redis URL is unset (Noop path) or the log channel cannot be configured, `console.warn` **once** and use `NoopBattleEventPublisher` for the log leg. Do not crash.
-  - [ ] Compose both legs into the fan-out publisher; extend the existing `[battle-service] local bootstrap config` `console.info` with `logEventsChannel` + `logConfigured` (mirror `character-service/src/index.ts`).
+- [x] **Task 5 — Local server wiring: notifications + log Redis legs with degraded mode (AC: 1, 2, 4)**
+  - [x] In `backend/battle-service/src/index.ts`, keep Epic 5's notifications Redis leg as-is. Add a log Redis leg on a new channel env `ROOM_LOG_EVENTS_CHANNEL` (default `room-log-events`) — **this default must exactly match Story 6.1's publisher channel and Story 6.2's `logWriter` subscriber channel** (cross-service contract; do not invent a new name).
+  - [x] If the Redis URL is unset (Noop path) or the log channel cannot be configured, `console.warn` **once** and use `NoopBattleEventPublisher` for the log leg. Do not crash.
+  - [x] Compose both legs into the fan-out publisher; extend the existing `[battle-service] local bootstrap config` `console.info` with `logEventsChannel` + `logConfigured` (mirror `character-service/src/index.ts`).
 
-- [ ] **Task 6 — Tests (AC: 1, 2, 3, 4, 5, 6)**
-  - [ ] `publisher.test.ts`: fan-out invokes every leg and uses `Promise.allSettled` (assert both legs invoked even when one rejects; a rejecting leg does **not** cause the composite `publish` to reject — AC 4); `createBattleStartedEventPayload` / `createBattleConcludedEventPayload` / `createBattleDiscardedEventPayload` each produce the enriched superset incl. `battle` snapshot and canonical mirrors; legacy notifications fields preserved exactly (regression guard for AC 6); **`battle_updated` payload is delivered to the notifications leg but NOT to the log leg** (explicit AC 5 guard — assert the log leg's `publish` is never called for `battle_updated`).
-  - [ ] `lambda.test.ts`: both env vars set → composite with two SNS legs; `LOG_TOPIC_ARN` absent → startup `console.warn` + notifications leg still active + handler still boots and responds (no throw). Follow the existing `vi.mock('./db')` / `vi.mock('./service')` / `vi.mock('@codegenie/serverless-express')` + `await import('./lambda.js')` pattern; add `delete process.env.LOG_TOPIC_ARN` (and Epic 5's notifications env) to `beforeEach`.
-  - [ ] `app.test.ts`: create/conclude/discard publish a payload containing the `battle` display context with correct `name`/`status`/`result`; a publisher that throws does **NOT** change the HTTP status (regression guard for AC 4); `battle_updated` from PATCH is published but the log leg never sees it (AC 5). Inject a spy publisher via the existing `createApp(model, { publisher })` / `buildBattleApp({ publisher })` option.
-  - [ ] Run the backend test + coverage gate from repo `backend/`: `cd backend && npm test` then `npm run test:coverage` (Vitest 3.2.4, v8 coverage, **70% line floor is a CI hard gate — do not lower**). `battle-service` primary coverage target is state-machine transitions + the fan-out/degraded/error-swallow behavior — assert real behavior, not filler.
+- [x] **Task 6 — Tests (AC: 1, 2, 3, 4, 5, 6)**
+  - [x] `publisher.test.ts`: fan-out invokes every leg and uses `Promise.allSettled` (assert both legs invoked even when one rejects; a rejecting leg does **not** cause the composite `publish` to reject — AC 4); `createBattleStartedEventPayload` / `createBattleConcludedEventPayload` / `createBattleDiscardedEventPayload` each produce the enriched superset incl. `battle` snapshot and canonical mirrors; legacy notifications fields preserved exactly (regression guard for AC 6); **`battle_updated` payload is delivered to the notifications leg but NOT to the log leg** (explicit AC 5 guard — assert the log leg's `publish` is never called for `battle_updated`).
+  - [x] `lambda.test.ts`: both env vars set → composite with two SNS legs; `LOG_TOPIC_ARN` absent → startup `console.warn` + notifications leg still active + handler still boots and responds (no throw). Follow the existing `vi.mock('./db')` / `vi.mock('./service')` / `vi.mock('@codegenie/serverless-express')` + `await import('./lambda.js')` pattern; add `delete process.env.LOG_TOPIC_ARN` (and Epic 5's notifications env) to `beforeEach`.
+  - [x] `app.test.ts`: create/conclude/discard publish a payload containing the `battle` display context with correct `name`/`status`/`result`; a publisher that throws does **NOT** change the HTTP status (regression guard for AC 4); `battle_updated` from PATCH is published but the log leg never sees it (AC 5). Inject a spy publisher via the existing `createApp(model, { publisher })` / `buildBattleApp({ publisher })` option.
+  - [x] Run the backend test + coverage gate from repo `backend/`: `cd backend && npm test` then `npm run test:coverage` (Vitest 3.2.4, v8 coverage, **70% line floor is a CI hard gate — do not lower**). `battle-service` primary coverage target is state-machine transitions + the fan-out/degraded/error-swallow behavior — assert real behavior, not filler.
 
-- [ ] **Task 7 — Infra wiring + docs (AC: 1, 2)**
-  - [ ] `backend/sam/template.yaml`: add `LOG_TOPIC_ARN: !Ref LogEventsTopic` to `BattleServiceFunction`'s `Environment` and a `sns:Publish` statement on `!Ref LogEventsTopic` to `BattleServiceRole` Policies (additive — do not remove/rename Epic 5's notifications `sns:Publish`). `LogEventsTopic` is created by Story 6.2's SAM work; if it is not yet present in the template, follow Story 6.1's deferral guidance: either defer this env+IAM until `LogEventsTopic` exists (note it in Completion Notes) or use a SAM parameter defaulting to empty + conditional IAM so `sam` still deploys with no log topic. Either way the running service must satisfy AC 2 with no `LOG_TOPIC_ARN` set. ([Source: architecture/core-architectural-decisions.md#IAM Policy Additions] — "`battle-service`: `sns:Publish` on `NOTIFICATIONS_TOPIC_ARN` + `LOG_TOPIC_ARN`".)
-  - [ ] `backend/docker-compose.local.yml`: add `ROOM_LOG_EVENTS_CHANNEL: room-log-events` to the `battle-service` service env block (idempotent if Epic 5 already added Redis envs) so local fan-out lands on the channel Story 6.2's `logWriter` subscribes to.
-  - [ ] Update the nearest docs in the same change: `backend/.env.example` (add `ROOM_LOG_EVENTS_CHANNEL=room-log-events` for battle-service if absent) and any `battle-service` README/env reference if present. Do not hardcode ARNs/endpoints; do not change dependency versions or lockfiles ([Source: _bmad-output/project-context.md] docs-in-same-change + scoped-changes rules).
+- [x] **Task 7 — Infra wiring + docs (AC: 1, 2)**
+  - [x] `backend/sam/template.yaml`: add `LOG_TOPIC_ARN: !Ref LogEventsTopic` to `BattleServiceFunction`'s `Environment` and a `sns:Publish` statement on `!Ref LogEventsTopic` to `BattleServiceRole` Policies (additive — do not remove/rename Epic 5's notifications `sns:Publish`). `LogEventsTopic` is created by Story 6.2's SAM work; if it is not yet present in the template, follow Story 6.1's deferral guidance: either defer this env+IAM until `LogEventsTopic` exists (note it in Completion Notes) or use a SAM parameter defaulting to empty + conditional IAM so `sam` still deploys with no log topic. Either way the running service must satisfy AC 2 with no `LOG_TOPIC_ARN` set. ([Source: architecture/core-architectural-decisions.md#IAM Policy Additions] — "`battle-service`: `sns:Publish` on `NOTIFICATIONS_TOPIC_ARN` + `LOG_TOPIC_ARN`".)
+  - [x] `backend/docker-compose.local.yml`: add `ROOM_LOG_EVENTS_CHANNEL: room-log-events` to the `battle-service` service env block (idempotent if Epic 5 already added Redis envs) so local fan-out lands on the channel Story 6.2's `logWriter` subscribes to.
+  - [x] Update the nearest docs in the same change: `backend/.env.example` (add `ROOM_LOG_EVENTS_CHANNEL=room-log-events` for battle-service if absent) and any `battle-service` README/env reference if present. Do not hardcode ARNs/endpoints; do not change dependency versions or lockfiles ([Source: _bmad-output/project-context.md] docs-in-same-change + scoped-changes rules).
 
 ## Dev Notes
 
@@ -209,8 +209,38 @@ Use `Promise.allSettled` over the legs. Never sequential `await publishNotificat
 
 ### Agent Model Used
 
+GPT-5
+
 ### Debug Log References
+
+- 2026-05-21: Verified Epic 5 prerequisites in `backend/battle-service/src/app.ts`, `publisher.ts`, `lambda.ts`, and `index.ts` before implementation.
+- 2026-05-21: Ran `cd backend && npm test` after installing local dependencies: 27 files, 164 tests passed.
+- 2026-05-21: Ran `cd backend && npm run test:coverage`: 27 files, 164 tests passed; all-files line coverage 86.18%.
 
 ### Completion Notes List
 
+- Implemented additive battle event payload enrichment with canonical mirrors (`eventType`, `actorId`, `occurredAt`) and a durable `battle` snapshot while preserving legacy notifications fields (`event`, `roomId`, `battleId`, `event_body.battleId`, `emittedAt`).
+- Added event-type-aware fan-out publishing via `Promise.allSettled`; lifecycle events publish to notifications and log legs, while `battle_updated` remains realtime-only and never targets the log leg.
+- Updated create, patch, conclude, and discard handlers to publish post-transition battle snapshots while preserving publish-error swallow behavior so request HTTP statuses are unaffected by publish failures.
+- Wired Lambda and local bootstraps with notifications plus log publishers, degraded-mode warnings, `LOG_TOPIC_ARN`, and `ROOM_LOG_EVENTS_CHANNEL=room-log-events`.
+- Added SAM IAM/env wiring for `BattleServiceFunction`, local compose env wiring, and README documentation. `backend/.env.example` already contained `ROOM_LOG_EVENTS_CHANNEL=room-log-events`, so no file change was needed there.
+- Documented variance: player-side character names are not resolved in `battle-service`; payload includes `playerSide.characterIds` plus monster snapshots to satisfy ADR-11 without outbound HTTP, with name rendering deferred to already-loaded client room state.
+
 ### File List
+
+- `backend/battle-service/src/publisher.ts`
+- `backend/battle-service/src/app.ts`
+- `backend/battle-service/src/lambda.ts`
+- `backend/battle-service/src/index.ts`
+- `backend/battle-service/src/publisher.test.ts`
+- `backend/battle-service/src/app.test.ts`
+- `backend/battle-service/src/lambda.test.ts`
+- `backend/sam/template.yaml`
+- `backend/docker-compose.local.yml`
+- `backend/README.md`
+- `_bmad-output/implementation-artifacts/6-3-battle-lifecycle-events-are-published-for-room-history.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+
+### Change Log
+
+- 2026-05-21: Implemented Story 6.3 battle lifecycle room-history publisher extension and moved story to review.

--- a/_bmad-output/implementation-artifacts/6-3-battle-lifecycle-events-are-published-for-room-history.md
+++ b/_bmad-output/implementation-artifacts/6-3-battle-lifecycle-events-are-published-for-room-history.md
@@ -1,6 +1,6 @@
 # Story 6.3: Battle Lifecycle Events Are Published for Room History
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -244,3 +244,8 @@ GPT-5
 ### Change Log
 
 - 2026-05-21: Implemented Story 6.3 battle lifecycle room-history publisher extension and moved story to review.
+
+### Review Findings
+
+- [x] [Review][Decision] Should `concludedAt` be carried in the published `battle` snapshot? — Task 3 names `concludedAt` as part of the post-conclude `BattleLike` snapshot, but the authoritative `BattleEventPayload['battle']` interface in Dev Notes and `toBattleSnapshot()` (`backend/battle-service/src/publisher.ts`) omit it. `occurredAt`/`emittedAt` already carry a publish-time timestamp (≈ conclude time) and Story 6.2 `buildSummary` needs only `name`/`result`, so the implementation matches the authoritative interface — but Story 6.7 drill-in renders from the raw stored payload and could surface a true conclude time. **Resolved: leave as-is** — implementation matches the authoritative interface; no current consumer needs `concludedAt`.
+- [x] [Review][Patch] Dead/misleading log-channel guards in local bootstrap [backend/battle-service/src/index.ts:13,16,34] — `logEventsChannel` is `process.env.ROOM_LOG_EVENTS_CHANNEL || 'room-log-events'`, so it is always truthy. As a result `redisUrl && logEventsChannel` (line 13), `!redisUrl || !logEventsChannel` (line 16) and `Boolean(redisUrl && logEventsChannel)` (line 34) all collapse to depend on `redisUrl` alone. The `logEventsChannel` terms are inert and imply a configuration path that cannot occur. Simplify to gate on `redisUrl` only, mirroring `lambda.ts`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -91,7 +91,7 @@ development_status:
   epic-6: in-progress
   6-1-character-events-are-published-for-room-history: done
   6-2-published-events-are-stored-and-readable-in-room-history: done
-  6-3-battle-lifecycle-events-are-published-for-room-history: review
+  6-3-battle-lifecycle-events-are-published-for-room-history: done
   6-4-room-history-api-returns-paginated-events: ready-for-dev
   6-5-room-history-loads-in-the-app: ready-for-dev
   6-6-room-history-view-shows-character-events: ready-for-dev

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -91,7 +91,7 @@ development_status:
   epic-6: in-progress
   6-1-character-events-are-published-for-room-history: done
   6-2-published-events-are-stored-and-readable-in-room-history: done
-  6-3-battle-lifecycle-events-are-published-for-room-history: ready-for-dev
+  6-3-battle-lifecycle-events-are-published-for-room-history: review
   6-4-room-history-api-returns-paginated-events: ready-for-dev
   6-5-room-history-loads-in-the-app: ready-for-dev
   6-6-room-history-view-shows-character-events: ready-for-dev

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,7 +21,7 @@ Implemented in this phase:
 - Room history log persistence and reader skeleton (`GET /logs?roomId=...`)
 - Room service synchronous call to character service on create/join flow.
 - Room notifications over WebSocket (`character_created`, `character_updated`, `character_deleted`).
-- Character events are also published to the room-history log target when `LOG_TOPIC_ARN` (Lambda) or `ROOM_LOG_EVENTS_CHANNEL` (local Redis, default `room-log-events`) is configured.
+- Character and battle lifecycle events are also published to the room-history log target when `LOG_TOPIC_ARN` (Lambda) or `ROOM_LOG_EVENTS_CHANNEL` (local Redis, default `room-log-events`) is configured.
 
 Transport by environment:
 

--- a/backend/battle-service/src/app.test.ts
+++ b/backend/battle-service/src/app.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
 import { createApp, type BattleLike, type BattleModelLike } from './app';
+import { FanOutBattleEventPublisher } from './publisher';
 
 function buildBattle(overrides: Partial<BattleLike> = {}): BattleLike {
   const now = new Date('2026-05-17T12:00:00.000Z');
@@ -56,7 +57,16 @@ describe('battle-service app', () => {
     expect(model.create).toHaveBeenCalledWith(expect.objectContaining({ roomId: 'room-1', name: 'Dungeon Door' }));
     expect(publisher.publish).toHaveBeenCalledWith(expect.objectContaining({
       event: 'battle_started',
-      event_body: { battleId: 'battle-1' }
+      eventType: 'battle_started',
+      battleId: 'battle-1',
+      actorId: 'battle-1',
+      event_body: { battleId: 'battle-1' },
+      battle: expect.objectContaining({
+        id: 'battle-1',
+        name: 'Dungeon Door',
+        status: 'active',
+        result: null
+      })
     }));
   });
 
@@ -251,8 +261,37 @@ describe('battle-service app', () => {
     );
     expect(publisher.publish).toHaveBeenCalledWith(expect.objectContaining({
       event: 'battle_updated',
-      event_body: { battleId: 'battle-1' }
+      eventType: 'battle_updated',
+      battleId: 'battle-1',
+      event_body: { battleId: 'battle-1' },
+      battle: expect.objectContaining({
+        name: 'Updated Battle',
+        status: 'active',
+        playerSide: { characterIds: ['character-1', 'character-2'], bonuses: [{ id: 'bonus-1', value: 3 }] },
+        monsterSide: {
+          monsters: [{ id: 'monster-1', name: 'Goblin', level: 6 }],
+          bonuses: [{ id: 'monster-bonus-1', value: -1 }]
+        }
+      })
     }));
+  });
+
+  it('publishes battle_updated to the notifications fan-out leg only', async () => {
+    const model = buildBattleModel();
+    const notifications = { publish: vi.fn().mockResolvedValue(undefined) };
+    const log = { publish: vi.fn().mockResolvedValue(undefined) };
+    const publisher = new FanOutBattleEventPublisher([
+      { target: 'notifications', publisher: notifications },
+      { target: 'log', publisher: log }
+    ]);
+    vi.mocked(model.findById).mockResolvedValue(buildBattle());
+    vi.mocked(model.findByIdAndUpdate).mockResolvedValue(buildBattle({ name: 'Updated' }));
+
+    const response = await request(createApp(model, { publisher })).patch('/battles/battle-1').send({ name: 'Updated' });
+
+    expect(response.status).toBe(200);
+    expect(notifications.publish).toHaveBeenCalledWith(expect.objectContaining({ event: 'battle_updated' }));
+    expect(log.publish).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -387,9 +426,19 @@ describe('battle-service app', () => {
     expect(publisher.publish).toHaveBeenCalledTimes(1);
     expect(publisher.publish).toHaveBeenCalledWith(expect.objectContaining({
       event: 'battle_concluded',
+      eventType: 'battle_concluded',
       roomId: 'room-1',
+      battleId: 'battle-1',
       event_body: { battleId: 'battle-1' },
-      emittedAt: expect.any(String)
+      emittedAt: expect.any(String),
+      occurredAt: expect.any(String),
+      battle: expect.objectContaining({
+        name: 'Dungeon Door',
+        status: 'concluded',
+        result: 'players_win',
+        playerSide: { characterIds: ['character-1'], bonuses: [{ id: 'bonus-1', value: 2 }] },
+        monsterSide: { monsters: [{ id: 'monster-1', name: 'Fungeater', level: 5 }], bonuses: [] }
+      })
     }));
   });
 
@@ -516,9 +565,18 @@ describe('battle-service app', () => {
     expect(publisher.publish).toHaveBeenCalledTimes(1);
     expect(publisher.publish).toHaveBeenCalledWith(expect.objectContaining({
       event: 'battle_discarded',
+      eventType: 'battle_discarded',
       roomId: 'room-1',
+      battleId: 'battle-1',
       event_body: { battleId: 'battle-1' },
-      emittedAt: expect.any(String)
+      emittedAt: expect.any(String),
+      battle: expect.objectContaining({
+        name: 'Dungeon Door',
+        status: 'discarded',
+        result: null,
+        playerSide: { characterIds: ['character-1'], bonuses: [{ id: 'bonus-1', value: 2 }] },
+        monsterSide: { monsters: [{ id: 'monster-1', name: 'Fungeater', level: 5 }], bonuses: [] }
+      })
     }));
   });
 

--- a/backend/battle-service/src/app.ts
+++ b/backend/battle-service/src/app.ts
@@ -4,7 +4,10 @@ import morgan from 'morgan';
 import {
   type BattleEventPublisher,
   NoopBattleEventPublisher,
-  createBattleEventPayload
+  createBattleConcludedEventPayload,
+  createBattleDiscardedEventPayload,
+  createBattleStartedEventPayload,
+  createBattleUpdatedEventPayload
 } from './publisher';
 
 export type BattleStatus = 'active' | 'concluded' | 'discarded';
@@ -345,13 +348,7 @@ export function createApp(battleModel: BattleModelLike, options: CreateBattleApp
       }
 
       try {
-        await publisher.publish(
-          createBattleEventPayload({
-            event: 'battle_started',
-            roomId: battle.roomId,
-            battleId: battle.id
-          })
-        );
+        await publisher.publish(createBattleStartedEventPayload({ battle }));
       } catch (error) {
         console.error('Failed to publish battle_started event', error);
       }
@@ -418,13 +415,7 @@ export function createApp(battleModel: BattleModelLike, options: CreateBattleApp
       }
 
       try {
-        await publisher.publish(
-          createBattleEventPayload({
-            event: 'battle_updated',
-            roomId: battle.roomId,
-            battleId: battle.id
-          })
-        );
+        await publisher.publish(createBattleUpdatedEventPayload({ battle }));
       } catch (error) {
         console.error('Failed to publish battle_updated event', error);
       }
@@ -465,13 +456,7 @@ export function createApp(battleModel: BattleModelLike, options: CreateBattleApp
       }
 
       try {
-        await publisher.publish(
-          createBattleEventPayload({
-            event: 'battle_concluded',
-            roomId: battle.roomId,
-            battleId: battle.id
-          })
-        );
+        await publisher.publish(createBattleConcludedEventPayload({ battle }));
       } catch (error) {
         console.error('Failed to publish battle_concluded event', error);
       }
@@ -504,13 +489,7 @@ export function createApp(battleModel: BattleModelLike, options: CreateBattleApp
       }
 
       try {
-        await publisher.publish(
-          createBattleEventPayload({
-            event: 'battle_discarded',
-            roomId: battle.roomId,
-            battleId: battle.id
-          })
-        );
+        await publisher.publish(createBattleDiscardedEventPayload({ battle }));
       } catch (error) {
         console.error('Failed to publish battle_discarded event', error);
       }

--- a/backend/battle-service/src/index.ts
+++ b/backend/battle-service/src/index.ts
@@ -1,14 +1,25 @@
 import dotenv from 'dotenv';
 import { connectToMongo } from './db';
-import { NoopBattleEventPublisher, RedisBattleEventPublisher } from './publisher';
+import { FanOutBattleEventPublisher, NoopBattleEventPublisher, RedisBattleEventPublisher } from './publisher';
 import { buildBattleApp } from './service';
 
 dotenv.config();
 const redisUrl = process.env.BATTLE_EVENTS_REDIS_URL;
 const eventsChannel = process.env.ROOM_CHARACTER_EVENTS_CHANNEL || 'room-character-events';
-const publisher = redisUrl
+const logEventsChannel = process.env.ROOM_LOG_EVENTS_CHANNEL || 'room-log-events';
+const notificationsPublisher = redisUrl
   ? new RedisBattleEventPublisher(redisUrl, eventsChannel)
   : new NoopBattleEventPublisher();
+const logPublisher = redisUrl && logEventsChannel
+  ? new RedisBattleEventPublisher(redisUrl, logEventsChannel)
+  : new NoopBattleEventPublisher();
+if (!redisUrl || !logEventsChannel) {
+  console.warn('[battle-service] log Redis publisher not configured; degraded - battle log history will be absent');
+}
+const publisher = new FanOutBattleEventPublisher([
+  { target: 'notifications', publisher: notificationsPublisher },
+  { target: 'log', publisher: logPublisher }
+]);
 const app = buildBattleApp({ publisher });
 const port = Number(process.env.PORT || 8086);
 const mongoUri = process.env.BATTLE_MONGO_URI || 'mongodb://localhost:27024/munch_battle_service';
@@ -18,7 +29,9 @@ console.info('[battle-service] local bootstrap config', {
   mongoUri,
   publisher: publisher.constructor.name,
   eventsChannel,
-  redisConfigured: Boolean(redisUrl)
+  logEventsChannel,
+  redisConfigured: Boolean(redisUrl),
+  logConfigured: Boolean(redisUrl && logEventsChannel)
 });
 
 connectToMongo(mongoUri)

--- a/backend/battle-service/src/index.ts
+++ b/backend/battle-service/src/index.ts
@@ -10,10 +10,10 @@ const logEventsChannel = process.env.ROOM_LOG_EVENTS_CHANNEL || 'room-log-events
 const notificationsPublisher = redisUrl
   ? new RedisBattleEventPublisher(redisUrl, eventsChannel)
   : new NoopBattleEventPublisher();
-const logPublisher = redisUrl && logEventsChannel
+const logPublisher = redisUrl
   ? new RedisBattleEventPublisher(redisUrl, logEventsChannel)
   : new NoopBattleEventPublisher();
-if (!redisUrl || !logEventsChannel) {
+if (!redisUrl) {
   console.warn('[battle-service] log Redis publisher not configured; degraded - battle log history will be absent');
 }
 const publisher = new FanOutBattleEventPublisher([
@@ -31,7 +31,7 @@ console.info('[battle-service] local bootstrap config', {
   eventsChannel,
   logEventsChannel,
   redisConfigured: Boolean(redisUrl),
-  logConfigured: Boolean(redisUrl && logEventsChannel)
+  logConfigured: Boolean(redisUrl)
 });
 
 connectToMongo(mongoUri)

--- a/backend/battle-service/src/lambda.test.ts
+++ b/backend/battle-service/src/lambda.test.ts
@@ -16,6 +16,9 @@ vi.mock('./service', () => ({
 }));
 
 vi.mock('./publisher', () => ({
+  FanOutBattleEventPublisher: class FanOutBattleEventPublisher {
+    constructor(public legs: unknown[]) { }
+  },
   NoopBattleEventPublisher: class NoopBattleEventPublisher { },
   SnsBattleEventPublisher: class SnsBattleEventPublisher {
     constructor(public client: unknown, public topicArn: string) { }
@@ -44,6 +47,7 @@ describe('battle-service lambda', () => {
     delete process.env.ROUTE_PREFIX;
     delete process.env.BATTLE_MONGO_URI;
     delete process.env.ROOM_CHARACTER_EVENTS_TOPIC_ARN;
+    delete process.env.LOG_TOPIC_ARN;
   });
 
   it('connects to battle Mongo before handling events', async () => {
@@ -59,6 +63,7 @@ describe('battle-service lambda', () => {
     process.env.ROUTE_PREFIX = '/prod';
     process.env.BATTLE_MONGO_URI = 'mongodb://mongo/battle';
     process.env.ROOM_CHARACTER_EVENTS_TOPIC_ARN = 'arn:aws:sns:topic';
+    process.env.LOG_TOPIC_ARN = 'arn:aws:sns:log-topic';
     mockServerHandler.mockResolvedValueOnce({ statusCode: 200 });
 
     const { handler } = await import('./lambda.js');
@@ -66,20 +71,38 @@ describe('battle-service lambda', () => {
 
     expect(mockBuildBattleApp).toHaveBeenCalledWith({
       routePrefix: '/prod',
-      publisher: expect.objectContaining({ topicArn: 'arn:aws:sns:topic' }),
+      publisher: expect.objectContaining({
+        legs: [
+          expect.objectContaining({
+            target: 'notifications',
+            publisher: expect.objectContaining({ topicArn: 'arn:aws:sns:topic' }),
+          }),
+          expect.objectContaining({
+            target: 'log',
+            publisher: expect.objectContaining({ topicArn: 'arn:aws:sns:log-topic' }),
+          }),
+        ],
+      }),
     });
     expect(mockConnectToMongo).toHaveBeenCalledWith('mongodb://mongo/battle');
     expect(response).toEqual({ statusCode: 200 });
   });
 
-  it('boots with noop publisher when no topic ARN is configured', async () => {
+  it('boots with degraded log publisher when no log topic ARN is configured', async () => {
     mockServerHandler.mockResolvedValueOnce({ statusCode: 200 });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     const { handler } = await import('./lambda.js');
     await handler({}, {});
 
-    const calls = mockBuildBattleApp.mock.calls as unknown as Array<[{ publisher: { constructor: { name: string } } }]>;
+    const calls = mockBuildBattleApp.mock.calls as unknown as Array<[{ publisher: { legs: Array<{ target: string; publisher: { constructor: { name: string } } }> } }]>;
     const call = calls[0]?.[0];
-    expect(call?.publisher.constructor.name).toBe('NoopBattleEventPublisher');
+    expect(call?.publisher.legs).toEqual([
+      expect.objectContaining({ target: 'notifications', publisher: expect.any(Object) }),
+      expect.objectContaining({ target: 'log', publisher: expect.any(Object) }),
+    ]);
+    expect(call?.publisher.legs[1]?.publisher.constructor.name).toBe('NoopBattleEventPublisher');
+    expect(warnSpy).toHaveBeenCalledWith('[battle-service] LOG_TOPIC_ARN not configured; degraded - battle log history will be absent');
+    warnSpy.mockRestore();
   });
 });

--- a/backend/battle-service/src/lambda.ts
+++ b/backend/battle-service/src/lambda.ts
@@ -1,14 +1,25 @@
 import { SNSClient } from '@aws-sdk/client-sns';
 import serverlessExpress from '@codegenie/serverless-express';
 import { connectToMongo } from './db';
-import { NoopBattleEventPublisher, SnsBattleEventPublisher } from './publisher';
+import { FanOutBattleEventPublisher, NoopBattleEventPublisher, SnsBattleEventPublisher } from './publisher';
 import { buildBattleApp } from './service';
 
 const routePrefix = process.env.ROUTE_PREFIX || '/';
 const topicArn = process.env.ROOM_CHARACTER_EVENTS_TOPIC_ARN;
-const publisher = topicArn
+const logTopicArn = process.env.LOG_TOPIC_ARN;
+const notificationsPublisher = topicArn
   ? new SnsBattleEventPublisher(new SNSClient({}), topicArn)
   : new NoopBattleEventPublisher();
+const logPublisher = logTopicArn
+  ? new SnsBattleEventPublisher(new SNSClient({}), logTopicArn)
+  : new NoopBattleEventPublisher();
+if (!logTopicArn) {
+  console.warn('[battle-service] LOG_TOPIC_ARN not configured; degraded - battle log history will be absent');
+}
+const publisher = new FanOutBattleEventPublisher([
+  { target: 'notifications', publisher: notificationsPublisher },
+  { target: 'log', publisher: logPublisher }
+]);
 const app = buildBattleApp({ routePrefix, publisher });
 const mongoUri = process.env.BATTLE_MONGO_URI || 'mongodb://localhost:27024/munch_battle_service';
 
@@ -16,7 +27,8 @@ console.info('[battle-service] lambda bootstrap config', {
   routePrefix,
   mongoUri,
   publisher: publisher.constructor.name,
-  topicArnConfigured: Boolean(topicArn)
+  topicArnConfigured: Boolean(topicArn),
+  logTopicArnConfigured: Boolean(logTopicArn)
 });
 
 const server = serverlessExpress({ app });

--- a/backend/battle-service/src/publisher.test.ts
+++ b/backend/battle-service/src/publisher.test.ts
@@ -22,36 +22,92 @@ vi.mock('@aws-sdk/client-sns', async (importOriginal) => {
 });
 
 import {
+  FanOutBattleEventPublisher,
   NoopBattleEventPublisher,
   RedisBattleEventPublisher,
   SnsBattleEventPublisher,
+  createBattleConcludedEventPayload,
+  createBattleDiscardedEventPayload,
   createBattleEventPayload,
+  createBattleStartedEventPayload,
+  createBattleUpdatedEventPayload,
 } from './publisher';
+import type { BattleLike } from './app';
 
-const buildPayload = (overrides: Partial<{ event: 'battle_started'; battleId: string; correlationId: string }> = {}) =>
+const buildBattle = (overrides: Partial<BattleLike> = {}): BattleLike => {
+  const now = new Date('2026-05-17T12:00:00.000Z');
+  return {
+    id: 'battle-1',
+    roomId: 'room-1',
+    name: 'Dungeon Door',
+    status: 'active',
+    playerSide: { characterIds: ['character-1'], bonuses: [{ id: 'bonus-1', value: 2 }] },
+    monsterSide: { monsters: [{ id: 'monster-1', name: 'Fungeater', level: 5 }], bonuses: [] },
+    result: null,
+    concludedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+};
+
+const buildPayload = (overrides: Partial<{ event: 'battle_started'; correlationId: string; battle: BattleLike }> = {}) =>
   createBattleEventPayload({
     event: 'battle_started',
-    roomId: 'room-1',
-    battleId: 'battle-1',
+    battle: buildBattle(),
     ...overrides,
   });
 
 describe('battle event publisher', () => {
   describe('createBattleEventPayload', () => {
-    it('produces the canonical event_body shape', () => {
+    it('produces the legacy notifications fields, canonical mirrors, and battle snapshot', () => {
       const payload = buildPayload();
       expect(payload).toMatchObject({
         event: 'battle_started',
+        eventType: 'battle_started',
         roomId: 'room-1',
+        battleId: 'battle-1',
+        actorId: 'battle-1',
         event_body: { battleId: 'battle-1' },
+        battle: {
+          id: 'battle-1',
+          name: 'Dungeon Door',
+          status: 'active',
+          result: null,
+          playerSide: { characterIds: ['character-1'], bonuses: [{ id: 'bonus-1', value: 2 }] },
+          monsterSide: { monsters: [{ id: 'monster-1', name: 'Fungeater', level: 5 }], bonuses: [] },
+        },
       });
       expect(typeof payload.emittedAt).toBe('string');
+      expect(payload.occurredAt).toBe(payload.emittedAt);
       expect(payload.correlationId).toBeUndefined();
     });
 
     it('includes correlationId when provided', () => {
       const payload = buildPayload({ correlationId: 'corr-1' });
       expect(payload.correlationId).toBe('corr-1');
+    });
+
+    it('creates enriched lifecycle and update payloads from post-transition snapshots', () => {
+      const concluded = buildBattle({ status: 'concluded', result: 'players_win' });
+      const discarded = buildBattle({ status: 'discarded' });
+
+      expect(createBattleStartedEventPayload({ battle: buildBattle() })).toMatchObject({
+        event: 'battle_started',
+        battle: { status: 'active', result: null },
+      });
+      expect(createBattleUpdatedEventPayload({ battle: buildBattle({ name: 'New Name' }) })).toMatchObject({
+        event: 'battle_updated',
+        battle: { name: 'New Name' },
+      });
+      expect(createBattleConcludedEventPayload({ battle: concluded })).toMatchObject({
+        event: 'battle_concluded',
+        battle: { status: 'concluded', result: 'players_win' },
+      });
+      expect(createBattleDiscardedEventPayload({ battle: discarded })).toMatchObject({
+        event: 'battle_discarded',
+        battle: { status: 'discarded', result: null },
+      });
     });
   });
 
@@ -113,6 +169,44 @@ describe('battle event publisher', () => {
 
       await expect(publisher.publish(buildPayload())).rejects.toThrow('Redis down');
       infoSpy.mockRestore();
+    });
+  });
+
+  describe('FanOutBattleEventPublisher', () => {
+    it('publishes lifecycle events to notifications and log legs in parallel without propagating failures', async () => {
+      const notifications = { publish: vi.fn().mockRejectedValue(new Error('notifications down')) };
+      const log = { publish: vi.fn().mockResolvedValue(undefined) };
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const publisher = new FanOutBattleEventPublisher([
+        { target: 'notifications', publisher: notifications },
+        { target: 'log', publisher: log },
+      ]);
+      const payload = createBattleConcludedEventPayload({ battle: buildBattle({ status: 'concluded', result: 'monster_wins' }) });
+
+      await expect(publisher.publish(payload)).resolves.toBeUndefined();
+
+      expect(notifications.publish).toHaveBeenCalledWith(payload);
+      expect(log.publish).toHaveBeenCalledWith(payload);
+      expect(errorSpy).toHaveBeenCalledWith('[battle-events] publisher leg failed', expect.objectContaining({
+        target: 'notifications',
+        event: 'battle_concluded',
+      }));
+      errorSpy.mockRestore();
+    });
+
+    it('publishes battle_updated to notifications only', async () => {
+      const notifications = { publish: vi.fn().mockResolvedValue(undefined) };
+      const log = { publish: vi.fn().mockResolvedValue(undefined) };
+      const publisher = new FanOutBattleEventPublisher([
+        { target: 'notifications', publisher: notifications },
+        { target: 'log', publisher: log },
+      ]);
+      const payload = createBattleUpdatedEventPayload({ battle: buildBattle() });
+
+      await publisher.publish(payload);
+
+      expect(notifications.publish).toHaveBeenCalledWith(payload);
+      expect(log.publish).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/battle-service/src/publisher.ts
+++ b/backend/battle-service/src/publisher.ts
@@ -1,16 +1,35 @@
 import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
 import { createClient } from 'redis';
+import type { BattleLike, BattleResult, BattleStatus, BonusItem, MonsterItem } from './app';
 
 export type BattleEventType = 'battle_started' | 'battle_updated' | 'battle_concluded' | 'battle_discarded';
 
 export interface BattleEventPayload {
   event: BattleEventType;
+  eventType: BattleEventType;
   roomId: string;
+  battleId: string;
+  actorId: string;
   event_body: {
     battleId: string;
   };
   emittedAt: string;
+  occurredAt: string;
   correlationId?: string;
+  battle: {
+    id: string;
+    name: string;
+    status: BattleStatus;
+    result: BattleResult;
+    playerSide: {
+      characterIds: string[];
+      bonuses: BonusItem[];
+    };
+    monsterSide: {
+      monsters: MonsterItem[];
+      bonuses: BonusItem[];
+    };
+  };
 }
 
 export interface BattleEventPublisher {
@@ -22,7 +41,7 @@ export class NoopBattleEventPublisher implements BattleEventPublisher {
     console.info('[battle-events] noop publisher configured; skipping publish', {
       event: payload.event,
       roomId: payload.roomId,
-      battleId: payload.event_body.battleId,
+      battleId: payload.battleId,
       correlationId: payload.correlationId
     });
   }
@@ -39,7 +58,7 @@ export class SnsBattleEventPublisher implements BattleEventPublisher {
       topicArn: this.topicArn,
       event: payload.event,
       roomId: payload.roomId,
-      battleId: payload.event_body.battleId,
+      battleId: payload.battleId,
       correlationId: payload.correlationId
     });
 
@@ -54,7 +73,7 @@ export class SnsBattleEventPublisher implements BattleEventPublisher {
       topicArn: this.topicArn,
       event: payload.event,
       roomId: payload.roomId,
-      battleId: payload.event_body.battleId,
+      battleId: payload.battleId,
       correlationId: payload.correlationId
     });
   }
@@ -103,7 +122,7 @@ export class RedisBattleEventPublisher implements BattleEventPublisher {
       channel: this.channel,
       event: payload.event,
       roomId: payload.roomId,
-      battleId: payload.event_body.battleId,
+      battleId: payload.battleId,
       correlationId: payload.correlationId
     });
     await this.client.publish(this.channel, JSON.stringify(payload));
@@ -111,33 +130,90 @@ export class RedisBattleEventPublisher implements BattleEventPublisher {
       channel: this.channel,
       event: payload.event,
       roomId: payload.roomId,
-      battleId: payload.event_body.battleId,
+      battleId: payload.battleId,
       correlationId: payload.correlationId
     });
   }
 }
 
-export const createBattleEventPayload = (input: {
-  event: BattleEventType;
-  roomId: string;
-  battleId: string;
-  correlationId?: string;
-}): BattleEventPayload => ({
-  event: input.event,
-  roomId: input.roomId,
-  event_body: {
-    battleId: input.battleId
+type BattleEventPublisherLeg = {
+  target: 'notifications' | 'log';
+  publisher: BattleEventPublisher;
+};
+
+const lifecycleLogEvents = new Set<BattleEventType>(['battle_started', 'battle_concluded', 'battle_discarded']);
+
+export class FanOutBattleEventPublisher implements BattleEventPublisher {
+  constructor(private readonly legs: BattleEventPublisherLeg[]) { }
+
+  async publish(payload: BattleEventPayload): Promise<void> {
+    const eligibleLegs = this.legs.filter((leg) => leg.target !== 'log' || lifecycleLogEvents.has(payload.eventType));
+    const results = await Promise.allSettled(eligibleLegs.map((leg) => leg.publisher.publish(payload)));
+
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        const leg = eligibleLegs[index];
+        console.error('[battle-events] publisher leg failed', {
+          target: leg?.target,
+          event: payload.event,
+          roomId: payload.roomId,
+          battleId: payload.battleId,
+          error: result.reason
+        });
+      }
+    });
+  }
+}
+
+const toBattleSnapshot = (battle: BattleLike): BattleEventPayload['battle'] => ({
+  id: battle.id,
+  name: battle.name,
+  status: battle.status,
+  result: battle.result,
+  playerSide: {
+    characterIds: [...battle.playerSide.characterIds],
+    bonuses: battle.playerSide.bonuses.map((bonus) => ({ ...bonus }))
   },
-  emittedAt: new Date().toISOString(),
-  correlationId: input.correlationId
+  monsterSide: {
+    monsters: battle.monsterSide.monsters.map((monster) => ({ ...monster })),
+    bonuses: battle.monsterSide.bonuses.map((bonus) => ({ ...bonus }))
+  }
 });
 
+export const createBattleEventPayload = (input: {
+  event: BattleEventType;
+  battle: BattleLike;
+  correlationId?: string;
+}): BattleEventPayload => {
+  const emittedAt = new Date().toISOString();
+  return {
+    event: input.event,
+    eventType: input.event,
+    roomId: input.battle.roomId,
+    battleId: input.battle.id,
+    actorId: input.battle.id,
+    event_body: {
+      battleId: input.battle.id
+    },
+    emittedAt,
+    occurredAt: emittedAt,
+    correlationId: input.correlationId,
+    battle: toBattleSnapshot(input.battle)
+  };
+};
+
 export const createBattleStartedEventPayload = (input: {
-  roomId: string;
-  battleId: string;
+  battle: BattleLike;
 }): BattleEventPayload => createBattleEventPayload({ event: 'battle_started', ...input });
 
 export const createBattleUpdatedEventPayload = (input: {
-  roomId: string;
-  battleId: string;
+  battle: BattleLike;
 }): BattleEventPayload => createBattleEventPayload({ event: 'battle_updated', ...input });
+
+export const createBattleConcludedEventPayload = (input: {
+  battle: BattleLike;
+}): BattleEventPayload => createBattleEventPayload({ event: 'battle_concluded', ...input });
+
+export const createBattleDiscardedEventPayload = (input: {
+  battle: BattleLike;
+}): BattleEventPayload => createBattleEventPayload({ event: 'battle_discarded', ...input });

--- a/backend/docker-compose.local.yml
+++ b/backend/docker-compose.local.yml
@@ -68,6 +68,7 @@ services:
       BATTLE_MONGO_URI: mongodb://mongo-battle:27017/munch_battle_service
       BATTLE_EVENTS_REDIS_URL: redis://redis:6379
       ROOM_CHARACTER_EVENTS_CHANNEL: room-character-events
+      ROOM_LOG_EVENTS_CHANNEL: room-log-events
     depends_on:
       - mongo-battle
       - redis

--- a/backend/sam/template.yaml
+++ b/backend/sam/template.yaml
@@ -149,6 +149,14 @@ Resources:
                 Action:
                   - sns:Publish
                 Resource: !Ref RoomCharacterEventsTopic
+        - PolicyName: PublishLogEvents
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Ref LogEventsTopic
 
   RoomNotificationsRole:
     Type: AWS::IAM::Role
@@ -396,6 +404,7 @@ Resources:
           BATTLE_MONGO_URI: !Ref BattleMongoUri
           ROUTE_PREFIX: !Ref RoutePrefix
           ROOM_CHARACTER_EVENTS_TOPIC_ARN: !Ref RoomCharacterEventsTopic
+          LOG_TOPIC_ARN: !Ref LogEventsTopic
       Events:
         BattleListGet:
           Type: HttpApi


### PR DESCRIPTION
## Summary

- Enrich battle lifecycle event payloads with canonical mirrors and battle snapshots for room history.
- Add event-type-aware fan-out so lifecycle events publish to notifications and log targets while `battle_updated` remains notifications-only.
- Wire Lambda, local Redis, SAM, compose, README, and story tracking for Story 6.3.

## Validation

- `cd backend && npm test` — 27 files, 164 tests passed.
- `cd backend && npm run test:coverage` — 27 files, 164 tests passed; all-files line coverage 86.18%.

## Notes

- `gh` CLI auth in this environment has an invalid token, so the PR was opened through the GitHub connector after pushing the branch over SSH.