### PR TITLE
[codex] Implement release channel validation

### DIFF
--- a/_bmad-output/implementation-artifacts/7-9-release-channel-availability-validation.md
+++ b/_bmad-output/implementation-artifacts/7-9-release-channel-availability-validation.md
@@ -1,6 +1,6 @@
 # Story 7.9: Release Channel Availability Validation
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -254,3 +254,18 @@ Codex GPT-5
 
 - 2026-05-23: Story drafted and set to ready-for-dev with Scope Guard, Task 0 prerequisite gate (7.5/7.6), and deferred-names list for 7.6/7.7/7.8. Documented variance: AC 1's readiness-checklist reference is a placeholder until 7.6 ships.
 - 2026-05-23: Implemented channel availability playbook, web validation script and tests, release evidence template/README, first concrete evidence artifact, and deployment-guide linkage. Set status to review.
+
+### Review Findings
+
+- [x] [Review][Decision] Redirect handling — 301/302 from CDN treated as FAIL; should redirects be followed or is this intentional? (AC 1 — a CloudFront trailing-slash redirect would cause a false FAIL) — resolved: follow redirects added
+- [x] [Review][Decision] Playbook smoke path references "battle" and "room history" — README says "Not implemented yet"; confirm these features exist in current release or update smoke path (AC 1 — smoke path may be impossible to complete) — resolved: README is stale, features exist
+- [x] [Review][Patch] No timeout on HTTP requests — hung connection blocks script indefinitely [scripts/web-channel-http.mjs:5]
+- [x] [Review][Patch] http:// base-url accepted but only node:https imported — script fails on http URLs [scripts/web-channel-http.mjs:1]
+- [x] [Review][Patch] --version / --base-url as last argv element produces misleading error [scripts/validate-web-channel.mjs:16-17]
+- [x] [Review][Patch] No test coverage for network error / catch branch [scripts/validate-web-channel.test.mjs]
+- [x] [Review][Patch] Evidence "Validated on" field lacks HH:mm timestamp; per-channel timestamps inconsistent [docs/release-evidence/1.1.1-2026-05-23-channel-availability.md]
+- [x] [Review][Patch] Deployment guide uses code-formatted path, not a clickable Markdown link to evidence [docs/deployment-guide.md]
+- [x] [Review][Patch] Readiness checklist reference links to non-existent file; should use TODO placeholder per spec [docs/release-evidence/1.1.1-2026-05-23-channel-availability.md]
+- [x] [Review][Patch] No test for --base-url argument path [scripts/validate-web-channel.test.mjs]
+- [x] [Review][Patch] Top-level await rejection has no catch — crashes with no structured output [scripts/validate-web-channel.mjs:165]
+- [x] [Review][Defer] No CI integration or npm script entry for the validation script — deferred, intentional per spec (operator-run during release review)

--- a/_bmad-output/implementation-artifacts/7-9-release-channel-availability-validation.md
+++ b/_bmad-output/implementation-artifacts/7-9-release-channel-availability-validation.md
@@ -1,6 +1,6 @@
 # Story 7.9: Release Channel Availability Validation
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -46,50 +46,50 @@ If the dev agent finds itself editing pipeline YAML, store-listing copy, or the 
 
 ## Tasks / Subtasks
 
-- [ ] **Task 0 (PREREQUISITE GATE — DO NOT SKIP):** Verify prerequisite stories before doing any other task (AC: 1, 2, 3)
-  - [ ] Read `_bmad-output/implementation-artifacts/sprint-status.yaml` and confirm `7-5-release-facing-compliance-content` is `done`. If not, **HALT** and report: "Story 7.9 cannot run end-to-end until 7.5 ships the privacy/support URLs the AC 2 metadata audit requires."
-  - [ ] Confirm `7-6-cross-platform-release-readiness-checklist` is `done`. If not, **HALT** and report: "Story 7.9 AC 1 references the readiness checklist owned by 7.6; without it, the playbook has no checklist input to record against." Acceptable fallback only if Ivan confirms explicitly: proceed with a placeholder marked `TODO: 7.6 dependency` in the playbook and the evidence template, and re-open this story when 7.6 lands to wire the real checklist reference in.
-  - [ ] Note: this story does **not** gate on 7.7 or 7.8. Supportability signals/diagnostic matrix are not in scope for user-visible availability validation.
+- [x] **Task 0 (PREREQUISITE GATE — DO NOT SKIP):** Verify prerequisite stories before doing any other task (AC: 1, 2, 3)
+  - [x] Read `_bmad-output/implementation-artifacts/sprint-status.yaml` and confirm `7-5-release-facing-compliance-content` is `done`. If not, **HALT** and report: "Story 7.9 cannot run end-to-end until 7.5 ships the privacy/support URLs the AC 2 metadata audit requires."
+  - [x] Confirm `7-6-cross-platform-release-readiness-checklist` is `done`. If not, **HALT** and report: "Story 7.9 AC 1 references the readiness checklist owned by 7.6; without it, the playbook has no checklist input to record against." Acceptable fallback only if Ivan confirms explicitly: proceed with a placeholder marked `TODO: 7.6 dependency` in the playbook and the evidence template, and re-open this story when 7.6 lands to wire the real checklist reference in.
+  - [x] Note: this story does **not** gate on 7.7 or 7.8. Supportability signals/diagnostic matrix are not in scope for user-visible availability validation.
 
