### PR TITLE
chore: bump frontend to 1.2.0

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Munch Helper",
     "slug": "munch-helper",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/munchkin-cat.png",
     "scheme": "munchhelper",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "munch-helper",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "munch-helper",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "@expo/ui": "~55.0.0",
         "@expo/vector-icons": "^15.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "munch-helper",
   "main": "expo-router/entry",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
This PR bumps frontend version to 1.2.0 after publishing 1.1.1