-- [ ] Task 1: Author the channel-availability validation playbook (AC: 1, 2, 3)
-  - [ ] Create `docs/release-validation/channel-availability-playbook.md` (new directory under `docs/` — sibling of `docs/release-evidence/`)
-  - [ ] Document a single-page step-by-step playbook covering all three channels; the playbook must be runnable by any developer with workflow access and store-console access
-  - [ ] **Web section:** steps to (a) verify `https://helpamunch.click/` returns HTTP 200 and serves HTML produced by `expo export --platform web` for the version under test; (b) verify `/privacy` and `/support` return HTTP 200 and render the content shipped by 7.5; (c) verify the web build's embedded `EXPO_PUBLIC_API_URL` matches the production API base (read from the deployed bundle, not from local env) so the deployed web app can actually reach the backend
-  - [ ] **iOS section:** steps to (a) open App Store Connect → TestFlight → confirm the most recent build for `click.helpamunch.mobileapp` matches the release version (`frontend/app.json` `expo.version`); (b) confirm the build is in "Ready to Test" status; (c) install via TestFlight on a real device and complete one end-to-end smoke (create room → create character → start and conclude one battle → open room history) to confirm the build is actually usable, not just delivered
-  - [ ] **Android section:** steps to (a) open Google Play Console → Internal testing track → confirm the most recent active release for `click.helpamunch.mobileapp` matches the release version; (b) confirm rollout status is "Available"; (c) install via the internal-testing opt-in link and complete the same end-to-end smoke as iOS
-  - [ ] **Metadata audit section:** a 5-row table per channel listing exactly which fields to audit (web: `<title>` and landing CTA; iOS: App Name, Subtitle, Promotional Text, Description, Support URL, Privacy Policy URL; Android: App name, Short description, Full description, Privacy Policy URL, Contact email/website) with a "does this overstate scope?" yes/no check per row referencing FR43–FR44 and NFR8–NFR9
-  - [ ] **Failure handling:** explicit instruction that any per-channel FAIL marks the release NOT-RELEASE-READY for that channel and that the release-readiness review (Story 7.6) is the place where a waiver is granted — Story 7.9's job is to record, not to waive
+- [x] Task 1: Author the channel-availability validation playbook (AC: 1, 2, 3)
+  - [x] Create `docs/release-validation/channel-availability-playbook.md` (new directory under `docs/` — sibling of `docs/release-evidence/`)
+  - [x] Document a single-page step-by-step playbook covering all three channels; the playbook must be runnable by any developer with workflow access and store-console access
+  - [x] **Web section:** steps to (a) verify `https://helpamunch.click/` returns HTTP 200 and serves HTML produced by `expo export --platform web` for the version under test; (b) verify `/privacy` and `/support` return HTTP 200 and render the content shipped by 7.5; (c) verify the web build's embedded `EXPO_PUBLIC_API_URL` matches the production API base (read from the deployed bundle, not from local env) so the deployed web app can actually reach the backend
+  - [x] **iOS section:** steps to (a) open App Store Connect → TestFlight → confirm the most recent build for `click.helpamunch.mobileapp` matches the release version (`frontend/app.json` `expo.version`); (b) confirm the build is in "Ready to Test" status; (c) install via TestFlight on a real device and complete one end-to-end smoke (create room → create character → start and conclude one battle → open room history) to confirm the build is actually usable, not just delivered
+  - [x] **Android section:** steps to (a) open Google Play Console → Internal testing track → confirm the most recent active release for `click.helpamunch.mobileapp` matches the release version; (b) confirm rollout status is "Available"; (c) install via the internal-testing opt-in link and complete the same end-to-end smoke as iOS
+  - [x] **Metadata audit section:** a 5-row table per channel listing exactly which fields to audit (web: `<title>` and landing CTA; iOS: App Name, Subtitle, Promotional Text, Description, Support URL, Privacy Policy URL; Android: App name, Short description, Full description, Privacy Policy URL, Contact email/website) with a "does this overstate scope?" yes/no check per row referencing FR43–FR44 and NFR8–NFR9
+  - [x] **Failure handling:** explicit instruction that any per-channel FAIL marks the release NOT-RELEASE-READY for that channel and that the release-readiness review (Story 7.6) is the place where a waiver is granted — Story 7.9's job is to record, not to waive
 
-- [ ] Task 2: Add a lightweight script to automate the web-channel reachability check (AC: 1)
-  - [ ] Create `scripts/validate-web-channel.mjs` — ESM, Node 24, zero new dependencies (use `node:https`, `node:process`)
-  - [ ] Accepts `--version <semver>` (required) and `--base-url https://helpamunch.click` (optional, defaults to that)
-  - [ ] Performs HEAD/GET on `/`, `/privacy`, `/support`; fails with non-zero exit if any returns ≠ 200 or content-type is not HTML
-  - [ ] On GET `/`, fetches the response body, looks for the version string passed via `--version` in the embedded bundle (e.g. matches the version emitted by `expo export`'s manifest or `<meta>` tag) — log a warning (not a hard fail) if not found, since the version-embedding strategy is owned by Expo and may change
-  - [ ] Writes a structured PASS/FAIL summary (JSON to stdout) suitable for pasting into the evidence artifact
-  - [ ] No interactive prompts; exit codes only (`0` PASS, `1` FAIL, `2` USAGE)
-  - [ ] Add a one-line invocation example to the playbook (Task 1) and to `docs/deployment-guide.md` under a new "Release Channel Validation" subsection
+- [x] Task 2: Add a lightweight script to automate the web-channel reachability check (AC: 1)
+  - [x] Create `scripts/validate-web-channel.mjs` — ESM, Node 24, zero new dependencies (use `node:https`, `node:process`)
+  - [x] Accepts `--version <semver>` (required) and `--base-url https://helpamunch.click` (optional, defaults to that)
+  - [x] Performs HEAD/GET on `/`, `/privacy`, `/support`; fails with non-zero exit if any returns ≠ 200 or content-type is not HTML
+  - [x] On GET `/`, fetches the response body, looks for the version string passed via `--version` in the embedded bundle (e.g. matches the version emitted by `expo export`'s manifest or `<meta>` tag) — log a warning (not a hard fail) if not found, since the version-embedding strategy is owned by Expo and may change
+  - [x] Writes a structured PASS/FAIL summary (JSON to stdout) suitable for pasting into the evidence artifact
+  - [x] No interactive prompts; exit codes only (`0` PASS, `1` FAIL, `2` USAGE)
+  - [x] Add a one-line invocation example to the playbook (Task 1) and to `docs/deployment-guide.md` under a new "Release Channel Validation" subsection
 
-- [ ] Task 3: Add unit tests for the web-channel script (AC: 1)
-  - [ ] Create `scripts/validate-web-channel.test.mjs` using `node:test`
-  - [ ] Mock `node:https` via a thin wrapper module so tests do not hit the network
-  - [ ] Cover: (a) all three URLs 200 → exit 0; (b) `/privacy` 404 → exit 1 and the failing path is named in stdout; (c) HTML content-type missing → exit 1; (d) `--version` missing → exit 2; (e) version string found vs not found → both paths logged but only "not found" emits a warning, neither is a hard fail
-  - [ ] Reuse the test-style conventions already established in `scripts/story-project-sync.test.mjs` and `scripts/ready-for-dev-orchestrator.test.mjs` (same `node --test` runner, same dry-run output style)
+- [x] Task 3: Add unit tests for the web-channel script (AC: 1)
+  - [x] Create `scripts/validate-web-channel.test.mjs` using `node:test`
+  - [x] Mock `node:https` via a thin wrapper module so tests do not hit the network
+  - [x] Cover: (a) all three URLs 200 → exit 0; (b) `/privacy` 404 → exit 1 and the failing path is named in stdout; (c) HTML content-type missing → exit 1; (d) `--version` missing → exit 2; (e) version string found vs not found → both paths logged but only "not found" emits a warning, neither is a hard fail
+  - [x] Reuse the test-style conventions already established in `scripts/story-project-sync.test.mjs` and `scripts/ready-for-dev-orchestrator.test.mjs` (same `node --test` runner, same dry-run output style)
 
-- [ ] Task 4: Create the evidence-artifact template (AC: 4)
-  - [ ] Create `docs/release-evidence/TEMPLATE-channel-availability.md` — a fill-in-the-blanks template that mirrors the playbook sections from Task 1
-  - [ ] Sections: `Release version`, `Validated on`, `Validator`, `Readiness checklist reference` (link to the 7.6 artifact for this release; placeholder allowed only if 7.6 not yet shipped), `Web channel`, `iOS channel`, `Android channel`, `Metadata audit`, `Per-channel verdict`, `Blockers / waivers`, `Final go / no-go`
-  - [ ] Add a brief README at `docs/release-evidence/README.md` (new) explaining: file naming convention `<version>-<YYYY-MM-DD>-channel-availability.md`, where to find the template, and where to link the artifact (deployment guide)
+- [x] Task 4: Create the evidence-artifact template (AC: 4)
+  - [x] Create `docs/release-evidence/TEMPLATE-channel-availability.md` — a fill-in-the-blanks template that mirrors the playbook sections from Task 1
+  - [x] Sections: `Release version`, `Validated on`, `Validator`, `Readiness checklist reference` (link to the 7.6 artifact for this release; placeholder allowed only if 7.6 not yet shipped), `Web channel`, `iOS channel`, `Android channel`, `Metadata audit`, `Per-channel verdict`, `Blockers / waivers`, `Final go / no-go`
+  - [x] Add a brief README at `docs/release-evidence/README.md` (new) explaining: file naming convention `<version>-<YYYY-MM-DD>-channel-availability.md`, where to find the template, and where to link the artifact (deployment guide)
 
-- [ ] Task 5: Wire the evidence artifact into the deployment guide (AC: 4)
-  - [ ] Edit `docs/deployment-guide.md` to add a new "Release Channel Validation" section under "CI/CD Workflows Found"
-  - [ ] The section must include: a one-paragraph summary of what Story 7.9's validation produces, the path to the playbook (`docs/release-validation/channel-availability-playbook.md`), the path to the evidence template (`docs/release-evidence/TEMPLATE-channel-availability.md`), the path to the web-channel script (`scripts/validate-web-channel.mjs`) with its one-line invocation, and a sentence locating prior evidence files under `docs/release-evidence/`
-  - [ ] Keep the edit minimal — do not restructure or rewrite existing sections of `deployment-guide.md`
+- [x] Task 5: Wire the evidence artifact into the deployment guide (AC: 4)
+  - [x] Edit `docs/deployment-guide.md` to add a new "Release Channel Validation" section under "CI/CD Workflows Found"
+  - [x] The section must include: a one-paragraph summary of what Story 7.9's validation produces, the path to the playbook (`docs/release-validation/channel-availability-playbook.md`), the path to the evidence template (`docs/release-evidence/TEMPLATE-channel-availability.md`), the path to the web-channel script (`scripts/validate-web-channel.mjs`) with its one-line invocation, and a sentence locating prior evidence files under `docs/release-evidence/`
+  - [x] Keep the edit minimal — do not restructure or rewrite existing sections of `deployment-guide.md`
 
-- [ ] Task 6: Verification (AC: 1, 2, 3, 4)
-  - [ ] Run `node --test scripts/validate-web-channel.test.mjs` → all pass
-  - [ ] Run `node scripts/validate-web-channel.mjs --version $(node -p "require('./frontend/app.json').expo.version")` against the live production URL → PASS or, if any URL fails, capture the failing output and treat as a real release blocker (not a script bug) until proven otherwise
-  - [ ] Walk through the playbook end-to-end once against the current production release, fill out the evidence template, save the result at `docs/release-evidence/<current-version>-$(date +%Y-%m-%d)-channel-availability.md`, and link it from `docs/deployment-guide.md` as the first concrete example
-  - [ ] Confirm no pipeline YAML, no privacy/support page content, no Pulumi config, and no Fastlane config was modified by this story
+- [x] Task 6: Verification (AC: 1, 2, 3, 4)
+  - [x] Run `node --test scripts/validate-web-channel.test.mjs` → all pass
+  - [x] Run `node scripts/validate-web-channel.mjs --version $(node -p "require('./frontend/app.json').expo.version")` against the live production URL → PASS or, if any URL fails, capture the failing output and treat as a real release blocker (not a script bug) until proven otherwise
+  - [x] Walk through the playbook end-to-end once against the current production release, fill out the evidence template, save the result at `docs/release-evidence/<current-version>-$(date +%Y-%m-%d)-channel-availability.md`, and link it from `docs/deployment-guide.md` as the first concrete example
+  - [x] Confirm no pipeline YAML, no privacy/support page content, no Pulumi config, and no Fastlane config was modified by this story
 
 ## Dev Notes
 
@@ -223,12 +223,34 @@ This is a description for the dev agent — the dev agent writes the actual play
 
 ### Agent Model Used
 
+Codex GPT-5
+
 ### Debug Log References
+
+- `node --test scripts/validate-web-channel.test.mjs`
+- `node scripts/validate-web-channel.mjs --version 1.1.1`
+- `curl -sS https://helpamunch.click/_expo/static/js/web/entry-b6ece002f90d8748151bf43d57442640.js | rg -o 'EXPO_PUBLIC_API_URL:"[^"]+"|https://helpamunch[^"]+'`
 
 ### Completion Notes List
 
+- Added the release channel availability playbook, evidence template, evidence README, and first `1.1.1` evidence artifact.
+- Added a dependency-free Node web channel validator with a thin HTTP wrapper and `node:test` coverage for success, failures, usage, and version-warning behavior.
+- Live web reachability passed for `/`, `/privacy`, and `/support`; the deployed bundle contains `EXPO_PUBLIC_API_URL:"https://helpamunch.click/api"`.
+- The first evidence artifact records NOT-RELEASE-READY because the deployed web `<title>` is empty and iOS/Android store-console plus device smoke checks require operator access.
+- Confirmed story scope guard: no pipeline YAML, privacy/support page content, Pulumi config, Fastlane config, frontend app config, backend files, or infrastructure files were modified.
+
 ### File List
+
+- `docs/deployment-guide.md`
+- `docs/release-validation/channel-availability-playbook.md`
+- `docs/release-evidence/README.md`
+- `docs/release-evidence/TEMPLATE-channel-availability.md`
+- `docs/release-evidence/1.1.1-2026-05-23-channel-availability.md`
+- `scripts/web-channel-http.mjs`
+- `scripts/validate-web-channel.mjs`
+- `scripts/validate-web-channel.test.mjs`
 
 ### Change Log
 
 - 2026-05-23: Story drafted and set to ready-for-dev with Scope Guard, Task 0 prerequisite gate (7.5/7.6), and deferred-names list for 7.6/7.7/7.8. Documented variance: AC 1's readiness-checklist reference is a placeholder until 7.6 ships.
+- 2026-05-23: Implemented channel availability playbook, web validation script and tests, release evidence template/README, first concrete evidence artifact, and deployment-guide linkage. Set status to review.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -101,3 +101,6 @@
 ## Deferred from: code review of 7-5-release-facing-compliance-content (2026-05-23)
 
 - Privacy page contact email (`frontend/app/privacy.tsx:83-87`) is plain `<Text>` with no `onPress`, `selectable`, `accessibilityRole`, or `accessibilityLabel`. The Support page already provides a tappable, labelled email button. Out of scope for story 7.5 (AC2 only requires the contact info to remain visible on supported phone sizes; AC4's tappable contact requirement is bound to the Support page). Follow-up: make the privacy contact email at least `selectable` and ideally tappable with parity accessibility props to match Support, in a separate UX/accessibility cleanup story.
+## Deferred from: code review of 7-9-release-channel-availability-validation (2026-05-24)
+
+- No CI integration or npm script entry for `scripts/validate-web-channel.mjs` — intentional per spec; the script is operator-run during release-readiness review, not a CI gate.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-26T17:42:48Z
-# last_updated: 2026-05-23
+# last_updated: 2026-05-24
 # project: munch-helper
 # project_key: NOKEY
 # tracking_system: file-system
@@ -107,5 +107,5 @@ development_status:
   7-6-cross-platform-release-readiness-checklist: done
   7-7-supportability-signals-failure-taxonomy: done
   7-8-diagnostic-validation-matrix: done
-  7-9-release-channel-availability-validation: ready-for-dev
+  7-9-release-channel-availability-validation: done
   epic-7-retrospective: optional

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -64,7 +64,7 @@ The web reachability check is automated with `scripts/validate-web-channel.mjs`:
 node scripts/validate-web-channel.mjs --version <release-version>
 ```
 
-Prior evidence examples include `docs/release-evidence/1.1.1-2026-05-23-channel-availability.md`.
+Prior evidence examples include [1.1.1-2026-05-23-channel-availability.md](release-evidence/1.1.1-2026-05-23-channel-availability.md).
 
 ## Operational Notes
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -54,6 +54,18 @@ The routes are owned by Expo Router files at `frontend/app/privacy.tsx` and
 - `.github/workflows/android-play-store-cd.yml`
 - `.github/workflows/ios-app-store-cd.yml`
 
+### Release Channel Validation
+
+Story 7.9 release channel validation produces a repeatable availability record for the current web, iOS, and Android release candidate. Run the playbook at `docs/release-validation/channel-availability-playbook.md`, start from the evidence template at `docs/release-evidence/TEMPLATE-channel-availability.md`, and save completed records under `docs/release-evidence/`.
+
+The web reachability check is automated with `scripts/validate-web-channel.mjs`:
+
+```bash
+node scripts/validate-web-channel.mjs --version <release-version>
+```
+
+Prior evidence examples include `docs/release-evidence/1.1.1-2026-05-23-channel-availability.md`.
+
 ## Operational Notes
 
 - CloudFront routes `/api/*` to the backend HTTP API and `/ws*` to the backend WebSocket API.

--- a/docs/release-evidence/1.1.1-2026-05-23-channel-availability.md
+++ b/docs/release-evidence/1.1.1-2026-05-23-channel-availability.md
@@ -6,7 +6,7 @@
 
 ## Validated on
 
-`2026-05-23 Europe/Vilnius`
+`2026-05-23 20:33 Europe/Vilnius`
 
 ## Validator
 
@@ -107,9 +107,9 @@ Codex
 
 | Channel | Verdict | Validator | Timestamp | Blocked items |
 |---|---|---|---|---|
-| Web | `NOT-RELEASE-READY` | Codex | `2026-05-23T20:33:23.049Z` | Empty deployed web title and browser render confirmation pending |
-| iOS | `NOT-RELEASE-READY` | Codex | `2026-05-23 Europe/Vilnius` | App Store Connect, TestFlight install, and smoke path not validated |
-| Android | `NOT-RELEASE-READY` | Codex | `2026-05-23 Europe/Vilnius` | Play Console, internal-testing install, and smoke path not validated |
+| Web | `NOT-RELEASE-READY` | Codex | `2026-05-23 20:33 Europe/Vilnius` | Empty deployed web title and browser render confirmation pending |
+| iOS | `NOT-RELEASE-READY` | Codex | `2026-05-23 20:33 Europe/Vilnius` | App Store Connect, TestFlight install, and smoke path not validated |
+| Android | `NOT-RELEASE-READY` | Codex | `2026-05-23 20:33 Europe/Vilnius` | Play Console, internal-testing install, and smoke path not validated |
 
 ## Blockers / waivers
 

--- a/docs/release-evidence/1.1.1-2026-05-23-channel-availability.md
+++ b/docs/release-evidence/1.1.1-2026-05-23-channel-availability.md
@@ -1,0 +1,121 @@
+# Channel Availability Evidence
+
+## Release version
+
+`1.1.1`
+
+## Validated on
+
+`2026-05-23 Europe/Vilnius`
+
+## Validator
+
+Codex
+
+## Readiness checklist reference
+
+[Release Readiness Checklist](../release-readiness-checklist.md)
+
+## Web channel
+
+- Version under test: `1.1.1`
+- Automated check command: `node scripts/validate-web-channel.mjs --version 1.1.1`
+- Automated check result: `PASS`
+- JSON output:
+
+```json
+{
+  "baseUrl": "https://helpamunch.click",
+  "checkedAt": "2026-05-23T20:33:23.049Z",
+  "checks": [
+    {
+      "contentType": "text/html",
+      "failures": [],
+      "path": "/",
+      "status": "PASS",
+      "statusCode": 200,
+      "url": "https://helpamunch.click/"
+    },
+    {
+      "contentType": "text/html",
+      "failures": [],
+      "path": "/privacy",
+      "status": "PASS",
+      "statusCode": 200,
+      "url": "https://helpamunch.click/privacy"
+    },
+    {
+      "contentType": "text/html",
+      "failures": [],
+      "path": "/support",
+      "status": "PASS",
+      "statusCode": 200,
+      "url": "https://helpamunch.click/support"
+    }
+  ],
+  "failedPaths": [],
+  "version": "1.1.1",
+  "versionFound": false,
+  "verdict": "PASS",
+  "warnings": [
+    "Version 1.1.1 was not found in the deployed / HTML body"
+  ]
+}
+```
+
+- Browser render check: `NOT VALIDATED`
+- Production API base check from deployed bundle: `PASS`
+- Notes: The deployed bundle contains `EXPO_PUBLIC_API_URL:"https://helpamunch.click/api"`. The automated check passed with a non-blocking warning because the current Expo export did not embed `1.1.1` in the home HTML body.
+
+## iOS channel
+
+- Bundle identifier: `click.helpamunch.mobileapp`
+- TestFlight build version matches release: `NOT VALIDATED`
+- TestFlight status is Ready to Test: `NOT VALIDATED`
+- Real-device smoke path: `NOT VALIDATED`
+- Notes: App Store Connect and real-device TestFlight access are required.
+
+## Android channel
+
+- Package: `click.helpamunch.mobileapp`
+- Internal testing release version matches release: `NOT VALIDATED`
+- Rollout status is Available: `NOT VALIDATED`
+- Internal-testing install smoke path: `NOT VALIDATED`
+- Notes: Play Console and internal-testing install access are required.
+
+## Metadata audit
+
+| Channel | Field | Overstates current scope? | Result | Evidence |
+|---|---|---|---|---|
+| Web | `<title>` | `No` | `FAIL` | Fetched home HTML has an empty `<title data-rh="true"></title>` instead of `Munch Helper`. |
+| Web | Landing primary CTA | `No` | `PASS` | Primary CTA text is `Rooms`, which points to a supported room workflow. |
+| Web | Privacy URL | `No` | `PASS` | `https://helpamunch.click/privacy` returns HTTP 200 HTML. Browser content render still needs manual confirmation. |
+| Web | Support URL | `No` | `PASS` | `https://helpamunch.click/support` returns HTTP 200 HTML. Browser content render still needs manual confirmation. |
+| Web | Landing capability copy | `No` | `PASS` | Copy references rooms, characters, games, and stat calculation; it does not exceed current app scope. |
+| iOS | App Name | `NOT VALIDATED` | `PENDING` | |
+| iOS | Subtitle | `NOT VALIDATED` | `PENDING` | |
+| iOS | Promotional Text | `NOT VALIDATED` | `PENDING` | |
+| iOS | Description | `NOT VALIDATED` | `PENDING` | |
+| iOS | Support URL and Privacy Policy URL | `NOT VALIDATED` | `PENDING` | |
+| Android | App name | `NOT VALIDATED` | `PENDING` | |
+| Android | Short description | `NOT VALIDATED` | `PENDING` | |
+| Android | Full description | `NOT VALIDATED` | `PENDING` | |
+| Android | Privacy Policy URL | `NOT VALIDATED` | `PENDING` | |
+| Android | Contact email/website | `NOT VALIDATED` | `PENDING` | |
+
+## Per-channel verdict
+
+| Channel | Verdict | Validator | Timestamp | Blocked items |
+|---|---|---|---|---|
+| Web | `NOT-RELEASE-READY` | Codex | `2026-05-23T20:33:23.049Z` | Empty deployed web title and browser render confirmation pending |
+| iOS | `NOT-RELEASE-READY` | Codex | `2026-05-23 Europe/Vilnius` | App Store Connect, TestFlight install, and smoke path not validated |
+| Android | `NOT-RELEASE-READY` | Codex | `2026-05-23 Europe/Vilnius` | Play Console, internal-testing install, and smoke path not validated |
+
+## Blockers / waivers
+
+- Web metadata blocker: deployed home HTML has an empty `<title>`.
+- No waiver recorded. Store-console and device checks must be completed before release approval.
+
+## Final go / no-go
+
+`NO-GO` because all channel checks have not been completed.

--- a/docs/release-evidence/README.md
+++ b/docs/release-evidence/README.md
@@ -1,0 +1,11 @@
+# Release Evidence
+
+Release channel availability evidence is saved here after running `docs/release-validation/channel-availability-playbook.md`.
+
+Use `docs/release-evidence/TEMPLATE-channel-availability.md` for each release and save the completed artifact as:
+
+```text
+<version>-<YYYY-MM-DD>-channel-availability.md
+```
+
+Link completed artifacts from `docs/deployment-guide.md` under "Release Channel Validation" so future releases can locate prior evidence.

--- a/docs/release-evidence/TEMPLATE-channel-availability.md
+++ b/docs/release-evidence/TEMPLATE-channel-availability.md
@@ -1,0 +1,84 @@
+# Channel Availability Evidence
+
+## Release version
+
+`<release-version>`
+
+## Validated on
+
+`<YYYY-MM-DD HH:mm timezone>`
+
+## Validator
+
+`<name / handle>`
+
+## Readiness checklist reference
+
+`<link to completed Story 7.6 release-readiness checklist artifact>`
+
+## Web channel
+
+- Version under test: `<release-version>`
+- Automated check command: `node scripts/validate-web-channel.mjs --version <release-version>`
+- Automated check result: `<PASS/FAIL>`
+- JSON output:
+
+```json
+{}
+```
+
+- Browser render check: `<PASS/FAIL>`
+- Production API base check from deployed bundle: `<PASS/FAIL>`
+- Notes: `<notes>`
+
+## iOS channel
+
+- Bundle identifier: `click.helpamunch.mobileapp`
+- TestFlight build version matches release: `<PASS/FAIL>`
+- TestFlight status is Ready to Test: `<PASS/FAIL>`
+- Real-device smoke path: `<PASS/FAIL>`
+- Notes: `<notes>`
+
+## Android channel
+
+- Package: `click.helpamunch.mobileapp`
+- Internal testing release version matches release: `<PASS/FAIL>`
+- Rollout status is Available: `<PASS/FAIL>`
+- Internal-testing install smoke path: `<PASS/FAIL>`
+- Notes: `<notes>`
+
+## Metadata audit
+
+| Channel | Field | Overstates current scope? | Result | Evidence |
+|---|---|---|---|---|
+| Web | `<title>` | `<Yes/No>` | `<PASS/FAIL>` | |
+| Web | Landing primary CTA | `<Yes/No>` | `<PASS/FAIL>` | |
+| Web | Privacy URL | `<Yes/No>` | `<PASS/FAIL>` | |
+| Web | Support URL | `<Yes/No>` | `<PASS/FAIL>` | |
+| Web | Landing capability copy | `<Yes/No>` | `<PASS/FAIL>` | |
+| iOS | App Name | `<Yes/No>` | `<PASS/FAIL>` | |
+| iOS | Subtitle | `<Yes/No>` | `<PASS/FAIL>` | |
+| iOS | Promotional Text | `<Yes/No>` | `<PASS/FAIL>` | |
+| iOS | Description | `<Yes/No>` | `<PASS/FAIL>` | |
+| iOS | Support URL and Privacy Policy URL | `<Yes/No>` | `<PASS/FAIL>` | |
+| Android | App name | `<Yes/No>` | `<PASS/FAIL>` | |
+| Android | Short description | `<Yes/No>` | `<PASS/FAIL>` | |
+| Android | Full description | `<Yes/No>` | `<PASS/FAIL>` | |
+| Android | Privacy Policy URL | `<Yes/No>` | `<PASS/FAIL>` | |
+| Android | Contact email/website | `<Yes/No>` | `<PASS/FAIL>` | |
+
+## Per-channel verdict
+
+| Channel | Verdict | Validator | Timestamp | Blocked items |
+|---|---|---|---|---|
+| Web | `<PASS/FAIL/NOT-RELEASE-READY>` | `<name>` | `<timestamp>` | |
+| iOS | `<PASS/FAIL/NOT-RELEASE-READY>` | `<name>` | `<timestamp>` | |
+| Android | `<PASS/FAIL/NOT-RELEASE-READY>` | `<name>` | `<timestamp>` | |
+
+## Blockers / waivers
+
+- `<blocker or waiver reference>`
+
+## Final go / no-go
+
+`<GO/NO-GO>` because `<reason>`.

--- a/docs/release-validation/channel-availability-playbook.md
+++ b/docs/release-validation/channel-availability-playbook.md
@@ -1,0 +1,78 @@
+# Release Channel Availability Playbook
+
+Use this playbook for each release candidate before approving web, iOS, or Android availability. Save the completed evidence from `docs/release-evidence/TEMPLATE-channel-availability.md` as `docs/release-evidence/<release-version>-<YYYY-MM-DD>-channel-availability.md`.
+
+## Prerequisites
+
+- Release version under validation, from `frontend/app.json` `expo.version`.
+- Completed Story 7.6 release-readiness checklist artifact for this release.
+- Access to App Store Connect TestFlight for `click.helpamunch.mobileapp`.
+- Access to Google Play Console internal testing for `click.helpamunch.mobileapp`.
+- A real iOS device with TestFlight and an Android device or emulator enrolled through the internal-testing opt-in link.
+
+If the Story 7.6 checklist is missing, record `TODO: 7.6 dependency` in the evidence artifact and mark affected channels NOT-RELEASE-READY until the checklist outcome exists or is waived through the Story 7.6 sign-off process.
+
+## Web Channel
+
+1. Run the automated reachability check:
+
+   ```bash
+   node scripts/validate-web-channel.mjs --version <release-version>
+   ```
+
+2. Paste the JSON output into the evidence artifact.
+3. Open `https://helpamunch.click/` and confirm the landing screen renders.
+4. Confirm `https://helpamunch.click/privacy` and `https://helpamunch.click/support` return the published Story 7.5 content.
+5. Inspect the deployed JavaScript bundle or page source and confirm the embedded `EXPO_PUBLIC_API_URL` points at the production API base. Use the deployed bundle, not local environment variables.
+
+PASS requires `/`, `/privacy`, and `/support` to return HTTP 200 HTML and for the deployed app to be able to reach the production backend.
+
+## iOS Channel
+
+1. Open App Store Connect.
+2. Navigate to TestFlight for `click.helpamunch.mobileapp`.
+3. Confirm the most recent build version matches `frontend/app.json` `expo.version`.
+4. Confirm the build status is `Ready to Test`.
+5. Install the build through TestFlight on a real device.
+6. Complete one smoke path: create room, create character, start and conclude one battle, then open room history.
+
+PASS requires the matching version to be Ready to Test and usable through the full smoke path.
+
+## Android Channel
+
+1. Open Google Play Console.
+2. Navigate to Internal testing for `click.helpamunch.mobileapp`.
+3. Confirm the most recent active release version matches `frontend/app.json` `expo.version`.
+4. Confirm rollout status is `Available`.
+5. Install the build through the internal-testing opt-in link.
+6. Complete one smoke path: create room, create character, start and conclude one battle, then open room history.
+
+PASS requires the matching version to be available on the internal track and usable through the full smoke path.
+
+## Metadata Audit
+
+Use FR43-FR44 and NFR8-NFR9 as the scope baseline: rooms, characters, battles, and room history are supported; channel-facing copy must not promise capabilities beyond the current release. Privacy and support URLs must be `https://helpamunch.click/privacy` and `https://helpamunch.click/support`.
+
+| Channel | Field | Expected check | Overstates scope? | Evidence |
+|---|---|---|---|---|
+| Web | `<title>` | Names Munch Helper without unsupported claims | Yes/No | |
+| Web | Landing primary CTA | Sends users into the supported room flow | Yes/No | |
+| Web | Privacy URL | Uses `https://helpamunch.click/privacy` | Yes/No | |
+| Web | Support URL | Uses `https://helpamunch.click/support` | Yes/No | |
+| Web | Landing capability copy | Limited to rooms, characters, battles, and room history | Yes/No | |
+| iOS | App Name | Names Munch Helper without unsupported claims | Yes/No | |
+| iOS | Subtitle | Limited to current supported session scope | Yes/No | |
+| iOS | Promotional Text | Does not promise unsupported workflows | Yes/No | |
+| iOS | Description | Limited to rooms, characters, battles, and room history | Yes/No | |
+| iOS | Support URL and Privacy Policy URL | Uses the stable Story 7.5 URLs | Yes/No | |
+| Android | App name | Names Munch Helper without unsupported claims | Yes/No | |
+| Android | Short description | Limited to current supported session scope | Yes/No | |
+| Android | Full description | Does not promise unsupported workflows | Yes/No | |
+| Android | Privacy Policy URL | Uses `https://helpamunch.click/privacy` | Yes/No | |
+| Android | Contact email/website | Points to current support contact or support URL | Yes/No | |
+
+## Failure Handling
+
+Any per-channel FAIL marks that channel NOT-RELEASE-READY in the evidence artifact. Name the failing check, paste or link the evidence, and do not grant waivers in this playbook. The Story 7.6 release-readiness review is the only place where a waiver is granted.
+
+The final release verdict is GO only when web, iOS, and Android all pass or when every exception is explicitly waived through the Story 7.6 sign-off process.

--- a/scripts/validate-web-channel.mjs
+++ b/scripts/validate-web-channel.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import process from "node:process";
+
+import { requestUrl as defaultRequestUrl } from "./web-channel-http.mjs";
+
+const DEFAULT_BASE_URL = "https://helpamunch.click";
+const REQUIRED_PATHS = ["/", "/privacy", "/support"];
+
+function usage() {
+  return "Usage: node scripts/validate-web-channel.mjs --version <semver> [--base-url https://helpamunch.click]";
+}
+
+export function parseArgs(argv) {
+  const parsed = {
+    baseUrl: DEFAULT_BASE_URL,
+    errors: [],
+    version: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--version") {
+      parsed.version = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--base-url") {
+      parsed.baseUrl = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    parsed.errors.push(`Unknown argument: ${arg}`);
+  }
+
+  if (!parsed.version) {
+    parsed.errors.push("--version is required");
+  }
+
+  try {
+    new URL(parsed.baseUrl);
+  } catch {
+    parsed.errors.push("--base-url must be a valid absolute URL");
+  }
+
+  return parsed;
+}
+
+function isHtml(headers) {
+  const raw = headers["content-type"] ?? headers["Content-Type"] ?? "";
+  return String(raw).toLowerCase().includes("text/html");
+}
+
+function buildUrl(baseUrl, path) {
+  const url = new URL(baseUrl);
+  url.pathname = path;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+async function checkPath(path, { baseUrl, requestUrl }) {
+  const url = buildUrl(baseUrl, path);
+  const head = await requestUrl(url, { method: "HEAD" });
+  const failures = [];
+
+  if (head.statusCode !== 200) {
+    failures.push(`HEAD ${path} returned ${head.statusCode}`);
+  }
+
+  if (!isHtml(head.headers)) {
+    failures.push(`HEAD ${path} did not return HTML content-type`);
+  }
+
+  const get = await requestUrl(url, { method: "GET" });
+
+  if (get.statusCode !== 200) {
+    failures.push(`GET ${path} returned ${get.statusCode}`);
+  }
+
+  if (!isHtml(get.headers)) {
+    failures.push(`GET ${path} did not return HTML content-type`);
+  }
+
+  return {
+    contentType: String(head.headers["content-type"] ?? head.headers["Content-Type"] ?? ""),
+    failures,
+    path,
+    status: failures.length === 0 ? "PASS" : "FAIL",
+    statusCode: head.statusCode,
+    url,
+    body: get.body,
+  };
+}
+
+export async function runValidation({
+  argv = process.argv.slice(2),
+  now = () => new Date(),
+  requestUrl = defaultRequestUrl,
+} = {}) {
+  const args = parseArgs(argv);
+
+  if (args.errors.length > 0) {
+    return {
+      exitCode: 2,
+      output: {
+        checkedAt: now().toISOString(),
+        errors: args.errors,
+        usage: usage(),
+        verdict: "USAGE",
+      },
+    };
+  }
+
+  const checks = [];
+  const warnings = [];
+
+  for (const path of REQUIRED_PATHS) {
+    try {
+      checks.push(await checkPath(path, { baseUrl: args.baseUrl, requestUrl }));
+    } catch (error) {
+      checks.push({
+        contentType: "",
+        failures: [`${path} request failed: ${error.message}`],
+        path,
+        status: "FAIL",
+        statusCode: 0,
+        url: buildUrl(args.baseUrl, path),
+        body: "",
+      });
+    }
+  }
+
+  const home = checks.find((check) => check.path === "/");
+  const versionFound = Boolean(home?.body?.includes(args.version));
+
+  if (!versionFound) {
+    warnings.push(`Version ${args.version} was not found in the deployed / HTML body`);
+  }
+
+  const failedChecks = checks.filter((check) => check.status === "FAIL");
+  const output = {
+    baseUrl: args.baseUrl,
+    checkedAt: now().toISOString(),
+    checks: checks.map(({ body, ...check }) => check),
+    failedPaths: failedChecks.map((check) => check.path),
+    version: args.version,
+    versionFound,
+    verdict: failedChecks.length === 0 ? "PASS" : "FAIL",
+    warnings,
+  };
+
+  return {
+    exitCode: failedChecks.length === 0 ? 0 : 1,
+    output,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const result = await runValidation();
+  console.log(JSON.stringify(result.output, null, 2));
+  process.exitCode = result.exitCode;
+}

--- a/scripts/validate-web-channel.mjs
+++ b/scripts/validate-web-channel.mjs
@@ -21,13 +21,21 @@ export function parseArgs(argv) {
     const arg = argv[index];
 
     if (arg === "--version") {
-      parsed.version = argv[index + 1] ?? null;
+      if (index + 1 >= argv.length) {
+        parsed.errors.push("--version requires a value");
+        continue;
+      }
+      parsed.version = argv[index + 1];
       index += 1;
       continue;
     }
 
     if (arg === "--base-url") {
-      parsed.baseUrl = argv[index + 1] ?? "";
+      if (index + 1 >= argv.length) {
+        parsed.errors.push("--base-url requires a value");
+        continue;
+      }
+      parsed.baseUrl = argv[index + 1];
       index += 1;
       continue;
     }
@@ -40,7 +48,10 @@ export function parseArgs(argv) {
   }
 
   try {
-    new URL(parsed.baseUrl);
+    const u = new URL(parsed.baseUrl);
+    if (u.protocol !== "https:") {
+      parsed.errors.push("--base-url must use https://");
+    }
   } catch {
     parsed.errors.push("--base-url must be a valid absolute URL");
   }
@@ -159,7 +170,12 @@ export async function runValidation({
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const result = await runValidation();
-  console.log(JSON.stringify(result.output, null, 2));
-  process.exitCode = result.exitCode;
+  try {
+    const result = await runValidation();
+    console.log(JSON.stringify(result.output, null, 2));
+    process.exitCode = result.exitCode;
+  } catch (error) {
+    console.error(JSON.stringify({ verdict: "ERROR", error: error.message }));
+    process.exitCode = 1;
+  }
 }

--- a/scripts/validate-web-channel.test.mjs
+++ b/scripts/validate-web-channel.test.mjs
@@ -148,3 +148,61 @@ test("version not found logs warning and is not a hard fail", async () => {
   assert.equal(result.output.versionFound, false);
   assert.match(result.output.warnings[0], /Version 1.1.1 was not found/);
 });
+
+test("network error on / exits 1 and names the failing path", async () => {
+  const result = await runValidation({
+    argv: ["--version", "1.1.1"],
+    now: fixedNow,
+    requestUrl: async (url, { method } = {}) => {
+      const path = new URL(url).pathname;
+      if (path === "/") throw new Error("ECONNREFUSED");
+      return { body: "", headers: { "content-type": "text/html" }, statusCode: 200 };
+    },
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.output.verdict, "FAIL");
+  assert.deepEqual(result.output.failedPaths, ["/"]);
+  assert.match(result.output.checks[0].failures[0], /request failed: ECONNREFUSED/);
+});
+
+test("--base-url overrides default and is used in checks", async () => {
+  const result = await runValidation({
+    argv: ["--version", "1.0.0", "--base-url", "https://example.com"],
+    now: fixedNow,
+    requestUrl: makeRequestUrl({
+      "HEAD /": htmlResponse(),
+      "GET /": htmlResponse("<html>1.0.0</html>"),
+      "HEAD /privacy": htmlResponse(),
+      "GET /privacy": htmlResponse(),
+      "HEAD /support": htmlResponse(),
+      "GET /support": htmlResponse(),
+    }),
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.output.baseUrl, "https://example.com");
+});
+
+test("invalid --base-url exits 2", async () => {
+  const result = await runValidation({
+    argv: ["--version", "1.0.0", "--base-url", "not-a-url"],
+    now: fixedNow,
+    requestUrl: makeRequestUrl({}),
+  });
+
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.output.verdict, "USAGE");
+});
+
+test("http:// --base-url exits 2", async () => {
+  const result = await runValidation({
+    argv: ["--version", "1.0.0", "--base-url", "http://example.com"],
+    now: fixedNow,
+    requestUrl: makeRequestUrl({}),
+  });
+
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.output.verdict, "USAGE");
+  assert.ok(result.output.errors.some((e) => e.includes("https://")));
+});

--- a/scripts/validate-web-channel.test.mjs
+++ b/scripts/validate-web-channel.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseArgs, runValidation } from "./validate-web-channel.mjs";
+
+function makeRequestUrl(responses) {
+  return async (url, { method = "GET" } = {}) => {
+    const path = new URL(url).pathname;
+    const key = `${method} ${path}`;
+    const response = responses[key] ?? responses[path];
+
+    if (!response) {
+      throw new Error(`No fake response for ${key}`);
+    }
+
+    return {
+      body: response.body ?? "",
+      headers: response.headers ?? { "content-type": "text/html; charset=utf-8" },
+      statusCode: response.statusCode ?? 200,
+    };
+  };
+}
+
+function htmlResponse(body = "<html>1.1.1</html>") {
+  return {
+    body,
+    headers: { "content-type": "text/html; charset=utf-8" },
+    statusCode: 200,
+  };
+}
+
+const fixedNow = () => new Date("2026-05-23T10:00:00.000Z");
+
+test("all three URLs return 200 HTML and exit 0", async () => {
+  const result = await runValidation({
+    argv: ["--version", "1.1.1"],
+    now: fixedNow,
+    requestUrl: makeRequestUrl({
+      "HEAD /": htmlResponse(),
+      "GET /": htmlResponse(),
+      "HEAD /privacy": htmlResponse(),
+      "GET /privacy": htmlResponse(),
+      "HEAD /support": htmlResponse(),
+      "GET /support": htmlResponse(),
+    }),
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.output.verdict, "PASS");
+  assert.deepEqual(result.output.failedPaths, []);
+});
+
+test("/privacy 404 exits 1 and names the failing path", async () => {
+  const result = await runValidation({
+    argv: ["--version", "1.1.1"],
+    now: fixedNow,
+    requestUrl: makeRequestUrl({
+      "HEAD /": htmlResponse(),
+      "GET /": htmlResponse(),
+      "HEAD /privacy": { ...htmlResponse(), statusCode: 404 },
+      "GET /privacy": { ...htmlResponse(), statusCode: 404 },
+      "HEAD /support": htmlResponse(),
+      "GET /support": htmlResponse(),
+    }),
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.output.verdict, "FAIL");
+  assert.deepEqual(result.output.failedPaths, ["/privacy"]);
+  assert.match(result.output.checks[1].failures.join("\n"), /HEAD \/privacy returned 404/);
+});
+
+test("missing HTML content-type exits 1", async () => {
+  const result = await runValidation({
+    argv: ["--version", "1.1.1"],
+    now: fixedNow,
+    requestUrl: makeRequestUrl({
+      "HEAD /": {
+        body: "",
+        headers: { "content-type": "application/json" },
+        statusCode: 200,
+      },
+      "GET /": {
+        body: "{}",
+        headers: { "content-type": "application/json" },
+        statusCode: 200,
+      },
+      "HEAD /privacy": htmlResponse(),
+      "GET /privacy": htmlResponse(),
+      "HEAD /support": htmlResponse(),
+      "GET /support": htmlResponse(),
+    }),
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(result.output.failedPaths, ["/"]);
+  assert.match(result.output.checks[0].failures.join("\n"), /did not return HTML/);
+});
+
+test("--version missing exits 2", async () => {
+  const parsed = parseArgs([]);
+  const result = await runValidation({
+    argv: [],
+    now: fixedNow,
+    requestUrl: makeRequestUrl({}),
+  });
+
+  assert.equal(parsed.version, null);
+  assert.deepEqual(parsed.errors, ["--version is required"]);
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.output.verdict, "USAGE");
+});
+
+test("version found logs no warning and is not a hard fail", async () => {
+  const result = await runValidation({
+    argv: ["--version", "1.1.1"],
+    now: fixedNow,
+    requestUrl: makeRequestUrl({
+      "HEAD /": htmlResponse(),
+      "GET /": htmlResponse("<html><meta name=\"app-version\" content=\"1.1.1\"></html>"),
+      "HEAD /privacy": htmlResponse(),
+      "GET /privacy": htmlResponse(),
+      "HEAD /support": htmlResponse(),
+      "GET /support": htmlResponse(),
+    }),
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.output.versionFound, true);
+  assert.deepEqual(result.output.warnings, []);
+});
+
+test("version not found logs warning and is not a hard fail", async () => {
+  const result = await runValidation({
+    argv: ["--version", "1.1.1"],
+    now: fixedNow,
+    requestUrl: makeRequestUrl({
+      "HEAD /": htmlResponse(),
+      "GET /": htmlResponse("<html>Munch Helper</html>"),
+      "HEAD /privacy": htmlResponse(),
+      "GET /privacy": htmlResponse(),
+      "HEAD /support": htmlResponse(),
+      "GET /support": htmlResponse(),
+    }),
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.output.versionFound, false);
+  assert.match(result.output.warnings[0], /Version 1.1.1 was not found/);
+});

--- a/scripts/web-channel-http.mjs
+++ b/scripts/web-channel-http.mjs
@@ -1,23 +1,40 @@
 import https from "node:https";
 
-export function requestUrl(url, { method = "GET" } = {}) {
+const MAX_REDIRECTS = 5;
+const TIMEOUT_MS = 30_000;
+
+export function requestUrl(url, { method = "GET" } = {}, _redirectCount = 0) {
+  const parsed = new URL(url);
+
+  if (parsed.protocol !== "https:") {
+    return Promise.reject(new Error(`Only https:// URLs are supported, got ${parsed.protocol}`));
+  }
+
   return new Promise((resolve, reject) => {
     const req = https.request(url, { method }, (res) => {
-      let body = "";
+      if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
+        if (_redirectCount >= MAX_REDIRECTS) {
+          resolve({ body: "", headers: res.headers, statusCode: res.statusCode });
+          return;
+        }
+        const target = new URL(res.headers.location, url).toString();
+        const redirectMethod = [301, 302, 303].includes(res.statusCode) ? "GET" : method;
+        res.resume();
+        resolve(requestUrl(target, { method: redirectMethod }, _redirectCount + 1));
+        return;
+      }
 
+      let body = "";
       res.setEncoding("utf8");
-      res.on("data", (chunk) => {
-        body += chunk;
-      });
+      res.on("data", (chunk) => { body += chunk; });
       res.on("end", () => {
-        resolve({
-          body,
-          headers: res.headers,
-          statusCode: res.statusCode ?? 0,
-        });
+        resolve({ body, headers: res.headers, statusCode: res.statusCode ?? 0 });
       });
     });
 
+    req.setTimeout(TIMEOUT_MS, () => {
+      req.destroy(new Error(`Request timed out after ${TIMEOUT_MS}ms`));
+    });
     req.on("error", reject);
     req.end();
   });

--- a/scripts/web-channel-http.mjs
+++ b/scripts/web-channel-http.mjs
@@ -1,0 +1,24 @@
+import https from "node:https";
+
+export function requestUrl(url, { method = "GET" } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { method }, (res) => {
+      let body = "";
+
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        resolve({
+          body,
+          headers: res.headers,
+          statusCode: res.statusCode ?? 0,
+        });
+      });
+    });
+
+    req.on("error", reject);
+    req.end();
+  });
+}


### PR DESCRIPTION
## Summary

- Add the Story 7.9 release channel availability playbook, evidence template, evidence README, and first 1.1.1 channel evidence artifact.
- Add a dependency-free Node web channel validator with a thin HTTPS wrapper and node:test coverage.
- Link release channel validation from the deployment guide and move the Story 7.9 artifact to review.

## Validation

- `node --test scripts/validate-web-channel.test.mjs`
- `node scripts/validate-web-channel.mjs --version 1.1.1`

## Notes

The live web reachability check passed for `/`, `/privacy`, and `/support`, and the deployed bundle contains `EXPO_PUBLIC_API_URL:"https://helpamunch.click/api"`. The first evidence artifact intentionally records NOT-RELEASE-READY because the deployed web `<title>` is empty and iOS/Android store-console plus device smoke checks require operator access.