### PR TITLE
Add localization support across the frontend

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -3,6 +3,7 @@ import { getRuntimeConfig } from '@/config/runtime';
 import { AppTheme } from '@/constants/theme';
 import { userProfileContext } from '@/context/UserContext';
 import { useUserProfile } from '@/hooks/useUser';
+import { LocalizationProvider } from '@/i18n';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
 import React, { useMemo, useState } from 'react';
@@ -37,17 +38,19 @@ export default function RootLayout() {
 
   return (
     <RootErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        <userProfileContext.Provider value={providerValue}>
-          <Stack screenOptions={{
-            headerShown: true,
-            headerStyle: { backgroundColor: AppTheme.colors.surface },
-            headerTintColor: AppTheme.colors.textPrimary,
-            contentStyle: { backgroundColor: AppTheme.colors.background },
-            headerShadowVisible: false,
-          }} />
-        </userProfileContext.Provider>
-      </QueryClientProvider>
+      <LocalizationProvider>
+        <QueryClientProvider client={queryClient}>
+          <userProfileContext.Provider value={providerValue}>
+            <Stack screenOptions={{
+              headerShown: true,
+              headerStyle: { backgroundColor: AppTheme.colors.surface },
+              headerTintColor: AppTheme.colors.textPrimary,
+              contentStyle: { backgroundColor: AppTheme.colors.background },
+              headerShadowVisible: false,
+            }} />
+          </userProfileContext.Provider>
+        </QueryClientProvider>
+      </LocalizationProvider>
     </RootErrorBoundary>
   );
 }

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -3,6 +3,7 @@ import { router, Stack } from 'expo-router';
 import React from 'react';
 import { Linking, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+import { useLocalization } from '@/i18n';
 
 const STORE_LINKS = {
   ios: 'https://apps.apple.com/us/app/munch-helper/id6760627502',
@@ -11,6 +12,7 @@ const STORE_LINKS = {
 
 export default function LandingPage() {
   const showStoreLinks = Platform.OS === 'web';
+  const { t } = useLocalization();
 
   const openAppStore = async () => {
     try {
@@ -46,52 +48,50 @@ export default function LandingPage() {
         style={{ flex: 1 }}
         edges={Platform.OS === 'ios' ? ['top'] : ['top', 'bottom', 'left', 'right']}
       >
-        <Stack.Screen options={{ title: 'Munch Helper', headerShown: false }} />
+        <Stack.Screen options={{ title: t('landing.title'), headerShown: false }} />
         <View style={styles.container}>
           <TouchableOpacity style={styles.privacyButton} onPress={() => router.navigate('/privacy')}>
-            <Text style={styles.privacyButtonText}>Privacy</Text>
+            <Text style={styles.privacyButtonText}>{t('landing.privacy')}</Text>
           </TouchableOpacity>
 
           <TouchableOpacity style={styles.supportButton} onPress={() => router.navigate('/support')}>
-            <Text style={styles.supportButtonText}>Support</Text>
+            <Text style={styles.supportButtonText}>{t('landing.support')}</Text>
           </TouchableOpacity>
 
           <View style={styles.heroSection}>
-            <Text style={styles.title}>Munch Helper</Text>
-            <Text style={styles.subtitle}>Your companion for board games like Munchkin</Text>
-            <Text style={styles.description}>
-              Create game rooms with your friends, manage characters in games, and forget about remembering and recalculating stats.
-            </Text>
+            <Text style={styles.title}>{t('landing.title')}</Text>
+            <Text style={styles.subtitle}>{t('landing.subtitle')}</Text>
+            <Text style={styles.description}>{t('landing.description')}</Text>
           </View>
 
           <View style={styles.actionsSection}>
             <TouchableOpacity style={styles.roomsButton} onPress={() => router.navigate('/rooms')}>
-              <Text style={styles.roomsButtonText}>Rooms</Text>
+              <Text style={styles.roomsButtonText}>{t('landing.rooms')}</Text>
             </TouchableOpacity>
           </View>
 
           {showStoreLinks ? (
             <View style={styles.storeLinksSection}>
-              <TouchableOpacity style={styles.storeLinkButton} onPress={openAppStore} accessibilityLabel="App Store">
+              <TouchableOpacity style={styles.storeLinkButton} onPress={openAppStore} accessibilityLabel={t('landing.appStore')}>
                 <Image
                   source={require('../assets/images/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg')}
                   style={styles.appStoreBadge}
                   contentFit="contain"
-                  accessibilityLabel="App Store badge"
+                  accessibilityLabel={t('landing.appStoreBadge')}
                 />
               </TouchableOpacity>
 
               <TouchableOpacity
                 style={[styles.storeLinkButton]}
                 onPress={openPlayStore}
-                accessibilityLabel="Google Play"
+                accessibilityLabel={t('landing.googlePlay')}
               >
-                <Text style={styles.playSoonNote}>Join Closed Beta</Text>
+                <Text style={styles.playSoonNote}>{t('landing.joinClosedBeta')}</Text>
                 <Image
                   source={require('../assets/images/GetItOnGooglePlay_Badge_Web_color_English.svg')}
                   style={styles.playStoreBadge}
                   contentFit="contain"
-                  accessibilityLabel="Google Play badge"
+                  accessibilityLabel={t('landing.googlePlayBadge')}
                 />
               </TouchableOpacity>
             </View>

--- a/frontend/app/main/modal-change-avatar.tsx
+++ b/frontend/app/main/modal-change-avatar.tsx
@@ -1,5 +1,6 @@
 import avatars from '@/constants/avatars';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import { Image } from 'expo-image';
 import React, { useState } from 'react';
 import {
@@ -24,6 +25,7 @@ export default function ChangeAvatarModal({
   onConfirm,
   onCancel,
 }: ChangeAvatarModalProps) {
+  const { t } = useLocalization();
   const [selectedAvatar, setSelectedAvatar] = useState<number>(
     selectedImage
   );
@@ -84,7 +86,7 @@ export default function ChangeAvatarModal({
               onPress={handleConfirm}
               activeOpacity={0.7}
             >
-              <Text style={styles.buttonText}>Select</Text>
+              <Text style={styles.buttonText}>{t('avatar.select')}</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -92,7 +94,7 @@ export default function ChangeAvatarModal({
               onPress={onCancel}
               activeOpacity={0.7}
             >
-              <Text style={styles.buttonText}>Cancel</Text>
+              <Text style={styles.buttonText}>{t('common.cancel')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/frontend/app/main/modal-change-user.tsx
+++ b/frontend/app/main/modal-change-user.tsx
@@ -1,9 +1,11 @@
 import avatars from '@/constants/avatars';
 import { AppTheme } from '@/constants/theme';
+import { SupportedLocale, useLocalization } from '@/i18n';
 import { Image } from 'expo-image';
 import React, { useState } from 'react';
 import {
   Modal,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -11,6 +13,7 @@ import {
   TouchableOpacity,
   View
 } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import ChangeAvatarModal from './modal-change-avatar';
 
 import { UserProfileInterface } from '@/hooks/useUser';
@@ -30,6 +33,7 @@ export default function ChangeUserModal({
 }: ChangeUserModalProps) {
   const [user, setUser] = useState<UserProfileInterface>(initialUser);
   const [showAvatarModal, setShowAvatarModal] = useState(false);
+  const { locale, localeOptions, setLocale, t } = useLocalization();
 
   const handlePickAvatar = () => {
     setShowAvatarModal(true);
@@ -47,6 +51,13 @@ export default function ChangeUserModal({
   const handleSave = () => {
     onConfirm(user);
   };
+
+  const languagePickerItems = localeOptions.map((option) => ({
+    label: option.nativeName === option.englishName
+      ? option.englishName
+      : `${option.nativeName} (${option.englishName})`,
+    value: option.code,
+  }));
 
   return (
     <Modal
@@ -70,13 +81,13 @@ export default function ChangeUserModal({
                 style={styles.changeAvatarButton}
                 onPress={handlePickAvatar}
               >
-                <Text style={styles.changeAvatarButtonText}>Change Avatar</Text>
+                <Text style={styles.changeAvatarButtonText}>{t('profile.changeAvatar')}</Text>
               </TouchableOpacity>
             </View>
 
             {/* Name Input */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Nickname:</Text>
+              <Text style={styles.fieldLabel}>{t('profile.nickname')}</Text>
               <TextInput
                 maxLength={14}
                 style={styles.input}
@@ -85,8 +96,26 @@ export default function ChangeUserModal({
                   setUser({ ...user, nickname: text })
                 }
                 placeholderTextColor="#888686"
-                placeholder="Enter nickname"
+                placeholder={t('profile.nicknamePlaceholder')}
               />
+            </View>
+
+            <View style={styles.fieldRow}>
+              <Text style={styles.fieldLabel}>{t('settings.language')}</Text>
+              <View style={styles.pickerFrame}>
+                <Picker
+                  selectedValue={locale}
+                  onValueChange={(nextLocale) => {
+                    void setLocale(nextLocale as SupportedLocale);
+                  }}
+                  style={styles.picker}
+                  dropdownIconColor="#000000"
+                >
+                  {languagePickerItems.map((option) => (
+                    <Picker.Item key={option.value} label={option.label} value={option.value} />
+                  ))}
+                </Picker>
+              </View>
             </View>
           </ScrollView>
 
@@ -97,7 +126,7 @@ export default function ChangeUserModal({
               onPress={handleSave}
               activeOpacity={0.7}
             >
-              <Text style={styles.buttonText}>Save</Text>
+              <Text style={styles.buttonText}>{t('common.save')}</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -105,7 +134,7 @@ export default function ChangeUserModal({
               onPress={onCancel}
               activeOpacity={0.7}
             >
-              <Text style={styles.buttonText}>Cancel</Text>
+              <Text style={styles.buttonText}>{t('common.cancel')}</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -204,6 +233,20 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     fontFamily: 'Roboto',
     alignContent: 'center',
+  },
+  pickerFrame: {
+    width: '50%',
+    minHeight: 34,
+    borderRadius: 5,
+    borderWidth: 2,
+    borderColor: '#484848',
+    backgroundColor: '#DFDFDF',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  picker: {
+    color: '#000000',
+    minHeight: Platform.OS === 'ios' ? 90 : 34,
   },
   buttonContainer: {
     flexDirection: 'row',

--- a/frontend/app/main/modal-room-create.tsx
+++ b/frontend/app/main/modal-room-create.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import {
   Modal,
   StyleSheet,
@@ -21,6 +22,8 @@ export default function RoomCreateModal({
   onCancel,
   game = 'Munchkin',
 }: RoomCreateModalProps) {
+  const { t } = useLocalization();
+
   return (
     <Modal
       transparent={true}
@@ -31,7 +34,7 @@ export default function RoomCreateModal({
       <View style={styles.overlay}>
         <View style={styles.container}>
           <View style={styles.titleContainer}>
-            <Text style={styles.titleText}>Create a room for {game}?</Text>
+            <Text style={styles.titleText}>{t('roomModal.createTitle', { game })}</Text>
           </View>
 
           <View style={styles.buttonContainer}>
@@ -41,7 +44,7 @@ export default function RoomCreateModal({
               activeOpacity={0.7}
               testID="yep-button"
             >
-              <Text style={styles.buttonText}>YEP</Text>
+              <Text style={styles.buttonText}>{t('roomModal.yes')}</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -50,7 +53,7 @@ export default function RoomCreateModal({
               activeOpacity={0.7}
               testID="no-button"
             >
-              <Text style={styles.buttonText}>NO</Text>
+              <Text style={styles.buttonText}>{t('roomModal.no')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/frontend/app/main/modal-room-join.tsx
+++ b/frontend/app/main/modal-room-join.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import { Modal, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 interface ModalRoomJoinProps {
@@ -11,6 +12,7 @@ interface ModalRoomJoinProps {
 
 export default function ModalRoomJoin({ visible, onClose, onJoin, game }: ModalRoomJoinProps) {
   const [roomName, setRoomName] = useState('');
+  const { t } = useLocalization();
 
   const handleJoin = () => {
     const roomNm = roomName.trim();
@@ -37,10 +39,10 @@ export default function ModalRoomJoin({ visible, onClose, onJoin, game }: ModalR
       <View style={styles.container}>
         <View style={styles.modalContent}>
           <View style={styles.formSection}>
-            <Text style={styles.title}>Join a room for {game}?</Text>
+            <Text style={styles.title}>{t('roomModal.joinTitle', { game })}</Text>
             <TextInput
               style={styles.input}
-              placeholder="Enter the room name"
+              placeholder={t('roomModal.roomNamePlaceholder')}
               placeholderTextColor="#888686"
               value={roomName}
               onChangeText={setRoomName}
@@ -54,14 +56,14 @@ export default function ModalRoomJoin({ visible, onClose, onJoin, game }: ModalR
               onPress={handleJoin}
               activeOpacity={0.7}
             >
-              <Text style={styles.buttonText}>Join</Text>
+              <Text style={styles.buttonText}>{t('rooms.join')}</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.button}
               onPress={handleCancel}
               activeOpacity={0.7}
             >
-              <Text style={styles.buttonText}>Cancel</Text>
+              <Text style={styles.buttonText}>{t('common.cancel')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/frontend/app/main/modal-shop.tsx
+++ b/frontend/app/main/modal-shop.tsx
@@ -1,5 +1,6 @@
 import VioletButton from '@/components/VioletButton';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import { Image, Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 interface ShopModalProps {
@@ -8,6 +9,8 @@ interface ShopModalProps {
 }
 
 export default function ShopModal({ visible, onClose }: ShopModalProps) {
+  const { t } = useLocalization();
+
   return (
     <Modal
       visible={visible}
@@ -19,7 +22,7 @@ export default function ShopModal({ visible, onClose }: ShopModalProps) {
         <View style={styles.modalContainer}>
           <ScrollView contentContainerStyle={styles.contentContainer}>
             <View style={styles.header}>
-              <Text style={styles.headerText}>Shop</Text>
+              <Text style={styles.headerText}>{t('shop.title')}</Text>
             </View>
 
             <Image
@@ -33,10 +36,10 @@ export default function ShopModal({ visible, onClose }: ShopModalProps) {
                 source={require('@/assets/images/coin-small.png')}
               />
               <View style={styles.coinInfo}>
-                <Text style={styles.coinAmount}>200 coins</Text>
+                <Text style={styles.coinAmount}>{t('shop.coinsAmount', { count: 200 })}</Text>
                 <Text style={styles.coinPrice}>$1.99</Text>
               </View>
-              <VioletButton title="Buy" onPress={() => { }} />
+              <VioletButton title={t('shop.buy')} onPress={() => { }} />
             </View>
 
             <View style={styles.coinItem}>
@@ -45,10 +48,10 @@ export default function ShopModal({ visible, onClose }: ShopModalProps) {
                 source={require('@/assets/images/coin-medium.png')}
               />
               <View style={styles.coinInfo}>
-                <Text style={styles.coinAmount}>500 coins</Text>
+                <Text style={styles.coinAmount}>{t('shop.coinsAmount', { count: 500 })}</Text>
                 <Text style={styles.coinPrice}>$3.99</Text>
               </View>
-              <VioletButton title="Buy" onPress={() => { }} />
+              <VioletButton title={t('shop.buy')} onPress={() => { }} />
             </View>
 
             <View style={styles.coinItem}>
@@ -57,15 +60,15 @@ export default function ShopModal({ visible, onClose }: ShopModalProps) {
                 source={require('@/assets/images/coin-large.png')}
               />
               <View style={styles.coinInfo}>
-                <Text style={styles.coinAmount}>1000 coins</Text>
+                <Text style={styles.coinAmount}>{t('shop.coinsAmount', { count: 1000 })}</Text>
                 <Text style={styles.coinPrice}>$7.99</Text>
               </View>
-              <VioletButton title="Buy" onPress={() => { }} />
+              <VioletButton title={t('shop.buy')} onPress={() => { }} />
             </View>
           </ScrollView>
 
           <TouchableOpacity style={styles.quitButton} onPress={onClose}>
-            <Text style={styles.quitButtonText}>Quit shop</Text>
+            <Text style={styles.quitButtonText}>{t('shop.quit')}</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/frontend/app/munchkin/[roomNumber]/(battle)/index.tsx
+++ b/frontend/app/munchkin/[roomNumber]/(battle)/index.tsx
@@ -8,6 +8,7 @@ import { useBattleActions } from '@/hooks/useBattleActions';
 import { useRoomCharacters } from '@/hooks/useCharacters';
 import { useRoomBattle } from '@/hooks/useRoomBattle';
 import { useUserProfile } from '@/hooks/useUser';
+import { useLocalization } from '@/i18n';
 import { computePlayerTotal, reconcilePlayerParticipants } from '@/utils/battlePlayerSide';
 import { createUuidV4 } from '@/utils/uuid';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -39,6 +40,7 @@ export default function BattleView() {
   const { roomNumber } = useLocalSearchParams<{ roomNumber: string }>();
   const router = useRouter();
   const roomId = Array.isArray(roomNumber) ? roomNumber[0] : roomNumber;
+  const { t } = useLocalization();
   const { userProfile } = useUserProfile();
   const { battle, isLoading, errorMessage } = useRoomBattle(roomId, userProfile);
   const { characters, isLoading: charactersLoading, errorMessage: charactersErrorMessage } = useRoomCharacters(roomId, userProfile);
@@ -131,7 +133,7 @@ export default function BattleView() {
     return monsterLevelTotal + bonusTotal;
   }, [draft]);
 
-  const comparisonLabel = playerTotal === monsterTotal ? 'Even' : playerTotal > monsterTotal ? 'Players ahead' : 'Monsters ahead';
+  const comparisonLabel = playerTotal === monsterTotal ? t('battle.even') : playerTotal > monsterTotal ? t('battle.playersAhead') : t('battle.monstersAhead');
   const comparisonBorderColor = playerTotal === monsterTotal
     ? AppTheme.colors.surfaceSubtle
     : playerTotal > monsterTotal
@@ -163,12 +165,12 @@ export default function BattleView() {
       setSavedDraft(nextDraft);
     } catch (error) {
       if (error instanceof ApiError && error.status === 409) {
-        setSaveError('Battle is not active');
+        setSaveError(t('battle.notActive'));
         return;
       }
-      setSaveError(error instanceof Error ? error.message : 'Failed to save battle');
+      setSaveError(error instanceof Error ? error.message : t('battle.saveFailed'));
     }
-  }, [battle, battleActions, draft, isDirty, isNameValid]);
+  }, [battle, battleActions, draft, isDirty, isNameValid, t]);
 
   const handleSelectConcludeResult = useCallback((result: BattleResult) => {
     setSelectedResult(result);
@@ -191,14 +193,14 @@ export default function BattleView() {
       router.back();
     } catch (error) {
       if (error instanceof ApiError && error.status === 409) {
-        setConcludeError('Battle is not active');
+        setConcludeError(t('battle.notActive'));
         return;
       }
-      setConcludeError(error instanceof Error ? error.message : 'Failed to conclude battle');
+      setConcludeError(error instanceof Error ? error.message : t('battle.concludeFailed'));
     } finally {
       setIsConcluding(false);
     }
-  }, [battle, battleActions, concludeDisabled, router, selectedResult]);
+  }, [battle, battleActions, concludeDisabled, router, selectedResult, t]);
 
   const handleRequestDiscardConfirm = useCallback(() => {
     setDiscardError(null);
@@ -228,14 +230,14 @@ export default function BattleView() {
       }
     } catch (error) {
       if (error instanceof ApiError && error.status === 409) {
-        setDiscardError('Battle is not active');
+        setDiscardError(t('battle.notActive'));
         return;
       }
-      setDiscardError(error instanceof Error ? error.message : 'Failed to discard battle');
+      setDiscardError(error instanceof Error ? error.message : t('battle.discardFailed'));
     } finally {
       setIsDiscarding(false);
     }
-  }, [battle, battleActions, isDiscarding, router]);
+  }, [battle, battleActions, isDiscarding, router, t]);
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -243,7 +245,7 @@ export default function BattleView() {
         {(isLoading || charactersLoading) && (
           <View style={styles.stateBlock}>
             <ActivityIndicator color={AppTheme.colors.accent} />
-            <Text style={styles.stateText}>Loading battle</Text>
+            <Text style={styles.stateText}>{t('battle.loading')}</Text>
           </View>
         )}
 
@@ -258,7 +260,7 @@ export default function BattleView() {
             <View style={styles.header}>
               <View style={styles.headerText}>
                 <TextInput
-                  accessibilityLabel="Battle name"
+                  accessibilityLabel={t('battle.name')}
                   style={styles.titleInput}
                   testID="battle-name-input"
                   value={draft.name}
@@ -267,7 +269,7 @@ export default function BattleView() {
                 <Text style={styles.status}>{battle.status}</Text>
               </View>
               <TouchableOpacity
-                accessibilityLabel="Save battle"
+                accessibilityLabel={t('battle.save')}
                 accessibilityRole="button"
                 accessibilityState={{ disabled: !canSave }}
                 disabled={!canSave}
@@ -276,7 +278,7 @@ export default function BattleView() {
                 onPress={handleSave}
               >
                 <Text style={[styles.saveButtonText, !canSave && styles.saveButtonTextDisabled]}>
-                  {battleActions.isLoading ? 'Saving' : 'Save'}
+                  {battleActions.isLoading ? t('common.saving') : t('common.save')}
                 </Text>
               </TouchableOpacity>
             </View>
@@ -296,7 +298,7 @@ export default function BattleView() {
               removedCharacterIds={playerParticipants.removed}
               selectedCharacterIds={draft.playerSide.characterIds}
               side="players"
-              title="Player Side"
+              title={t('battle.playerSide')}
               toneColor={AppTheme.colors.accent}
               total={playerTotal}
               onAddBonus={(value) => updatePlayerSide((side) => ({
@@ -321,7 +323,7 @@ export default function BattleView() {
               bonuses={draft.monsterSide.bonuses}
               monsters={draft.monsterSide.monsters}
               side="monsters"
-              title="Monster Side"
+              title={t('battle.monsterSide')}
               toneColor={AppTheme.colors.danger}
               total={monsterTotal}
               onAddBonus={(value) => updateMonsterSide((side) => ({
@@ -371,7 +373,7 @@ export default function BattleView() {
 
         {!isLoading && !errorMessage && !battle && (
           <View style={styles.stateBlock}>
-            <Text style={styles.stateText}>No active battle</Text>
+            <Text style={styles.stateText}>{t('battle.noActive')}</Text>
           </View>
         )}
       </ScrollView>

--- a/frontend/app/munchkin/[roomNumber]/_layout.tsx
+++ b/frontend/app/munchkin/[roomNumber]/_layout.tsx
@@ -3,6 +3,7 @@ import { RoomHeaderTitle } from '@/components/munchkin/RoomHeaderTitle';
 import { AppTheme } from '@/constants/theme';
 import { useRoomCodeClipboard } from '@/hooks/useRoomCodeClipboard';
 import { useRoomBattle } from '@/hooks/useRoomBattle';
+import { useLocalization } from '@/i18n';
 import { Ionicons } from '@expo/vector-icons';
 import { Stack, useLocalSearchParams, useRouter, useSegments } from 'expo-router';
 import { StyleSheet, TouchableOpacity } from 'react-native';
@@ -13,6 +14,7 @@ export default function RoomLayout() {
   const segments = useSegments();
   const roomId = Array.isArray(roomNumber) ? roomNumber[0] : roomNumber;
   const roomCode = roomId ?? '';
+  const { t } = useLocalization();
   const { buttonLabel, accessibilityLabel, copyRoomCode } = useRoomCodeClipboard(roomCode);
   const { battle } = useRoomBattle(roomId);
   const isBattleRoute = segments.some((segment) => String(segment) === '(battle)');
@@ -29,7 +31,7 @@ export default function RoomLayout() {
           headerLeft: usesDetailHeader
             ? () => (
                 <TouchableOpacity
-                  accessibilityLabel="Back to room"
+                  accessibilityLabel={t('rooms.backToRoom')}
                   accessibilityRole="button"
                   onPress={() => {
                     if (router.canGoBack()) {
@@ -60,7 +62,7 @@ export default function RoomLayout() {
                   }}
                 />
               ),
-          title: isBattleRoute ? battle?.name ?? 'Battle' : isLogRoute ? 'History' : undefined,
+          title: isBattleRoute ? battle?.name ?? t('rooms.battle') : isLogRoute ? t('history.title') : undefined,
         }}
       />
       <Stack

--- a/frontend/app/munchkin/[roomNumber]/index.tsx
+++ b/frontend/app/munchkin/[roomNumber]/index.tsx
@@ -7,6 +7,7 @@ import { useRoomCharacters } from '@/hooks/useCharacters';
 import { useReconnectOnForeground } from '@/hooks/useReconnectOnForeground';
 import { useRoomBattle } from '@/hooks/useRoomBattle';
 import { useRoomCodeClipboard } from '@/hooks/useRoomCodeClipboard';
+import { useLocalization } from '@/i18n';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Platform, Pressable, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -43,6 +44,7 @@ const MunchkinIndexView: React.FC = () => {
   const router = useRouter();
   const roomId = Array.isArray(roomNumber) ? roomNumber[0] : roomNumber;
   const roomCode = roomId ?? '';
+  const { t } = useLocalization();
   const { userProfile } = useContext(userProfileContext);
   const {
     characters,
@@ -210,11 +212,11 @@ const MunchkinIndexView: React.FC = () => {
       setShowUndoToast(true);
     } catch (error) {
       setDangerFlash(true);
-      setActionError(error instanceof Error ? error.message : 'Failed to update character stats');
+      setActionError(error instanceof Error ? error.message : t('rooms.updateStatsFailed'));
       setShowUndoToast(false);
       setUndoState(null);
     }
-  }, [selectedCharacter, selectedCharacterId, update]);
+  }, [selectedCharacter, selectedCharacterId, update, t]);
 
   const handleQuickEditUndo = useCallback(() => {
     if (!undoState) {
@@ -227,9 +229,9 @@ const MunchkinIndexView: React.FC = () => {
       level: undoState.previous.level,
       power: undoState.previous.power,
     }).catch((error) => {
-      setActionError(error instanceof Error ? error.message : 'Failed to undo character stats');
+      setActionError(error instanceof Error ? error.message : t('rooms.undoStatsFailed'));
     });
-  }, [undoState, update]);
+  }, [undoState, update, t]);
 
   const handleOpenFullEdit = useCallback(() => {
     setDeleteError(null);
@@ -316,13 +318,13 @@ const MunchkinIndexView: React.FC = () => {
         // Re-sync the room instead of navigating to a battle that does not
         // exist, and let the next press start a fresh one.
         await refreshBattle();
-        setActionError('Could not start the battle. Please try again.');
+        setActionError(t('rooms.startBattleRetry'));
         return;
       }
 
-      setActionError(error instanceof Error ? error.message : 'Failed to start battle');
+      setActionError(error instanceof Error ? error.message : t('rooms.startBattleFailed'));
     }
-  }, [battle, battleActions, createDefaultBattleName, navigateToBattle, refreshBattle, roomId]);
+  }, [battle, battleActions, createDefaultBattleName, navigateToBattle, refreshBattle, roomId, t]);
 
   useReconnectOnForeground(Boolean(roomId && userProfile.id && !isConnected), handleReconnect);
 
@@ -347,14 +349,14 @@ const MunchkinIndexView: React.FC = () => {
 
           {isTimedOut && !isConnected && (
             <Pressable
-              accessibilityLabel="Connection lost. Tap to retry"
+              accessibilityLabel={t('rooms.connectionLostRetryAccessibility')}
               accessibilityRole="button"
               onPress={() => {
                 void handleReconnect();
               }}
               style={styles.connectionRetryButton}
             >
-              <Text style={styles.connectionRetryButtonText}>Connection lost · Retry</Text>
+              <Text style={styles.connectionRetryButtonText}>{t('rooms.connectionLostRetry')}</Text>
             </Pressable>
           )}
 
@@ -375,7 +377,7 @@ const MunchkinIndexView: React.FC = () => {
 
           <View style={styles.actionButtons}>
             <TouchableOpacity
-              accessibilityLabel="Open battle"
+              accessibilityLabel={t('rooms.openBattle')}
               accessibilityRole="button"
               disabled={!roomId || isBattleLoading || battleActions.isLoading}
               onPress={() => {
@@ -386,16 +388,16 @@ const MunchkinIndexView: React.FC = () => {
                 (!roomId || isBattleLoading || battleActions.isLoading) && styles.actionButtonDisabled,
               ]}
             >
-              <Text style={styles.battleButtonText}>Battle</Text>
+              <Text style={styles.battleButtonText}>{t('rooms.battle')}</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              accessibilityLabel="Open room history"
+              accessibilityLabel={t('rooms.openHistory')}
               accessibilityRole="button"
               disabled={!roomId}
               onPress={navigateToLog}
               style={[styles.logButton, !roomId && styles.actionButtonDisabled]}
             >
-              <Text style={styles.logButtonText}>Log</Text>
+              <Text style={styles.logButtonText}>{t('rooms.log')}</Text>
             </TouchableOpacity>
           </View>
 
@@ -425,7 +427,7 @@ const MunchkinIndexView: React.FC = () => {
                 });
                 setCreateCharacterModalVisible(false);
               } catch (error) {
-                setActionError(error instanceof Error ? error.message : 'Failed to create character');
+                setActionError(error instanceof Error ? error.message : t('rooms.createCharacterFailed'));
               }
             }}
             onCancel={() => setCreateCharacterModalVisible(false)}
@@ -451,7 +453,7 @@ const MunchkinIndexView: React.FC = () => {
                   });
                   setChangeCharacterModalVisible(false);
                 } catch (error) {
-                  setActionError(error instanceof Error ? error.message : 'Failed to update character');
+                  setActionError(error instanceof Error ? error.message : t('rooms.updateCharacterFailed'));
                 }
               }}
               onDelete={async (characterId) => {
@@ -472,7 +474,7 @@ const MunchkinIndexView: React.FC = () => {
                     return;
                   }
 
-                  setDeleteError(error instanceof Error ? error.message : 'Failed to delete character');
+                  setDeleteError(error instanceof Error ? error.message : t('rooms.deleteCharacterFailed'));
                 } finally {
                   setPendingDeleteCharacterId((current) => (current === characterId ? null : current));
                 }
@@ -497,7 +499,7 @@ const MunchkinIndexView: React.FC = () => {
           {showUndoToast && undoState && (
             <Animated.View style={[styles.undoToastWrapper, { transform: [{ translateY: undoToastTranslateY }] }]} pointerEvents="box-none">
               <Pressable style={styles.undoToast} onPress={handleQuickEditUndo}>
-                <Text style={styles.undoToastText}>Undo</Text>
+                <Text style={styles.undoToastText}>{t('rooms.undo')}</Text>
               </Pressable>
             </Animated.View>
           )}

--- a/frontend/app/munchkin/[roomNumber]/log.tsx
+++ b/frontend/app/munchkin/[roomNumber]/log.tsx
@@ -4,6 +4,7 @@ import LogEntry from '@/components/munchkin/LogEntry';
 import { AppTheme } from '@/constants/theme';
 import { userProfileContext } from '@/context/UserContext';
 import { useRoomLogs } from '@/hooks/useRoomLogs';
+import { useLocalization } from '@/i18n';
 import { useLocalSearchParams } from 'expo-router';
 import React, { useCallback, useContext, useState } from 'react';
 import { ActivityIndicator, FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -12,6 +13,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 export default function RoomHistoryLogScreen() {
   const { roomNumber } = useLocalSearchParams<{ roomNumber: string }>();
   const roomId = Array.isArray(roomNumber) ? roomNumber[0] : roomNumber;
+  const { t } = useLocalization();
   const { userProfile } = useContext(userProfileContext);
   const [selectedEntry, setSelectedEntry] = useState<LogEvent | null>(null);
   const {
@@ -57,7 +59,7 @@ export default function RoomHistoryLogScreen() {
       return (
         <View style={styles.footerState}>
           <ActivityIndicator color={AppTheme.colors.accent} />
-          <Text style={styles.stateText}>Loading more history</Text>
+          <Text style={styles.stateText}>{t('history.loadingMore')}</Text>
         </View>
       );
     }
@@ -67,26 +69,26 @@ export default function RoomHistoryLogScreen() {
         <View style={styles.footerState}>
           <Text style={styles.errorText}>{errorMessage}</Text>
           <TouchableOpacity
-            accessibilityLabel="Retry loading older history"
+            accessibilityLabel={t('history.retryOlder')}
             accessibilityRole="button"
             onPress={handleNextPageRetry}
             style={styles.retryButton}
           >
-            <Text style={styles.retryButtonText}>Retry</Text>
+            <Text style={styles.retryButtonText}>{t('history.retry')}</Text>
           </TouchableOpacity>
         </View>
       );
     }
 
     return null;
-  }, [errorMessage, handleNextPageRetry, isFetchingNextPage, isNextPageError]);
+  }, [errorMessage, handleNextPageRetry, isFetchingNextPage, isNextPageError, t]);
 
   return (
     <SafeAreaView edges={['bottom', 'left', 'right']} style={styles.safeArea}>
       {isLoading && (
         <View style={styles.stateBlock}>
           <ActivityIndicator color={AppTheme.colors.accent} />
-          <Text style={styles.stateText}>Loading history</Text>
+          <Text style={styles.stateText}>{t('history.loading')}</Text>
         </View>
       )}
 
@@ -94,12 +96,12 @@ export default function RoomHistoryLogScreen() {
         <View style={styles.stateBlock}>
           <Text style={styles.errorText}>{errorMessage}</Text>
           <TouchableOpacity
-            accessibilityLabel="Retry loading room history"
+            accessibilityLabel={t('history.retryRoom')}
             accessibilityRole="button"
             onPress={handleInitialRetry}
             style={styles.retryButton}
           >
-            <Text style={styles.retryButtonText}>Retry</Text>
+            <Text style={styles.retryButtonText}>{t('history.retry')}</Text>
           </TouchableOpacity>
         </View>
       )}
@@ -109,7 +111,7 @@ export default function RoomHistoryLogScreen() {
           contentContainerStyle={entries.length === 0 ? styles.emptyContent : styles.listContent}
           data={entries}
           keyExtractor={(item) => item.id}
-          ListEmptyComponent={<Text style={styles.emptyText}>No events recorded yet.</Text>}
+          ListEmptyComponent={<Text style={styles.emptyText}>{t('history.empty')}</Text>}
           ListFooterComponent={renderFooter}
           onEndReached={handleEndReached}
           onEndReachedThreshold={0.4}

--- a/frontend/app/munchkin/modal-change-caracter.tsx
+++ b/frontend/app/munchkin/modal-change-caracter.tsx
@@ -1,5 +1,6 @@
 import ConfirmDialog from '@/components/ConfirmDialog';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import { Image } from 'expo-image';
 import React, { useEffect, useRef, useState } from 'react';
 import {
@@ -44,6 +45,7 @@ export default function ChangeCharacterModal({
   deleteError = null,
   onCancel,
 }: ChangeCharacterModalProps) {
+  const { t } = useLocalization();
   const [character, setCharacter] = useState<Character>(
     initialCharacter || {
       id: 'temp-id',
@@ -81,7 +83,7 @@ export default function ChangeCharacterModal({
     setIsDeletePending(false);
     activeDeleteRef.current = null;
     pendingDeleteCharacterIdRef.current = null;
-  }, [initialCharacter?.id]);
+  }, [initialCharacter]);
 
   const handleSave = () => {
     if (isDeletePending) {
@@ -161,9 +163,9 @@ export default function ChangeCharacterModal({
         <View style={styles.container}>
           <ConfirmDialog
             visible={deleteConfirmVisible}
-            title="Delete character?"
-            message="This action cannot be undone."
-            confirmLabel="Delete"
+            title={t('character.deleteTitle')}
+            message={t('character.deleteMessage')}
+            confirmLabel={t('character.delete')}
             onConfirm={handleDeleteConfirmAccept}
             onCancel={handleDeleteConfirmCancel}
           />
@@ -177,7 +179,7 @@ export default function ChangeCharacterModal({
 
             {/* Name Input */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Name:</Text>
+              <Text style={styles.fieldLabel}>{t('character.name')}</Text>
               <TextInput
                 style={styles.input}
                 value={character.nickname}
@@ -190,7 +192,7 @@ export default function ChangeCharacterModal({
 
             {/* Level Selection */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Level:</Text>
+              <Text style={styles.fieldLabel}>{t('character.level')}</Text>
               <View style={styles.inputGroup}>
                 <View style={styles.valueDisplay}>
                   <Text style={styles.valueText}>{character.level}</Text>
@@ -212,7 +214,7 @@ export default function ChangeCharacterModal({
 
             {/* Power Selection */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Power:</Text>
+              <Text style={styles.fieldLabel}>{t('character.power')}</Text>
               <View style={styles.inputGroup}>
                 <View style={styles.valueDisplay}>
                   <Text style={styles.valueText}>{character.power}</Text>
@@ -234,7 +236,7 @@ export default function ChangeCharacterModal({
 
             {/* Class Selection */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Class:</Text>
+              <Text style={styles.fieldLabel}>{t('character.class')}</Text>
               <View style={styles.inputGroupVertical}>
                 {character.class.map((cls, index) => (
                   <View style={styles.classRow} key={`class-${index}`}>
@@ -285,7 +287,7 @@ export default function ChangeCharacterModal({
 
             {/* Race Selection */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Race:</Text>
+              <Text style={styles.fieldLabel}>{t('character.race')}</Text>
               <View style={styles.inputGroupVertical}>
                 {character.race.map((race, index) => (
                   <View style={styles.classRow} key={`race-${index}`}>
@@ -342,7 +344,7 @@ export default function ChangeCharacterModal({
 
             {/* Gender Selection */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Gender:</Text>
+              <Text style={styles.fieldLabel}>{t('character.gender')}</Text>
               <View style={styles.genderContainer}>
                 <TouchableOpacity
                   style={styles.genderRow}
@@ -360,7 +362,7 @@ export default function ChangeCharacterModal({
                       <View style={styles.radioDot} />
                     )}
                   </View>
-                  <Text style={styles.genderLabel}>Male</Text>
+                  <Text style={styles.genderLabel}>{t('character.male')}</Text>
                 </TouchableOpacity>
 
                 <TouchableOpacity
@@ -379,14 +381,14 @@ export default function ChangeCharacterModal({
                       <View style={styles.radioDot} />
                     )}
                   </View>
-                  <Text style={styles.genderLabel}>Female</Text>
+                  <Text style={styles.genderLabel}>{t('character.female')}</Text>
                 </TouchableOpacity>
               </View>
             </View>
 
             {/* Color Selection */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Color:</Text>
+              <Text style={styles.fieldLabel}>{t('character.color')}</Text>
               <Pressable
                 style={[
                   styles.colorPicker,
@@ -410,7 +412,7 @@ export default function ChangeCharacterModal({
                       setColorModalVisible(false);
                     }}
                   >
-                    <Text style={[styles.contentContainer, styles.headerText]}>Select Color</Text>
+                    <Text style={[styles.contentContainer, styles.headerText]}>{t('character.selectColor')}</Text>
                     <Panel5 />
                   </ColorPicker>
                 </Pressable>
@@ -428,7 +430,7 @@ export default function ChangeCharacterModal({
               disabled={isDeletePending}
               testID="delete-character-button"
             >
-              <Text style={styles.deleteButtonText}>{isDeletePending ? 'Deleting Character...' : 'Delete Character'}</Text>
+              <Text style={styles.deleteButtonText}>{isDeletePending ? t('character.deletingCharacter') : t('character.deleteCharacter')}</Text>
             </TouchableOpacity>
           </ScrollView>
 
@@ -441,7 +443,7 @@ export default function ChangeCharacterModal({
               disabled={isDeletePending}
               testID="save-character-button"
             >
-              <Text style={styles.buttonText}>Save</Text>
+              <Text style={styles.buttonText}>{t('common.save')}</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -451,7 +453,7 @@ export default function ChangeCharacterModal({
               disabled={isDeletePending}
               testID="cancel-character-button"
             >
-              <Text style={styles.buttonText}>Cancel</Text>
+              <Text style={styles.buttonText}>{t('common.cancel')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/frontend/app/munchkin/modal-create-character.tsx
+++ b/frontend/app/munchkin/modal-create-character.tsx
@@ -1,5 +1,6 @@
 import avatars from '@/constants/avatars';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import { Image } from 'expo-image';
 import React, { useState } from 'react';
 import {
@@ -33,6 +34,7 @@ export default function CreateCharacterModal({
   onConfirm,
   onCancel,
 }: CreateCharacterModalProps) {
+  const { t } = useLocalization();
   const [character, setCharacter] = useState<Character>({
     id: Math.random().toString(36).substring(2, 10),
     avatar: Math.floor(Math.random() * avatars.length),
@@ -60,7 +62,7 @@ export default function CreateCharacterModal({
             style={styles.content}
             contentContainerStyle={styles.contentContainer}
           >
-            <Text style={styles.headerText}>New character</Text>
+            <Text style={styles.headerText}>{t('character.new')}</Text>
 
             <View style={styles.avatarContainer}>
               <Image
@@ -71,7 +73,7 @@ export default function CreateCharacterModal({
 
             {/* Color Selection */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Color:</Text>
+              <Text style={styles.fieldLabel}>{t('character.color')}</Text>
               <View
                 style={[
                   styles.colorPicker,
@@ -82,7 +84,7 @@ export default function CreateCharacterModal({
 
             {/* Name Input */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Name:</Text>
+              <Text style={styles.fieldLabel}>{t('character.name')}</Text>
               <TextInput
                 style={styles.input}
                 value={character.name}
@@ -96,7 +98,7 @@ export default function CreateCharacterModal({
 
             {/* Gender Selection */}
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Gender:</Text>
+              <Text style={styles.fieldLabel}>{t('character.gender')}</Text>
               <View style={styles.optionContainer}>
                 <TouchableOpacity
                   style={styles.optionRow}
@@ -114,7 +116,7 @@ export default function CreateCharacterModal({
                       <View style={styles.radioDot} />
                     )}
                   </View>
-                  <Text style={styles.optionLabel}>Male</Text>
+                  <Text style={styles.optionLabel}>{t('character.male')}</Text>
                 </TouchableOpacity>
 
                 <TouchableOpacity
@@ -133,7 +135,7 @@ export default function CreateCharacterModal({
                       <View style={styles.radioDot} />
                     )}
                   </View>
-                  <Text style={styles.optionLabel}>Female</Text>
+                  <Text style={styles.optionLabel}>{t('character.female')}</Text>
                 </TouchableOpacity>
               </View>
             </View>
@@ -146,7 +148,7 @@ export default function CreateCharacterModal({
               onPress={handleCreate}
               activeOpacity={0.7}
             >
-              <Text style={styles.buttonText}>Create</Text>
+              <Text style={styles.buttonText}>{t('character.create')}</Text>
             </TouchableOpacity>
 
             <TouchableOpacity
@@ -154,7 +156,7 @@ export default function CreateCharacterModal({
               onPress={onCancel}
               activeOpacity={0.7}
             >
-              <Text style={styles.buttonText}>Cancel</Text>
+              <Text style={styles.buttonText}>{t('common.cancel')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/frontend/app/privacy.tsx
+++ b/frontend/app/privacy.tsx
@@ -4,85 +4,86 @@ import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 import { PRIVACY_EFFECTIVE_DATE, SUPPORT_EMAIL } from '@/constants/releaseContent';
+import { useLocalization } from '@/i18n';
 
 export default function PrivacyPolicyPage() {
+  const { t } = useLocalization();
+
   return (
     <SafeAreaProvider>
       <SafeAreaView
         style={styles.safeArea}
         edges={Platform.OS === 'ios' ? [] : ['top', 'bottom', 'left', 'right']}
       >
-        <Stack.Screen options={{ title: 'Privacy Policy' }} />
+        <Stack.Screen options={{ title: t('privacy.title') }} />
 
         <ScrollView contentContainerStyle={styles.content}>
-          <Text style={styles.title}>Privacy Policy</Text>
-          <Text style={styles.meta}>Effective date: {PRIVACY_EFFECTIVE_DATE}</Text>
+          <Text style={styles.title}>{t('privacy.title')}</Text>
+          <Text style={styles.meta}>{t('privacy.effectiveDate', { date: PRIVACY_EFFECTIVE_DATE })}</Text>
 
           <PolicySection
-            title="1. Overview"
-            body="Munch Helper is a companion app for tabletop games like Munchkin. It does not require sign-up, account creation, email, password, or any third-party identity provider. The app creates an anonymous player profile so you can enter rooms and play without a traditional account."
+            title={t('privacy.section1Title')}
+            body={t('privacy.section1Body')}
           />
 
           <PolicySection
-            title="2. Information We Process"
-            body="The app processes the profile and gameplay information needed to run the game: your nickname, avatar selection from a fixed local image set, and a server-assigned user identifier. Character records can include name, avatar, color, level, power, class, race, and gender. Room, battle, and room history log records are also processed when those features are used."
+            title={t('privacy.section2Title')}
+            body={t('privacy.section2Body')}
           />
 
           <PolicySection
-            title="3. Session Data"
-            body="To restore your session between launches, the app stores your user profile locally on your device with AsyncStorage under the user key. The profile is also stored server-side so you can rejoin rooms. Characters, battles, rooms, and room history are stored server-side to keep shared gameplay state available."
+            title={t('privacy.section3Title')}
+            body={t('privacy.section3Body')}
           />
 
           <PolicySection
-            title="4. Room Participation"
-            body="When you join a room, your nickname, avatar, and character details become visible to other players in that same room. Room, battle, and room history log state is shared in real time with participants in the room so everyone sees the same gameplay state."
+            title={t('privacy.section4Title')}
+            body={t('privacy.section4Body')}
           />
 
           <PolicySection
-            title="5. Server Communication"
-            body="The app sends and retrieves profile, room, character, battle, and log data through backend APIs and uses WebSocket connections for real-time updates between players in the same room."
+            title={t('privacy.section5Title')}
+            body={t('privacy.section5Body')}
           />
 
           <PolicySection
-            title="6. Why Data Is Used"
-            body="Data is used only to operate core features: creating player profiles, creating and joining rooms, managing characters, running battles, showing room history, synchronizing shared game state, and maintaining a stable multiplayer experience."
+            title={t('privacy.section6Title')}
+            body={t('privacy.section6Body')}
           />
 
           <PolicySection
-            title="7. Data Sharing"
-            body="Your profile and gameplay data is shared only with other participants in rooms you join so multiplayer features can function. Munch Helper does not sell data and does not include third-party advertising, analytics, or tracking SDKs."
+            title={t('privacy.section7Title')}
+            body={t('privacy.section7Body')}
           />
 
           <PolicySection
-            title="8. Children"
-            body="Munch Helper is not directed to children and does not include children-directed features. If you believe a child has provided information through the app, contact support and request deletion assistance."
+            title={t('privacy.section8Title')}
+            body={t('privacy.section8Body')}
           />
 
           <PolicySection
-            title="9. Security"
-            body="Reasonable technical measures are used to protect data in storage and transit. However, no method of transmission or storage can be guaranteed as completely secure."
+            title={t('privacy.section9Title')}
+            body={t('privacy.section9Body')}
           />
 
           <PolicySection
-            title="10. Data Retention and Deletion"
-            body="Local profile data remains on your device until you clear app data or uninstall the app. Server-side data may be retained as needed to operate and maintain the service. You can contact support to request data deletion assistance."
+            title={t('privacy.section10Title')}
+            body={t('privacy.section10Body')}
           />
 
           <PolicySection
-            title="11. International Use"
-            body="By using the app, you understand that data may be processed in infrastructure regions selected by the service operator."
+            title={t('privacy.section11Title')}
+            body={t('privacy.section11Body')}
           />
 
           <PolicySection
-            title="12. Changes to This Policy"
-            body="This policy may be updated from time to time. Updates will be reflected by changing the effective date on this page."
+            title={t('privacy.section12Title')}
+            body={t('privacy.section12Body')}
           />
 
           <View style={styles.contactCard}>
-            <Text style={styles.contactTitle}>Contact</Text>
-            <Text style={styles.contactText}>
-              For privacy questions or requests, email: {SUPPORT_EMAIL}
-            </Text>
+            <Text style={styles.contactTitle}>{t('privacy.contact')}</Text>
+            <Text style={styles.contactText}>{t('privacy.contactText', { email: SUPPORT_EMAIL })}</Text>
           </View>
         </ScrollView>
       </SafeAreaView>

--- a/frontend/app/rooms.tsx
+++ b/frontend/app/rooms.tsx
@@ -6,6 +6,7 @@ import { Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native
 import VioletButton from '@/components/VioletButton';
 import avatars from '@/constants/avatars';
 import { userProfileContext } from '@/context/UserContext';
+import { useLocalization } from '@/i18n';
 import { router, Stack } from 'expo-router';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import ChangeUserModal from './main/modal-change-user';
@@ -19,6 +20,7 @@ export default function Home() {
   const [joinRoomModalVisible, setJoinRoomModalVisible] = useState(false);
   const [changeUserModalVisible, setChangeUserModalVisible] = useState(false);
   const { userProfile, setUserProfile } = useContext(userProfileContext);
+  const { t } = useLocalization();
 
   return (
     <SafeAreaProvider>
@@ -28,7 +30,7 @@ export default function Home() {
       >
         <View style={styles.container}>
           {/* Status Bar */}
-          <Stack.Screen options={{ title: 'Games' }} />
+          <Stack.Screen options={{ title: t('rooms.title') }} />
 
           {/* Main Content */}
           <View style={styles.mainContent}>
@@ -36,14 +38,14 @@ export default function Home() {
             <View style={styles.gameCard}>
               <View style={styles.gameTitle}>
                 <Text style={styles.gameTitleText}>Munch ⚔️</Text>
-                <Text style={styles.gameTitleText}>Classic</Text>
+                <Text style={styles.gameTitleText}>{t('rooms.munchClassic')}</Text>
               </View>
               <View style={styles.gameActions}>
                 <TouchableOpacity style={styles.actionButton} onPress={() => setCreateRoomModalVisible(true)}>
-                  <Text style={styles.actionButtonLabel}>Create</Text>
+                  <Text style={styles.actionButtonLabel}>{t('rooms.create')}</Text>
                 </TouchableOpacity>
                 <TouchableOpacity style={styles.actionButton} onPress={() => setJoinRoomModalVisible(true)}>
-                  <Text style={styles.actionButtonLabel}>Join</Text>
+                  <Text style={styles.actionButtonLabel}>{t('rooms.join')}</Text>
                 </TouchableOpacity>
               </View>
             </View>
@@ -53,7 +55,7 @@ export default function Home() {
           <View style={styles.roomsHistoryContainer}>
             {/* TODO: Not implemented yet */}
             <TouchableOpacity style={[styles.roomsHistoryButton, { opacity: 0 }]}>
-              <Text style={styles.roomsHistoryText}>Rooms history</Text>
+              <Text style={styles.roomsHistoryText}>{t('rooms.history')}</Text>
             </TouchableOpacity>
           </View>
 
@@ -66,7 +68,7 @@ export default function Home() {
               />
               <View style={{ justifyContent: 'center', alignItems: 'center', gap: 5, width: '50%' }}>
                 <Text style={styles.profileNickname}>{userProfile.nickname}</Text>
-                <VioletButton title="Change" onPress={() => setChangeUserModalVisible(true)} />
+                <VioletButton title={t('rooms.changeProfile')} onPress={() => setChangeUserModalVisible(true)} />
               </View>
             </View>
             {/* Currently not implemented

--- a/frontend/app/support.tsx
+++ b/frontend/app/support.tsx
@@ -4,8 +4,11 @@ import { Linking, Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 import { SUPPORT_EMAIL } from '@/constants/releaseContent';
+import { useLocalization } from '@/i18n';
 
 export default function SupportPage() {
+  const { t } = useLocalization();
+
   const handleEmailPress = async () => {
     try {
       await Linking.openURL(`mailto:${SUPPORT_EMAIL}`);
@@ -20,20 +23,16 @@ export default function SupportPage() {
         style={styles.safeArea}
         edges={Platform.OS === 'ios' ? [] : ['top', 'bottom', 'left', 'right']}
       >
-        <Stack.Screen options={{ title: 'Support' }} />
+        <Stack.Screen options={{ title: t('support.title') }} />
 
         <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.title}>Support</Text>
-          <Text style={styles.description}>
-            Need help with Munch Helper rooms, characters, battles, or room history? Contact me
-            without creating an account and include a short description of the issue, the room code
-            if relevant, and what you expected to happen.
-          </Text>
+          <Text style={styles.title}>{t('support.title')}</Text>
+          <Text style={styles.description}>{t('support.description')}</Text>
 
           <View style={styles.emailCard}>
-            <Text style={styles.emailLabel}>Contact Email</Text>
+            <Text style={styles.emailLabel}>{t('support.contactEmail')}</Text>
             <TouchableOpacity
-              accessibilityLabel={`Email support at ${SUPPORT_EMAIL}`}
+              accessibilityLabel={t('support.emailSupportAt', { email: SUPPORT_EMAIL })}
               accessibilityRole="button"
               onPress={handleEmailPress}
               style={styles.emailButton}

--- a/frontend/components/RootErrorBoundary.tsx
+++ b/frontend/components/RootErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { DEFAULT_LOCALE, translate } from '@/i18n';
 
 type RootErrorBoundaryProps = {
   children: React.ReactNode;
@@ -34,8 +35,8 @@ export class RootErrorBoundary extends React.Component<RootErrorBoundaryProps, R
     if (this.state.hasError) {
       return (
         <View style={styles.container}>
-          <Text style={styles.title}>Something went wrong</Text>
-          <Text style={styles.message}>{this.state.errorMessage || 'Unexpected application error.'}</Text>
+          <Text style={styles.title}>{translate(DEFAULT_LOCALE, 'error.title')}</Text>
+          <Text style={styles.message}>{this.state.errorMessage || translate(DEFAULT_LOCALE, 'error.unexpected')}</Text>
         </View>
       );
     }

--- a/frontend/components/munchkin/ActiveBattleBanner.tsx
+++ b/frontend/components/munchkin/ActiveBattleBanner.tsx
@@ -1,4 +1,5 @@
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import React, { memo, useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
@@ -11,13 +12,14 @@ const ActiveBattleBanner = memo(function ActiveBattleBanner({
   battleName,
   onViewBattle,
 }: ActiveBattleBannerProps) {
-  const label = useMemo(() => battleName?.trim() || 'Battle in progress', [battleName]);
+  const { t } = useLocalization();
+  const label = useMemo(() => battleName?.trim() || t('battle.inProgress'), [battleName, t]);
 
   return (
     <Pressable
       accessible
       accessibilityRole="button"
-      accessibilityLabel="Battle in progress. Tap to view."
+      accessibilityLabel={t('battle.inProgressAccessibility')}
       onPress={onViewBattle}
       style={({ pressed }) => [styles.banner, pressed && styles.bannerPressed]}
       testID="active-battle-banner"
@@ -26,7 +28,7 @@ const ActiveBattleBanner = memo(function ActiveBattleBanner({
         <Text style={styles.icon}>⚔️</Text>
         <Text style={styles.label} numberOfLines={1}>{label}</Text>
       </View>
-      <Text style={styles.actionText}>View Battle →</Text>
+      <Text style={styles.actionText}>{t('battle.viewBattle')}</Text>
     </Pressable>
   );
 });

--- a/frontend/components/munchkin/BattleConcludeAction.tsx
+++ b/frontend/components/munchkin/BattleConcludeAction.tsx
@@ -1,5 +1,6 @@
 import { BattleResult } from '@/api/battles';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import React, { memo } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -20,11 +21,13 @@ function BattleConcludeAction({
   isConcluding,
   dirtyHint,
 }: BattleConcludeActionProps) {
+  const { t } = useLocalization();
+
   return (
     <View style={styles.root} testID="battle-conclude-action">
       <View accessibilityRole="radiogroup" style={styles.resultRow}>
         <TouchableOpacity
-          accessibilityLabel="Players Win"
+          accessibilityLabel={t('battle.playersWin')}
           accessibilityRole="radio"
           accessibilityState={{ selected: selectedResult === 'players_win' }}
           style={[
@@ -35,12 +38,12 @@ function BattleConcludeAction({
           onPress={() => onSelectResult('players_win')}
         >
           <Text style={[styles.resultText, selectedResult === 'players_win' ? styles.resultTextSelected : styles.resultTextUnselected]}>
-            Players Win
+            {t('battle.playersWin')}
           </Text>
         </TouchableOpacity>
 
         <TouchableOpacity
-          accessibilityLabel="Monsters Win"
+          accessibilityLabel={t('battle.monstersWin')}
           accessibilityRole="radio"
           accessibilityState={{ selected: selectedResult === 'monster_wins' }}
           style={[
@@ -51,13 +54,13 @@ function BattleConcludeAction({
           onPress={() => onSelectResult('monster_wins')}
         >
           <Text style={[styles.resultText, selectedResult === 'monster_wins' ? styles.resultTextSelected : styles.resultTextUnselected]}>
-            Monsters Win
+            {t('battle.monstersWin')}
           </Text>
         </TouchableOpacity>
       </View>
 
       <TouchableOpacity
-        accessibilityLabel="Conclude battle"
+        accessibilityLabel={t('battle.concludeAccessibility')}
         accessibilityRole="button"
         accessibilityState={{ disabled }}
         disabled={disabled}
@@ -66,13 +69,13 @@ function BattleConcludeAction({
         onPress={onConclude}
       >
         <Text style={[styles.concludeButtonText, disabled && styles.concludeButtonTextDisabled]}>
-          {isConcluding ? 'Concluding...' : 'Conclude'}
+          {isConcluding ? t('battle.concluding') : t('battle.conclude')}
         </Text>
       </TouchableOpacity>
 
       {dirtyHint && (
         <Text style={styles.hintText} testID="battle-conclude-dirty-hint">
-          Save your changes before concluding
+          {t('battle.concludeDirtyHint')}
         </Text>
       )}
     </View>

--- a/frontend/components/munchkin/BattleDiscardAction.tsx
+++ b/frontend/components/munchkin/BattleDiscardAction.tsx
@@ -1,5 +1,6 @@
 import ConfirmDialog from '@/components/ConfirmDialog';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import React, { memo } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -18,10 +19,12 @@ function BattleDiscardAction({
   onCancelConfirm,
   isDiscarding,
 }: BattleDiscardActionProps) {
+  const { t } = useLocalization();
+
   return (
     <View style={styles.root} testID="battle-discard-action">
       <TouchableOpacity
-        accessibilityLabel="Discard battle"
+        accessibilityLabel={t('battle.discardAccessibility')}
         accessibilityRole="button"
         accessibilityState={{ disabled: isDiscarding }}
         disabled={isDiscarding}
@@ -30,15 +33,15 @@ function BattleDiscardAction({
         onPress={onRequestConfirm}
       >
         <Text style={[styles.discardButtonText, isDiscarding && styles.discardButtonTextDisabled]}>
-          {isDiscarding ? 'Discarding...' : 'Discard'}
+          {isDiscarding ? t('battle.discarding') : t('battle.discard')}
         </Text>
       </TouchableOpacity>
 
       <ConfirmDialog
-        cancelLabel="Keep battle"
-        confirmLabel="Discard"
-        message="This battle will be discarded and removed from the room. This can't be undone."
-        title="Discard battle?"
+        cancelLabel={t('battle.keepBattle')}
+        confirmLabel={t('battle.discard')}
+        message={t('battle.discardMessage')}
+        title={t('battle.discardTitle')}
         visible={confirmVisible}
         onCancel={onCancelConfirm}
         onConfirm={onConfirmDiscard}

--- a/frontend/components/munchkin/BattleHistoryModal.tsx
+++ b/frontend/components/munchkin/BattleHistoryModal.tsx
@@ -2,6 +2,7 @@ import type { LogEvent } from '@/api/logs';
 import { AppTheme } from '@/constants/theme';
 import { useRoomCharacters } from '@/hooks/useCharacters';
 import type { UserProfileInterface } from '@/hooks/useUser';
+import { useLocalization } from '@/i18n';
 import React, { memo, useMemo } from 'react';
 import {
   Modal,
@@ -15,7 +16,6 @@ import {
 
 import {
   formatSignedValue,
-  getBattleResultLabel,
   narrowBattlePayload,
 } from './logEntryBattle';
 import { formatRelativeTime } from './logEntryTime';
@@ -45,6 +45,7 @@ function resultColor(result: unknown): string {
 }
 
 function BattleHistoryModal({ entry, roomId, userProfile, onClose }: BattleHistoryModalProps) {
+  const { t } = useLocalization();
   const isVisible = entry !== null;
   const { characters } = useRoomCharacters(roomId, userProfile);
   const characterById = useMemo(
@@ -53,8 +54,11 @@ function BattleHistoryModal({ entry, roomId, userProfile, onClose }: BattleHisto
   );
   const battle = entry ? narrowBattlePayload(entry.payload) : null;
   const isConcluded = entry?.eventType === 'battle_concluded';
-  const title = battle?.name || entry?.summary || 'Battle';
-  const status = capitalizeStatus(battle?.status, entry?.eventType === 'battle_discarded' ? 'discarded' : 'concluded');
+  const title = battle?.name || entry?.summary || t('rooms.battle');
+  const status = capitalizeStatus(
+    battle?.status,
+    entry?.eventType === 'battle_discarded' ? t('history.discarded') : t('history.concluded')
+  );
   const relativeTime = entry ? formatRelativeTime(entry.occurredAt) : '';
   const playerIds = battle?.playerSide?.characterIds ?? [];
   const playerBonuses = battle?.playerSide?.bonuses ?? [];
@@ -84,7 +88,7 @@ function BattleHistoryModal({ entry, roomId, userProfile, onClose }: BattleHisto
               <Text style={styles.status}>{status}</Text>
             </View>
             <TouchableOpacity
-              accessibilityLabel="Close battle history"
+              accessibilityLabel={t('history.closeBattleHistory')}
               accessibilityRole="button"
               hitSlop={8}
               onPress={onClose}
@@ -102,12 +106,16 @@ function BattleHistoryModal({ entry, roomId, userProfile, onClose }: BattleHisto
                   style={[styles.resultChip, { color: resultColor(battle.result) }]}
                   testID="battle-history-result"
                 >
-                  {getBattleResultLabel(battle.result, '—')}
+                  {battle.result === 'players_win'
+                    ? t('battle.playersWin')
+                    : battle.result === 'monster_wins'
+                      ? t('battle.monsterWins')
+                      : '—'}
                 </Text>
               )}
 
               <View style={styles.section}>
-                <Text style={styles.playerHeading}>Player Side</Text>
+                <Text style={styles.playerHeading}>{t('battle.playerSide')}</Text>
                 {playerIds.length > 0 ? playerIds.map((characterId) => {
                   const character = characterById.get(characterId);
                   const hasLevel = character && Number.isFinite(character.level);
@@ -115,19 +123,19 @@ function BattleHistoryModal({ entry, roomId, userProfile, onClose }: BattleHisto
                   return (
                     <View key={characterId} style={styles.rowLine}>
                       <Text style={styles.bodyText}>
-                        {character?.nickname ?? 'Removed character'}
+                        {character?.nickname ?? t('battle.removedCharacter')}
                       </Text>
                       {character && (hasLevel || hasPower) && (
                         <Text style={styles.captionText}>
-                          {hasLevel ? `Level ${character.level}` : null}
+                          {hasLevel ? t('battle.levelValue', { level: character.level }) : null}
                           {hasLevel && hasPower ? ' · ' : null}
-                          {hasPower ? `Power ${character.power}` : null}
+                          {hasPower ? t('battle.powerValue', { value: character.power }) : null}
                         </Text>
                       )}
                     </View>
                   );
                 }) : (
-                  <Text style={styles.captionText}>No player participants</Text>
+                  <Text style={styles.captionText}>{t('history.noPlayerParticipants')}</Text>
                 )}
                 {playerBonuses.length > 0 && (
                   <View style={styles.bonusList}>
@@ -139,13 +147,13 @@ function BattleHistoryModal({ entry, roomId, userProfile, onClose }: BattleHisto
               </View>
 
               <View style={styles.section}>
-                <Text style={styles.monsterHeading}>Monster Side</Text>
+                <Text style={styles.monsterHeading}>{t('battle.monsterSide')}</Text>
                 {monsters.length > 0 ? monsters.map((monster) => (
                   <Text key={monster.id} style={styles.bodyText}>
-                    {monster.name || 'Unknown monster'} · Level {Number.isFinite(monster.level) ? monster.level : '—'}
+                    {monster.name || t('history.unknownMonster')} · {Number.isFinite(monster.level) ? t('battle.levelValue', { level: monster.level }) : t('battle.levelValue', { level: '—' })}
                   </Text>
                 )) : (
-                  <Text style={styles.captionText}>No monsters recorded</Text>
+                  <Text style={styles.captionText}>{t('history.noMonstersRecorded')}</Text>
                 )}
                 {monsterBonuses.length > 0 && (
                   <View style={styles.bonusList}>

--- a/frontend/components/munchkin/BattleSidePanel.tsx
+++ b/frontend/components/munchkin/BattleSidePanel.tsx
@@ -1,6 +1,7 @@
 import { BonusItem, MonsterItem } from '@/api/battles';
 import { Character as RoomCharacter } from '@/api/characters';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import type { ActivePlayerParticipant } from '@/utils/battlePlayerSide';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { Image, Modal, Pressable, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
@@ -48,6 +49,7 @@ function BattleSidePanel({
   onAddBonus,
   onRemoveBonus,
 }: BattleSidePanelProps) {
+  const { t } = useLocalization();
   const [selectedCharacterId, setSelectedCharacterId] = useState('');
   const [monsterName, setMonsterName] = useState(DEFAULT_MONSTER_NAME);
   const [monsterLevelText, setMonsterLevelText] = useState(DEFAULT_MONSTER_LEVEL);
@@ -99,12 +101,12 @@ function BattleSidePanel({
 
       {side === 'players' && (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Characters</Text>
+          <Text style={styles.sectionTitle}>{t('battle.characters')}</Text>
           {selectedParticipants.map(({ id, character }) => (
             <View key={id} style={styles.row} testID="battle-participant-active">
-              <Text style={styles.rowText}>{character.nickname} · Power {character.level + character.power}</Text>
+              <Text style={styles.rowText}>{character.nickname} · {t('battle.powerValue', { value: character.level + character.power })}</Text>
               <TouchableOpacity
-                accessibilityLabel={`Remove ${character.nickname}`}
+                accessibilityLabel={t('battle.removeName', { name: character.nickname })}
                 accessibilityRole="button"
                 style={styles.removeButton}
                 testID={`remove-character-${id}`}
@@ -116,11 +118,11 @@ function BattleSidePanel({
           ))}
           {removedCharacterIds.map((id) => (
             <View key={id} style={styles.removedRow} testID="battle-participant-removed">
-              <Text accessibilityLabel={`${id} - removed from room`} style={styles.removedText}>
-                Removed character
+              <Text accessibilityLabel={t('battle.removedCharacterAccessibility', { id })} style={styles.removedText}>
+                {t('battle.removedCharacter')}
               </Text>
               <TouchableOpacity
-                accessibilityLabel="Drop removed character from draft"
+                accessibilityLabel={t('battle.dropRemovedCharacter')}
                 accessibilityRole="button"
                 style={styles.removeButton}
                 testID={`discard-removed-character-${id}`}
@@ -134,7 +136,7 @@ function BattleSidePanel({
             <View style={styles.selectWrap}>
               {availableCharacters.map((character) => (
                 <TouchableOpacity
-                  accessibilityLabel={`Select ${character.nickname}`}
+                  accessibilityLabel={t('battle.selectCharacter', { name: character.nickname })}
                   accessibilityRole="button"
                   key={character.id}
                   style={[styles.choice, selectedCharacterId === character.id && styles.choiceSelected]}
@@ -144,10 +146,10 @@ function BattleSidePanel({
                   <Text style={styles.choiceText}>{character.nickname}</Text>
                 </TouchableOpacity>
               ))}
-              {availableCharacters.length === 0 && <Text style={styles.mutedText}>No characters available</Text>}
+              {availableCharacters.length === 0 && <Text style={styles.mutedText}>{t('battle.noCharactersAvailable')}</Text>}
             </View>
             <TouchableOpacity
-              accessibilityLabel="Add selected character"
+              accessibilityLabel={t('battle.addSelectedCharacter')}
               accessibilityRole="button"
               disabled={!selectedCharacterId}
               style={[styles.addButton, !selectedCharacterId && styles.disabledButton]}
@@ -162,12 +164,12 @@ function BattleSidePanel({
 
       {side === 'monsters' && (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Monsters</Text>
+          <Text style={styles.sectionTitle}>{t('battle.monsters')}</Text>
           {monsters.map((monster, index) => (
             <View key={monster.id} style={styles.row}>
-              <Text style={styles.rowText}>{monster.name} · Level {monster.level}{index === 0 ? ' · Main' : ''}</Text>
+              <Text style={styles.rowText}>{monster.name} · {t('battle.levelValue', { level: monster.level })}{index === 0 ? ` · ${t('battle.mainMonster')}` : ''}</Text>
               <TouchableOpacity
-                accessibilityLabel={`Remove ${monster.name}`}
+                accessibilityLabel={t('battle.removeName', { name: monster.name })}
                 accessibilityRole="button"
                 style={styles.removeButton}
                 testID={`remove-monster-${monster.id}`}
@@ -178,7 +180,7 @@ function BattleSidePanel({
             </View>
           ))}
           <TouchableOpacity
-            accessibilityLabel="Open add monster dialog"
+            accessibilityLabel={t('battle.openAddMonster')}
             accessibilityRole="button"
             style={styles.openDialogButton}
             testID="open-add-monster"
@@ -188,18 +190,18 @@ function BattleSidePanel({
               setIsMonsterModalVisible(true);
             }}
           >
-            <Text style={styles.openDialogButtonText}>Add monster</Text>
+            <Text style={styles.openDialogButtonText}>{t('battle.addMonster')}</Text>
           </TouchableOpacity>
         </View>
       )}
 
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Bonuses</Text>
+        <Text style={styles.sectionTitle}>{t('battle.bonuses')}</Text>
         {bonuses.map((bonus) => (
           <View key={bonus.id} style={styles.row}>
             <Text style={styles.rowText}>{bonus.value >= 0 ? `+${bonus.value}` : bonus.value}</Text>
             <TouchableOpacity
-              accessibilityLabel={`Remove bonus ${bonus.value}`}
+              accessibilityLabel={t('battle.removeBonus', { value: bonus.value })}
               accessibilityRole="button"
               style={styles.removeButton}
               testID={`remove-bonus-${side}-${bonus.id}`}
@@ -212,7 +214,7 @@ function BattleSidePanel({
         <View style={styles.bonusGrid}>
           {BONUS_VALUES.map((value) => (
             <TouchableOpacity
-              accessibilityLabel={`Add bonus ${value}`}
+              accessibilityLabel={t('battle.addBonus', { value })}
               accessibilityRole="button"
               key={value}
               style={styles.bonusButton}
@@ -229,7 +231,7 @@ function BattleSidePanel({
         <Modal transparent visible={isMonsterModalVisible} animationType="fade" onRequestClose={closeMonsterModal}>
           <View style={styles.modalRoot}>
             <Pressable
-              accessibilityLabel="Cancel add monster"
+              accessibilityLabel={t('battle.cancelAddMonster')}
               style={styles.modalBackdrop}
               testID="add-monster-backdrop"
               onPress={closeMonsterModal}
@@ -237,13 +239,13 @@ function BattleSidePanel({
             <View style={styles.monsterDialog} testID="add-monster-dialog">
               <View style={styles.monsterDialogForm}>
                 <View style={styles.monsterDialogHeadline}>
-                  <Text style={styles.monsterDialogHeadlineText}>Add monster</Text>
+                  <Text style={styles.monsterDialogHeadlineText}>{t('battle.addMonster')}</Text>
                 </View>
                 <Image accessibilityIgnoresInvertColors source={monsterImage} style={styles.monsterDialogImage} />
                 <View style={styles.monsterDialogField}>
-                  <Text style={styles.monsterDialogLabel}>Name:</Text>
+                  <Text style={styles.monsterDialogLabel}>{t('character.name')}</Text>
                   <TextInput
-                    accessibilityLabel="Monster name"
+                    accessibilityLabel={t('battle.monsterName')}
                     placeholder={DEFAULT_MONSTER_NAME}
                     placeholderTextColor={AppTheme.colors.surfaceWarm}
                     style={styles.monsterDialogInput}
@@ -253,9 +255,9 @@ function BattleSidePanel({
                   />
                 </View>
                 <View style={styles.monsterDialogField}>
-                  <Text style={styles.monsterDialogLabel}>Level:</Text>
+                  <Text style={styles.monsterDialogLabel}>{t('character.level')}</Text>
                   <TextInput
-                    accessibilityLabel="Monster level"
+                    accessibilityLabel={t('battle.monsterLevel')}
                     inputMode="numeric"
                     keyboardType="number-pad"
                     placeholder={DEFAULT_MONSTER_LEVEL}
@@ -269,23 +271,23 @@ function BattleSidePanel({
               </View>
               <View style={styles.monsterDialogActions}>
                 <TouchableOpacity
-                  accessibilityLabel="Save monster"
+                  accessibilityLabel={t('battle.saveMonster')}
                   accessibilityRole="button"
                   disabled={!monsterName.trim()}
                   style={[styles.monsterDialogButton, !monsterName.trim() && styles.monsterDialogButtonDisabled]}
                   testID="save-monster"
                   onPress={handleAddMonster}
                 >
-                  <Text style={styles.monsterDialogButtonText}>Save</Text>
+                  <Text style={styles.monsterDialogButtonText}>{t('common.save')}</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
-                  accessibilityLabel="Cancel add monster"
+                  accessibilityLabel={t('battle.cancelAddMonster')}
                   accessibilityRole="button"
                   style={styles.monsterDialogButton}
                   testID="cancel-add-monster"
                   onPress={closeMonsterModal}
                 >
-                  <Text style={styles.monsterDialogButtonText}>Cancel</Text>
+                  <Text style={styles.monsterDialogButtonText}>{t('common.cancel')}</Text>
                 </TouchableOpacity>
               </View>
             </View>

--- a/frontend/components/munchkin/CurrentCharacterFooter.tsx
+++ b/frontend/components/munchkin/CurrentCharacterFooter.tsx
@@ -2,6 +2,7 @@ import { Character as RoomCharacter } from '@/api/characters';
 import VioletButton from '@/components/VioletButton';
 import avatars from '@/constants/avatars';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import React, { memo } from 'react';
 import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
 
@@ -16,6 +17,8 @@ const CurrentCharacterFooter = memo(function CurrentCharacterFooter({
   character,
   onChangePress,
 }: CurrentCharacterFooterProps) {
+  const { t } = useLocalization();
+
   return (
     <View style={styles.currentCharacterFooter}>
       <View style={[styles.avatarWrapper, { backgroundColor: character.color }]}>
@@ -25,8 +28,8 @@ const CurrentCharacterFooter = memo(function CurrentCharacterFooter({
       <View style={styles.footerInfo}>
         <Text style={styles.footerNickname}>{character.nickname}</Text>
         <View style={styles.footerStats}>
-          <Text style={styles.footerStatText}>{character.level} lvl</Text>
-          <Text style={styles.footerStatText}>{character.power} str</Text>
+          <Text style={styles.footerStatText}>{t('character.levelAbbrev', { level: character.level })}</Text>
+          <Text style={styles.footerStatText}>{t('character.strengthAbbrev', { power: character.power })}</Text>
         </View>
       </View>
 
@@ -40,7 +43,7 @@ const CurrentCharacterFooter = memo(function CurrentCharacterFooter({
         </ScrollView>
       </View>
 
-      <VioletButton title="Change" onPress={() => onChangePress(character)} />
+      <VioletButton title={t('rooms.changeProfile')} onPress={() => onChangePress(character)} />
     </View>
   );
 });

--- a/frontend/components/munchkin/LogEntry.localization.test.tsx
+++ b/frontend/components/munchkin/LogEntry.localization.test.tsx
@@ -1,0 +1,75 @@
+import type { LogEvent } from '@/api/logs';
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockLocale = vi.hoisted(() => ({ value: 'en' as 'en' | 'lt' }));
+
+vi.mock('@/constants/avatars', () => ({
+  default: Array.from({ length: 10 }, (_, index) => index + 1),
+}));
+
+vi.mock('@/i18n', async () => {
+  const actual = await vi.importActual<typeof import('@/i18n')>('@/i18n');
+  return {
+    ...actual,
+    useLocalization: () => ({
+      locale: mockLocale.value,
+      localeOptions: actual.LOCALE_INFOS,
+      setLocale: vi.fn(),
+      t: (key: Parameters<typeof actual.translate>[1], values?: Parameters<typeof actual.translate>[2]) =>
+        actual.translate(mockLocale.value, key, values),
+    }),
+  };
+});
+
+vi.mock('react-native', async () => {
+  const actual = await vi.importActual<typeof import('react-native')>('react-native');
+  return {
+    ...actual,
+    Image: 'Image',
+  };
+});
+
+vi.mock('./logEntryTime', () => ({
+  formatRelativeTime: vi.fn(() => '3m ago'),
+}));
+
+describe('LogEntry localization', () => {
+  beforeEach(() => {
+    mockLocale.value = 'en';
+  });
+
+  it('renders the same structured battle-started event in the active language', async () => {
+    const { default: LogEntry } = await import('./LogEntry');
+    const entry: LogEvent = {
+      id: 'log-1',
+      roomId: 'room-1',
+      eventType: 'battle_started',
+      actorId: 'user-1',
+      summary: 'Battle started',
+      payload: {
+        battle: {
+          id: 'battle-1',
+          name: 'Cave Dragon',
+        },
+      },
+      occurredAt: '2026-05-21T11:57:00.000Z',
+    };
+
+    let englishRenderer: any;
+    act(() => {
+      englishRenderer = TestRenderer.create(<LogEntry entry={entry} />);
+    });
+    expect(englishRenderer!.root.findByProps({ testID: 'log-entry-row' }).props.accessibilityLabel)
+      .toBe('Battle Cave Dragon, started, 3m ago.');
+
+    mockLocale.value = 'lt';
+    let lithuanianRenderer: any;
+    act(() => {
+      lithuanianRenderer = TestRenderer.create(<LogEntry entry={entry} />);
+    });
+    expect(lithuanianRenderer!.root.findByProps({ testID: 'log-entry-row' }).props.accessibilityLabel)
+      .toBe('Mūšis Cave Dragon, pradėtas, 3m ago.');
+  });
+});

--- a/frontend/components/munchkin/LogEntry.tsx
+++ b/frontend/components/munchkin/LogEntry.tsx
@@ -1,11 +1,12 @@
 import type { LogEvent } from '@/api/logs';
 import avatars from '@/constants/avatars';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
+import type { TranslationKey } from '@/i18n';
 import React, { memo, useMemo } from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import {
-  getBattleResultLabel,
   hasUsableBattlePayload,
   narrowBattlePayload,
 } from './logEntryBattle';
@@ -32,9 +33,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function formatDisplayValue(value: unknown): string {
+function formatDisplayValue(value: unknown, t: (key: TranslationKey) => string): string {
   if (value === null || value === undefined || value === '') {
-    return 'none';
+    return t('history.none');
   }
 
   if (typeof value === 'string') {
@@ -45,7 +46,7 @@ function formatDisplayValue(value: unknown): string {
         const parsedValue: unknown = JSON.parse(trimmedValue);
 
         if (Array.isArray(parsedValue)) {
-          return formatDisplayValue(parsedValue);
+          return formatDisplayValue(parsedValue, t);
         }
       } catch {
         return value;
@@ -61,16 +62,16 @@ function formatDisplayValue(value: unknown): string {
 
   if (Array.isArray(value)) {
     if (value.length === 0) {
-      return '<Empty>';
+      return t('history.emptyValue');
     }
 
-    return value.map(formatDisplayValue).join(', ');
+    return value.map((item) => formatDisplayValue(item, t)).join(', ');
   }
 
   return String(value);
 }
 
-function getCharacterDisplay(payload: unknown, summary: string): CharacterDisplay {
+function getCharacterDisplay(payload: unknown, summary: string, unknownCharacterLabel: string): CharacterDisplay {
   const character = isRecord(payload) && isRecord(payload.character) ? payload.character : {};
   const rawName = typeof character.name === 'string' ? character.name.trim() : '';
   const rawAvatarId = typeof character.avatarId === 'number' && Number.isInteger(character.avatarId)
@@ -81,13 +82,13 @@ function getCharacterDisplay(payload: unknown, summary: string): CharacterDispla
     : AppTheme.colors.surfaceWarm;
 
   return {
-    name: rawName || summary || 'Unknown character',
+    name: rawName || summary || unknownCharacterLabel,
     avatarId: rawAvatarId,
     color: rawColor,
   };
 }
 
-function getDiffRows(payload: unknown): DiffRow[] {
+function getDiffRows(payload: unknown, t: (key: TranslationKey) => string): DiffRow[] {
   if (!isRecord(payload) || !isRecord(payload.changes)) {
     return [];
   }
@@ -99,8 +100,8 @@ function getDiffRows(payload: unknown): DiffRow[] {
 
     return [{
       field,
-      prev: formatDisplayValue(change.prev),
-      next: formatDisplayValue(change.next),
+      prev: formatDisplayValue(change.prev, t),
+      next: formatDisplayValue(change.next, t),
     }];
   });
 }
@@ -112,7 +113,7 @@ function appendTime(label: string, relativeTime: string): string {
 function getActionAccessibilityLabel(
   name: string,
   summary: string,
-  action: 'created' | 'removed',
+  action: string,
   relativeTime: string,
 ): string {
   const baseLabel = name === summary ? summary : `${name} ${action}`;
@@ -124,20 +125,21 @@ function getUpdateAccessibilityLabel(
   summary: string,
   diffRows: DiffRow[],
   relativeTime: string,
+  t: (key: TranslationKey, values?: Record<string, string | number>) => string,
 ): string {
   if (diffRows.length === 0) {
     return appendTime(summary || name, relativeTime);
   }
 
   const changes = diffRows
-    .map(({ field, prev, next }) => `${field} changed from ${prev} to ${next}`)
+    .map(({ field, prev, next }) => t('history.fieldChanged', { field, prev, next }))
     .join(', ');
 
   return appendTime(`${name}, ${changes}`, relativeTime);
 }
 
-function getNeutralAccessibilityLabel(summary: string, relativeTime: string): string {
-  return appendTime(summary || 'Log entry', relativeTime);
+function getNeutralAccessibilityLabel(summary: string, relativeTime: string, logEntryLabel: string): string {
+  return appendTime(summary || logEntryLabel, relativeTime);
 }
 
 function getBattleAccessibilityLabel(
@@ -146,10 +148,11 @@ function getBattleAccessibilityLabel(
   relativeTime: string,
   isInteractive: boolean,
   hasStructuredName: boolean,
+  t: (key: TranslationKey, values?: Record<string, string | number>) => string,
 ): string {
-  const suffix = isInteractive ? ' Double-tap to open battle record.' : '';
-  const prefix = hasStructuredName ? 'Battle ' : '';
-  return `${prefix}${name}, ${statusPhrase}, ${relativeTime}.${suffix}`;
+  const suffix = isInteractive ? t('history.openBattleRecordHint') : '';
+  const prefix = hasStructuredName ? `${t('rooms.battle')} ` : '';
+  return t('history.battleAccessibility', { prefix, name, status: statusPhrase, relativeTime, suffix });
 }
 
 function getResultColor(result: unknown): string {
@@ -165,15 +168,16 @@ function getResultColor(result: unknown): string {
 }
 
 function LogEntry({ entry, onPress }: LogEntryProps) {
+  const { t } = useLocalization();
   const relativeTime = formatRelativeTime(entry.occurredAt);
   const character = useMemo(
-    () => getCharacterDisplay(entry.payload, entry.summary),
-    [entry.payload, entry.summary],
+    () => getCharacterDisplay(entry.payload, entry.summary, t('history.unknownCharacter')),
+    [entry.payload, entry.summary, t],
   );
   const avatarSource = avatars[character.avatarId] ?? avatars[0];
 
   if (entry.eventType === 'character_created' || entry.eventType === 'character_deleted') {
-    const action = entry.eventType === 'character_created' ? 'created' : 'removed';
+    const action = entry.eventType === 'character_created' ? t('history.created') : t('history.removed');
 
     return (
       <View
@@ -203,12 +207,13 @@ function LogEntry({ entry, onPress }: LogEntryProps) {
   }
 
   if (entry.eventType === 'character_updated') {
-    const diffRows = getDiffRows(entry.payload);
+    const diffRows = getDiffRows(entry.payload, t);
     const accessibilityLabel = getUpdateAccessibilityLabel(
       character.name,
       entry.summary,
       diffRows,
       relativeTime,
+      t,
     );
 
     return (
@@ -251,13 +256,13 @@ function LogEntry({ entry, onPress }: LogEntryProps) {
 
   if (entry.eventType === 'battle_started') {
     const startedBattle = narrowBattlePayload(entry.payload);
-    const name = startedBattle?.name || entry.summary || 'Battle';
+    const name = startedBattle?.name || entry.summary || t('rooms.battle');
     const hasStructuredName = Boolean(startedBattle?.name);
 
     return (
       <View
         accessible
-        accessibilityLabel={getBattleAccessibilityLabel(name, 'started', relativeTime, false, hasStructuredName)}
+        accessibilityLabel={getBattleAccessibilityLabel(name, t('history.started'), relativeTime, false, hasStructuredName, t)}
         style={styles.row}
         testID="log-entry-row"
       >
@@ -276,7 +281,7 @@ function LogEntry({ entry, onPress }: LogEntryProps) {
             <Text style={styles.name}>{name}</Text>
             <Text style={styles.timestamp}>{relativeTime}</Text>
           </View>
-          <Text style={styles.actionLabel}>started</Text>
+          <Text style={styles.actionLabel}>{t('history.started')}</Text>
         </View>
       </View>
     );
@@ -284,11 +289,17 @@ function LogEntry({ entry, onPress }: LogEntryProps) {
 
   if (entry.eventType === 'battle_concluded' || entry.eventType === 'battle_discarded') {
     const battle = narrowBattlePayload(entry.payload);
-    const name = battle?.name || entry.summary || 'Battle';
+    const name = battle?.name || entry.summary || t('rooms.battle');
     const hasStructuredName = Boolean(battle?.name);
     const isConcluded = entry.eventType === 'battle_concluded';
     const isInteractive = hasUsableBattlePayload(entry.payload);
-    const statusPhrase = isConcluded ? getBattleResultLabel(battle?.result) : 'discarded';
+    const statusPhrase = isConcluded
+      ? battle?.result === 'players_win'
+        ? t('battle.playersWin')
+        : battle?.result === 'monster_wins'
+          ? t('battle.monsterWins')
+          : t('history.concluded')
+      : t('history.discarded');
     const rowContents = (
       <>
         <View style={styles.battleGlyphWrapper}>
@@ -314,7 +325,7 @@ function LogEntry({ entry, onPress }: LogEntryProps) {
               {statusPhrase}
             </Text>
           ) : (
-            <Text style={styles.actionLabel}>discarded</Text>
+            <Text style={styles.actionLabel}>{t('history.discarded')}</Text>
           )}
         </View>
       </>
@@ -325,6 +336,7 @@ function LogEntry({ entry, onPress }: LogEntryProps) {
       relativeTime,
       isInteractive,
       hasStructuredName,
+      t,
     );
 
     if (isInteractive) {
@@ -358,7 +370,7 @@ function LogEntry({ entry, onPress }: LogEntryProps) {
   return (
     <View
       accessible
-      accessibilityLabel={getNeutralAccessibilityLabel(entry.summary, relativeTime)}
+      accessibilityLabel={getNeutralAccessibilityLabel(entry.summary, relativeTime, t('history.logEntry'))}
       style={styles.neutralRow}
       testID="log-entry-row"
     >

--- a/frontend/components/munchkin/NativePicker.tsx
+++ b/frontend/components/munchkin/NativePicker.tsx
@@ -1,4 +1,5 @@
 import { Picker } from '@react-native-picker/picker';
+import { useLocalization } from '@/i18n';
 import React from 'react';
 
 type NativePickerProps = {
@@ -14,9 +15,11 @@ export default function NativePicker({
   options,
   pickerKey,
 }: NativePickerProps) {
+  const { t } = useLocalization();
+
   return (
     <Picker selectedValue={selectedValue} onValueChange={onValueChange}>
-      <Picker.Item label="<Select>" value="<Select>" />
+      <Picker.Item label={t('common.select')} value="<Select>" />
       {options.map((option) => (
         <Picker.Item key={`${pickerKey}-${option}`} label={option} value={option} />
       ))}

--- a/frontend/components/munchkin/QuickEditSheet.tsx
+++ b/frontend/components/munchkin/QuickEditSheet.tsx
@@ -1,5 +1,6 @@
 import { Character as RoomCharacter } from '@/api/characters';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import * as Haptics from 'expo-haptics';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -41,6 +42,7 @@ export default function QuickEditSheet({
   onOpenFullEdit,
   hasErrorFlash,
 }: QuickEditSheetProps) {
+  const { t } = useLocalization();
   const [isRendered, setIsRendered] = useState(visible);
   const [isSaving, setIsSaving] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
@@ -229,11 +231,11 @@ export default function QuickEditSheet({
         >
           <View testID="quick-edit-drag-area" style={styles.dragArea} {...panResponder.panHandlers}>
             <View style={styles.dragHandle} />
-            <Text style={styles.title}>Quick Edit</Text>
+            <Text style={styles.title}>{t('character.quickEdit')}</Text>
           </View>
 
           <View style={styles.stepperRow}>
-            <Text style={styles.label}>Level</Text>
+            <Text style={styles.label}>{t('character.level').replace(':', '')}</Text>
             <View style={styles.stepper}>
               <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('level', -1)}>
                 <Text style={styles.stepperButtonText}>−</Text>
@@ -246,7 +248,7 @@ export default function QuickEditSheet({
           </View>
 
           <View style={styles.stepperRow}>
-            <Text style={styles.label}>Power</Text>
+            <Text style={styles.label}>{t('character.power').replace(':', '')}</Text>
             <View style={styles.stepper}>
               <TouchableOpacity style={styles.stepperButton} onPress={() => applyStep('power', -1)}>
                 <Text style={styles.stepperButtonText}>−</Text>
@@ -260,10 +262,10 @@ export default function QuickEditSheet({
 
           <View style={styles.actions}>
             <TouchableOpacity onPress={handleOpenFullEdit} style={styles.secondaryAction}>
-              <Text style={styles.secondaryActionText}>Edit more…</Text>
+              <Text style={styles.secondaryActionText}>{t('character.editMore')}</Text>
             </TouchableOpacity>
             <TouchableOpacity onPress={handleSave} style={styles.primaryAction} disabled={isSaving}>
-              <Text style={styles.primaryActionText}>{isSaving ? 'Saving…' : 'Save'}</Text>
+              <Text style={styles.primaryActionText}>{isSaving ? t('common.saving') : t('common.save')}</Text>
             </TouchableOpacity>
           </View>
         </Animated.View>

--- a/frontend/components/munchkin/ReconnectingBanner.tsx
+++ b/frontend/components/munchkin/ReconnectingBanner.tsx
@@ -1,4 +1,5 @@
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import React, { useEffect } from 'react';
 import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
 
@@ -15,18 +16,21 @@ export default function ReconnectingBanner({ visible }: ReconnectingBannerProps)
 }
 
 function MountedReconnectingBanner() {
+  const { t } = useLocalization();
+  const label = t('network.reconnecting');
+
   useEffect(() => {
-    AccessibilityInfo.announceForAccessibility('Reconnecting…');
-  }, []);
+    AccessibilityInfo.announceForAccessibility(label);
+  }, [label]);
 
   return (
     <View
       accessible
       accessibilityRole="alert"
-      accessibilityLabel="Reconnecting…"
+      accessibilityLabel={label}
       style={styles.banner}
     >
-      <Text style={styles.label}>Reconnecting…</Text>
+      <Text style={styles.label}>{label}</Text>
     </View>
   );
 }

--- a/frontend/components/munchkin/RoomCharacterCard.tsx
+++ b/frontend/components/munchkin/RoomCharacterCard.tsx
@@ -2,6 +2,7 @@ import { Character as RoomCharacter } from '@/api/characters';
 import VioletButton from '@/components/VioletButton';
 import avatars from '@/constants/avatars';
 import { AppTheme } from '@/constants/theme';
+import { useLocalization } from '@/i18n';
 import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AccessibilityInfo,
@@ -31,7 +32,12 @@ const RoomCharacterCard = memo(function RoomCharacterCard({
   onChangePress,
   realtimeFlashSignal = 0,
 }: RoomCharacterCardProps) {
-  const accessibilityLabel = `${character.nickname}, Level ${character.level}, Power ${character.power}`;
+  const { t } = useLocalization();
+  const accessibilityLabel = t('character.statsAccessibility', {
+    name: character.nickname,
+    level: character.level,
+    power: character.power,
+  });
   const animatedBorderProgress = useRef(new Animated.Value(0)).current;
   const reducedMotionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isReducedMotionEnabled, setIsReducedMotionEnabled] = useState<boolean | null>(null);
@@ -121,7 +127,7 @@ const RoomCharacterCard = memo(function RoomCharacterCard({
         accessible
         accessibilityRole="button"
         accessibilityLabel={accessibilityLabel}
-        accessibilityHint="Tap to edit stats"
+        accessibilityHint={t('character.editHint')}
       >
         <View style={styles.characterContent}>
           <View style={[styles.avatarWrapper, { backgroundColor: character.color }]}>
@@ -131,8 +137,8 @@ const RoomCharacterCard = memo(function RoomCharacterCard({
           <View style={styles.characterInfo}>
             <Text style={styles.characterNickname} testID="character-nickname">{character.nickname}</Text>
             <View style={styles.statsRow}>
-              <Text style={styles.characterStats}>{character.level} lvl</Text>
-              <Text style={styles.characterStats}>{character.power} str</Text>
+              <Text style={styles.characterStats}>{t('character.levelAbbrev', { level: character.level })}</Text>
+              <Text style={styles.characterStats}>{t('character.strengthAbbrev', { power: character.power })}</Text>
             </View>
           </View>
         </View>
@@ -148,7 +154,7 @@ const RoomCharacterCard = memo(function RoomCharacterCard({
         </ScrollView>
       </View>
 
-      <VioletButton title="Change" onPress={() => onChangePress(character)} testID="change-character-button" />
+      <VioletButton title={t('rooms.changeProfile')} onPress={() => onChangePress(character)} testID="change-character-button" />
     </Animated.View>
   );
 });

--- a/frontend/components/munchkin/RoomCharactersList.tsx
+++ b/frontend/components/munchkin/RoomCharactersList.tsx
@@ -1,5 +1,6 @@
 import { Character as RoomCharacter } from '@/api/characters';
 import VioletButton from '@/components/VioletButton';
+import { useLocalization } from '@/i18n';
 import React, { memo, useMemo } from 'react';
 import { ActivityIndicator, FlatList, StyleSheet, Text, View } from 'react-native';
 
@@ -26,6 +27,8 @@ const RoomCharactersList = memo(function RoomCharactersList({
   onCreateCharacter,
   onChangePress,
 }: RoomCharactersListProps) {
+  const { t } = useLocalization();
+
   const listHeader = useMemo(() => {
     if (!actionError) {
       return null;
@@ -43,7 +46,7 @@ const RoomCharactersList = memo(function RoomCharactersList({
       return (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="small" color="#FFFFFF" />
-          <Text style={styles.loadingText}>Loading characters...</Text>
+          <Text style={styles.loadingText}>{t('character.loading')}</Text>
         </View>
       );
     }
@@ -57,7 +60,7 @@ const RoomCharactersList = memo(function RoomCharactersList({
     }
 
     return null;
-  }, [errorMessage, isLoading]);
+  }, [errorMessage, isLoading, t]);
 
   return (
     <FlatList
@@ -78,7 +81,7 @@ const RoomCharactersList = memo(function RoomCharactersList({
       ListEmptyComponent={listEmpty}
       ListFooterComponent={
         <View style={styles.createCharacterButtonContainer}>
-          <VioletButton title="Create a character" onPress={onCreateCharacter} disabled={isCreateBlocked} testID="create-character-button" />
+          <VioletButton title={t('character.createButton')} onPress={onCreateCharacter} disabled={isCreateBlocked} testID="create-character-button" />
         </View>
       }
       removeClippedSubviews

--- a/frontend/hooks/useRoomCodeClipboard.ts
+++ b/frontend/hooks/useRoomCodeClipboard.ts
@@ -1,15 +1,17 @@
 import { setStringAsync } from 'expo-clipboard';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLocalization } from '@/i18n';
 
 export const COPIED_LABEL_RESET_MS = 1500;
 
 interface UseRoomCodeClipboardResult {
-  buttonLabel: 'Copy' | 'Copied ✓';
+  buttonLabel: string;
   accessibilityLabel: string;
   copyRoomCode: () => Promise<void>;
 }
 
 export function useRoomCodeClipboard(roomCode: string): UseRoomCodeClipboardResult {
+  const { t } = useLocalization();
   const [isCopied, setIsCopied] = useState(false);
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
@@ -59,8 +61,8 @@ export function useRoomCodeClipboard(roomCode: string): UseRoomCodeClipboardResu
   }, [clearResetTimeout]);
 
   return {
-    buttonLabel: isCopied ? 'Copied ✓' : 'Copy',
-    accessibilityLabel: roomCode.length > 0 ? `Copy room code ${roomCode}` : 'Copy room code',
+    buttonLabel: isCopied ? t('rooms.copied') : t('rooms.copy'),
+    accessibilityLabel: roomCode.length > 0 ? t('rooms.copyRoomCodeValue', { roomCode }) : t('rooms.copyRoomCode'),
     copyRoomCode,
   };
 }

--- a/frontend/i18n/LocalizationContext.tsx
+++ b/frontend/i18n/LocalizationContext.tsx
@@ -1,0 +1,80 @@
+import React, { createContext, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { detectDeviceLocale } from '@/i18n/detectLocale';
+import {
+  DEFAULT_LOCALE,
+  LOCALE_INFOS,
+  LocaleInfo,
+  SupportedLocale,
+} from '@/i18n/locales';
+import { loadStoredLocale, saveStoredLocale } from '@/i18n/storage';
+import { translate, TranslationKey, TranslationValues } from '@/i18n/translate';
+
+type LocalizationContextValue = {
+  locale: SupportedLocale;
+  localeOptions: LocaleInfo[];
+  setLocale: (locale: SupportedLocale) => Promise<void>;
+  t: (key: TranslationKey, values?: TranslationValues) => string;
+};
+
+const defaultContextValue: LocalizationContextValue = {
+  locale: DEFAULT_LOCALE,
+  localeOptions: LOCALE_INFOS,
+  setLocale: async () => undefined,
+  t: (key, values) => translate(DEFAULT_LOCALE, key, values),
+};
+
+const LocalizationContext = createContext<LocalizationContextValue>(defaultContextValue);
+
+export function LocalizationProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<SupportedLocale>(DEFAULT_LOCALE);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadLocale = async () => {
+      try {
+        const storedLocale = await loadStoredLocale();
+        const nextLocale = storedLocale || detectDeviceLocale() || DEFAULT_LOCALE;
+        if (mounted) {
+          setLocaleState(nextLocale);
+        }
+      } catch {
+        if (mounted) {
+          setLocaleState(DEFAULT_LOCALE);
+        }
+      }
+    };
+
+    loadLocale();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const setLocale = useCallback(async (nextLocale: SupportedLocale) => {
+    setLocaleState(nextLocale);
+    await saveStoredLocale(nextLocale);
+  }, []);
+
+  const value = useMemo<LocalizationContextValue>(
+    () => ({
+      locale,
+      localeOptions: LOCALE_INFOS,
+      setLocale,
+      t: (key, values) => translate(locale, key, values),
+    }),
+    [locale, setLocale]
+  );
+
+  return (
+    <LocalizationContext.Provider value={value}>
+      {children}
+    </LocalizationContext.Provider>
+  );
+}
+
+export function useLocalization(): LocalizationContextValue {
+  return React.useContext(LocalizationContext);
+}

--- a/frontend/i18n/detectLocale.ts
+++ b/frontend/i18n/detectLocale.ts
@@ -1,0 +1,41 @@
+import { NativeModules, Platform } from 'react-native';
+
+import { normalizeLocale, SupportedLocale } from '@/i18n/locales';
+
+type SettingsManager = {
+  settings?: {
+    AppleLocale?: string;
+    AppleLanguages?: string[];
+  };
+};
+
+type I18nManager = {
+  localeIdentifier?: string;
+};
+
+function getNavigatorLanguage(): string | null {
+  if (typeof navigator === 'undefined') {
+    return null;
+  }
+
+  const languages = 'languages' in navigator && Array.isArray(navigator.languages)
+    ? navigator.languages
+    : [];
+  return languages[0] || navigator.language || null;
+}
+
+function getNativeLanguage(): string | null {
+  const settingsManager = NativeModules.SettingsManager as SettingsManager | undefined;
+  const i18nManager = NativeModules.I18nManager as I18nManager | undefined;
+  return (
+    settingsManager?.settings?.AppleLocale ||
+    settingsManager?.settings?.AppleLanguages?.[0] ||
+    i18nManager?.localeIdentifier ||
+    null
+  );
+}
+
+export function detectDeviceLocale(): SupportedLocale | null {
+  const detected = Platform.OS === 'web' ? getNavigatorLanguage() : getNativeLanguage();
+  return normalizeLocale(detected);
+}

--- a/frontend/i18n/en.ts
+++ b/frontend/i18n/en.ts
@@ -1,0 +1,453 @@
+export type Messages = {
+  common: {
+    cancel: string;
+    save: string;
+    saving: string;
+    select: string;
+    done: string;
+  };
+  settings: {
+    language: string;
+  };
+  profile: {
+    changeAvatar: string;
+    nickname: string;
+    nicknamePlaceholder: string;
+  };
+  landing: {
+    title: string;
+    privacy: string;
+    support: string;
+    subtitle: string;
+    description: string;
+    rooms: string;
+    appStore: string;
+    appStoreBadge: string;
+    googlePlay: string;
+    googlePlayBadge: string;
+    joinClosedBeta: string;
+  };
+  rooms: {
+    title: string;
+    munchClassic: string;
+    create: string;
+    join: string;
+    history: string;
+    changeProfile: string;
+    coins: string;
+    shop: string;
+    copy: string;
+    copied: string;
+    copyRoomCode: string;
+    copyRoomCodeValue: string;
+    connectionLostRetry: string;
+    connectionLostRetryAccessibility: string;
+    openBattle: string;
+    openHistory: string;
+    battle: string;
+    log: string;
+    undo: string;
+    startBattleRetry: string;
+    startBattleFailed: string;
+    createCharacterFailed: string;
+    updateCharacterFailed: string;
+    deleteCharacterFailed: string;
+    updateStatsFailed: string;
+    undoStatsFailed: string;
+    backToRoom: string;
+  };
+  support: {
+    title: string;
+    description: string;
+    contactEmail: string;
+    emailSupportAt: string;
+  };
+  privacy: {
+    title: string;
+    effectiveDate: string;
+    section1Title: string;
+    section1Body: string;
+    section2Title: string;
+    section2Body: string;
+    section3Title: string;
+    section3Body: string;
+    section4Title: string;
+    section4Body: string;
+    section5Title: string;
+    section5Body: string;
+    section6Title: string;
+    section6Body: string;
+    section7Title: string;
+    section7Body: string;
+    section8Title: string;
+    section8Body: string;
+    section9Title: string;
+    section9Body: string;
+    section10Title: string;
+    section10Body: string;
+    section11Title: string;
+    section11Body: string;
+    section12Title: string;
+    section12Body: string;
+    contact: string;
+    contactText: string;
+  };
+  shop: {
+    title: string;
+    buy: string;
+    coinsAmount: string;
+    quit: string;
+  };
+  roomModal: {
+    createTitle: string;
+    joinTitle: string;
+    roomNamePlaceholder: string;
+    yes: string;
+    no: string;
+  };
+  avatar: {
+    select: string;
+  };
+  character: {
+    new: string;
+    color: string;
+    name: string;
+    gender: string;
+    level: string;
+    power: string;
+    class: string;
+    race: string;
+    male: string;
+    female: string;
+    create: string;
+    selectColor: string;
+    deleteTitle: string;
+    deleteMessage: string;
+    delete: string;
+    deleteCharacter: string;
+    deletingCharacter: string;
+    quickEdit: string;
+    editMore: string;
+    loading: string;
+    createButton: string;
+    statsAccessibility: string;
+    editHint: string;
+    levelAbbrev: string;
+    strengthAbbrev: string;
+  };
+  error: {
+    title: string;
+    unexpected: string;
+  };
+  battle: {
+    inProgress: string;
+    inProgressAccessibility: string;
+    viewBattle: string;
+    loading: string;
+    noActive: string;
+    name: string;
+    save: string;
+    notActive: string;
+    saveFailed: string;
+    concludeFailed: string;
+    discardFailed: string;
+    even: string;
+    playersAhead: string;
+    monstersAhead: string;
+    playerSide: string;
+    monsterSide: string;
+    characters: string;
+    monsters: string;
+    bonuses: string;
+    powerValue: string;
+    removedCharacter: string;
+    removedCharacterAccessibility: string;
+    dropRemovedCharacter: string;
+    selectCharacter: string;
+    noCharactersAvailable: string;
+    addSelectedCharacter: string;
+    levelValue: string;
+    mainMonster: string;
+    openAddMonster: string;
+    addMonster: string;
+    cancelAddMonster: string;
+    monsterName: string;
+    monsterLevel: string;
+    saveMonster: string;
+    removeName: string;
+    removeBonus: string;
+    addBonus: string;
+    playersWin: string;
+    monstersWin: string;
+    monsterWins: string;
+    conclude: string;
+    concluding: string;
+    concludeAccessibility: string;
+    concludeDirtyHint: string;
+    discard: string;
+    discarding: string;
+    discardAccessibility: string;
+    discardTitle: string;
+    discardMessage: string;
+    keepBattle: string;
+  };
+  history: {
+    title: string;
+    loading: string;
+    loadingMore: string;
+    retry: string;
+    retryOlder: string;
+    retryRoom: string;
+    empty: string;
+    created: string;
+    removed: string;
+    started: string;
+    concluded: string;
+    discarded: string;
+    logEntry: string;
+    unknownCharacter: string;
+    unknownMonster: string;
+    none: string;
+    emptyValue: string;
+    fieldChanged: string;
+    battleAccessibility: string;
+    openBattleRecordHint: string;
+    closeBattleHistory: string;
+    noPlayerParticipants: string;
+    noMonstersRecorded: string;
+    levelPower: string;
+  };
+  network: {
+    reconnecting: string;
+  };
+  user: {
+    defaultName: string;
+  };
+};
+
+export const en: Messages = {
+  common: {
+    cancel: 'Cancel',
+    save: 'Save',
+    saving: 'Saving',
+    select: '<Select>',
+    done: 'Done',
+  },
+  settings: {
+    language: 'Language',
+  },
+  profile: {
+    changeAvatar: 'Change Avatar',
+    nickname: 'Nickname:',
+    nicknamePlaceholder: 'Enter nickname',
+  },
+  landing: {
+    title: 'Munch Helper',
+    privacy: 'Privacy',
+    support: 'Support',
+    subtitle: 'Your companion for board games like Munchkin',
+    description: 'Create game rooms with your friends, manage characters in games, and forget about remembering and recalculating stats.',
+    rooms: 'Rooms',
+    appStore: 'App Store',
+    appStoreBadge: 'App Store badge',
+    googlePlay: 'Google Play',
+    googlePlayBadge: 'Google Play badge',
+    joinClosedBeta: 'Join Closed Beta',
+  },
+  rooms: {
+    title: 'Games',
+    munchClassic: 'Classic',
+    create: 'Create',
+    join: 'Join',
+    history: 'Rooms history',
+    changeProfile: 'Change',
+    coins: 'coins',
+    shop: 'Shop',
+    copy: 'Copy',
+    copied: 'Copied ✓',
+    copyRoomCode: 'Copy room code',
+    copyRoomCodeValue: 'Copy room code {{roomCode}}',
+    connectionLostRetry: 'Connection lost · Retry',
+    connectionLostRetryAccessibility: 'Connection lost. Tap to retry',
+    openBattle: 'Open battle',
+    openHistory: 'Open room history',
+    battle: 'Battle',
+    log: 'Log',
+    undo: 'Undo',
+    startBattleRetry: 'Could not start the battle. Please try again.',
+    startBattleFailed: 'Failed to start battle',
+    createCharacterFailed: 'Failed to create character',
+    updateCharacterFailed: 'Failed to update character',
+    deleteCharacterFailed: 'Failed to delete character',
+    updateStatsFailed: 'Failed to update character stats',
+    undoStatsFailed: 'Failed to undo character stats',
+    backToRoom: 'Back to room',
+  },
+  support: {
+    title: 'Support',
+    description: 'Need help with Munch Helper rooms, characters, battles, or room history? Contact me without creating an account and include a short description of the issue, the room code if relevant, and what you expected to happen.',
+    contactEmail: 'Contact Email',
+    emailSupportAt: 'Email support at {{email}}',
+  },
+  privacy: {
+    title: 'Privacy Policy',
+    effectiveDate: 'Effective date: {{date}}',
+    section1Title: '1. Overview',
+    section1Body: 'Munch Helper is a companion app for tabletop games like Munchkin. It does not require sign-up, account creation, email, password, or any third-party identity provider. The app creates an anonymous player profile so you can enter rooms and play without a traditional account.',
+    section2Title: '2. Information We Process',
+    section2Body: 'The app processes the profile and gameplay information needed to run the game: your nickname, avatar selection from a fixed local image set, and a server-assigned user identifier. Character records can include name, avatar, color, level, power, class, race, and gender. Room, battle, and room history log records are also processed when those features are used.',
+    section3Title: '3. Session Data',
+    section3Body: 'To restore your session between launches, the app stores your user profile locally on your device with AsyncStorage under the user key. The profile is also stored server-side so you can rejoin rooms. Characters, battles, rooms, and room history are stored server-side to keep shared gameplay state available.',
+    section4Title: '4. Room Participation',
+    section4Body: 'When you join a room, your nickname, avatar, and character details become visible to other players in that same room. Room, battle, and room history log state is shared in real time with participants in the room so everyone sees the same gameplay state.',
+    section5Title: '5. Server Communication',
+    section5Body: 'The app sends and retrieves profile, room, character, battle, and log data through backend APIs and uses WebSocket connections for real-time updates between players in the same room.',
+    section6Title: '6. Why Data Is Used',
+    section6Body: 'Data is used only to operate core features: creating player profiles, creating and joining rooms, managing characters, running battles, showing room history, synchronizing shared game state, and maintaining a stable multiplayer experience.',
+    section7Title: '7. Data Sharing',
+    section7Body: 'Your profile and gameplay data is shared only with other participants in rooms you join so multiplayer features can function. Munch Helper does not sell data and does not include third-party advertising, analytics, or tracking SDKs.',
+    section8Title: '8. Children',
+    section8Body: 'Munch Helper is not directed to children and does not include children-directed features. If you believe a child has provided information through the app, contact support and request deletion assistance.',
+    section9Title: '9. Security',
+    section9Body: 'Reasonable technical measures are used to protect data in storage and transit. However, no method of transmission or storage can be guaranteed as completely secure.',
+    section10Title: '10. Data Retention and Deletion',
+    section10Body: 'Local profile data remains on your device until you clear app data or uninstall the app. Server-side data may be retained as needed to operate and maintain the service. You can contact support to request data deletion assistance.',
+    section11Title: '11. International Use',
+    section11Body: 'By using the app, you understand that data may be processed in infrastructure regions selected by the service operator.',
+    section12Title: '12. Changes to This Policy',
+    section12Body: 'This policy may be updated from time to time. Updates will be reflected by changing the effective date on this page.',
+    contact: 'Contact',
+    contactText: 'For privacy questions or requests, email: {{email}}',
+  },
+  shop: {
+    title: 'Shop',
+    buy: 'Buy',
+    coinsAmount: '{{count}} coins',
+    quit: 'Quit shop',
+  },
+  roomModal: {
+    createTitle: 'Create a room for {{game}}?',
+    joinTitle: 'Join a room for {{game}}?',
+    roomNamePlaceholder: 'Enter the room name',
+    yes: 'YEP',
+    no: 'NO',
+  },
+  avatar: {
+    select: 'Select',
+  },
+  character: {
+    new: 'New character',
+    color: 'Color:',
+    name: 'Name:',
+    gender: 'Gender:',
+    level: 'Level:',
+    power: 'Power:',
+    class: 'Class:',
+    race: 'Race:',
+    male: 'Male',
+    female: 'Female',
+    create: 'Create',
+    selectColor: 'Select Color',
+    deleteTitle: 'Delete character?',
+    deleteMessage: 'This action cannot be undone.',
+    delete: 'Delete',
+    deleteCharacter: 'Delete Character',
+    deletingCharacter: 'Deleting Character...',
+    quickEdit: 'Quick Edit',
+    editMore: 'Edit more…',
+    loading: 'Loading characters...',
+    createButton: 'Create a character',
+    statsAccessibility: '{{name}}, Level {{level}}, Power {{power}}',
+    editHint: 'Tap to edit stats',
+    levelAbbrev: '{{level}} lvl',
+    strengthAbbrev: '{{power}} str',
+  },
+  error: {
+    title: 'Something went wrong',
+    unexpected: 'Unexpected application error.',
+  },
+  battle: {
+    inProgress: 'Battle in progress',
+    inProgressAccessibility: 'Battle in progress. Tap to view.',
+    viewBattle: 'View Battle →',
+    loading: 'Loading battle',
+    noActive: 'No active battle',
+    name: 'Battle name',
+    save: 'Save battle',
+    notActive: 'Battle is not active',
+    saveFailed: 'Failed to save battle',
+    concludeFailed: 'Failed to conclude battle',
+    discardFailed: 'Failed to discard battle',
+    even: 'Even',
+    playersAhead: 'Players ahead',
+    monstersAhead: 'Monsters ahead',
+    playerSide: 'Player Side',
+    monsterSide: 'Monster Side',
+    characters: 'Characters',
+    monsters: 'Monsters',
+    bonuses: 'Bonuses',
+    powerValue: 'Power {{value}}',
+    removedCharacter: 'Removed character',
+    removedCharacterAccessibility: '{{id}} - removed from room',
+    dropRemovedCharacter: 'Drop removed character from draft',
+    selectCharacter: 'Select {{name}}',
+    noCharactersAvailable: 'No characters available',
+    addSelectedCharacter: 'Add selected character',
+    levelValue: 'Level {{level}}',
+    mainMonster: 'Main',
+    openAddMonster: 'Open add monster dialog',
+    addMonster: 'Add monster',
+    cancelAddMonster: 'Cancel add monster',
+    monsterName: 'Monster name',
+    monsterLevel: 'Monster level',
+    saveMonster: 'Save monster',
+    removeName: 'Remove {{name}}',
+    removeBonus: 'Remove bonus {{value}}',
+    addBonus: 'Add bonus {{value}}',
+    playersWin: 'Players Win',
+    monstersWin: 'Monsters Win',
+    monsterWins: 'Monster Wins',
+    conclude: 'Conclude',
+    concluding: 'Concluding...',
+    concludeAccessibility: 'Conclude battle',
+    concludeDirtyHint: 'Save your changes before concluding',
+    discard: 'Discard',
+    discarding: 'Discarding...',
+    discardAccessibility: 'Discard battle',
+    discardTitle: 'Discard battle?',
+    discardMessage: "This battle will be discarded and removed from the room. This can't be undone.",
+    keepBattle: 'Keep battle',
+  },
+  history: {
+    title: 'History',
+    loading: 'Loading history',
+    loadingMore: 'Loading more history',
+    retry: 'Retry',
+    retryOlder: 'Retry loading older history',
+    retryRoom: 'Retry loading room history',
+    empty: 'No events recorded yet.',
+    created: 'created',
+    removed: 'removed',
+    started: 'started',
+    concluded: 'Concluded',
+    discarded: 'discarded',
+    logEntry: 'Log entry',
+    unknownCharacter: 'Unknown character',
+    unknownMonster: 'Unknown monster',
+    none: 'none',
+    emptyValue: '<Empty>',
+    fieldChanged: '{{field}} changed from {{prev}} to {{next}}',
+    battleAccessibility: '{{prefix}}{{name}}, {{status}}, {{relativeTime}}.{{suffix}}',
+    openBattleRecordHint: ' Double-tap to open battle record.',
+    closeBattleHistory: 'Close battle history',
+    noPlayerParticipants: 'No player participants',
+    noMonstersRecorded: 'No monsters recorded',
+    levelPower: 'Level {{level}} · Power {{power}}',
+  },
+  network: {
+    reconnecting: 'Reconnecting…',
+  },
+  user: {
+    defaultName: 'Player {{postfix}}',
+  },
+};

--- a/frontend/i18n/i18n.test.tsx
+++ b/frontend/i18n/i18n.test.tsx
@@ -1,0 +1,152 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LocalizationProvider, useLocalization } from '@/i18n/LocalizationContext';
+import { detectDeviceLocale } from '@/i18n/detectLocale';
+import {
+  LOCALE_INFOS,
+  normalizeLocale,
+  SUPPORTED_LOCALES,
+} from '@/i18n/locales';
+import { LANGUAGE_STORAGE_KEY, loadStoredLocale, saveStoredLocale } from '@/i18n/storage';
+import { interpolate, translate } from '@/i18n/translate';
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+  },
+}));
+
+vi.mock('react-native', () => ({
+  NativeModules: {
+    SettingsManager: {
+      settings: {
+        AppleLanguages: ['fr-CA'],
+      },
+    },
+  },
+  Platform: {
+    OS: 'ios',
+  },
+}));
+
+const mockedAsyncStorage = vi.mocked(AsyncStorage);
+
+describe('i18n locale metadata', () => {
+  it('lists every first-launch supported language', () => {
+    expect(SUPPORTED_LOCALES).toEqual([
+      'en',
+      'pl',
+      'de',
+      'fr',
+      'lt',
+      'lv',
+      'et',
+      'ru',
+      'be',
+      'uk',
+    ]);
+    expect(LOCALE_INFOS.map((locale) => locale.englishName)).toEqual([
+      'English',
+      'Polish',
+      'German',
+      'French',
+      'Lithuanian',
+      'Latvian',
+      'Estonian',
+      'Russian',
+      'Belarusian',
+      'Ukrainian',
+    ]);
+  });
+
+  it('normalizes full locale tags to supported base languages', () => {
+    expect(normalizeLocale('fr-CA')).toBe('fr');
+    expect(normalizeLocale('LT_lt')).toBe('lt');
+    expect(normalizeLocale('es-MX')).toBeNull();
+  });
+
+  it('detects the native device locale through the local helper', () => {
+    expect(detectDeviceLocale()).toBe('fr');
+  });
+});
+
+describe('i18n translation lookup', () => {
+  it('interpolates dynamic values', () => {
+    expect(interpolate('Room {{roomCode}} for {{name}}', { roomCode: 'ROOM42', name: 'Alice' }))
+      .toBe('Room ROOM42 for Alice');
+  });
+
+  it('falls back to English for missing locale keys', () => {
+    expect(translate('pl', 'common.save')).toBe('Zapisz');
+    expect(translate('pl', 'common.done')).toBe('Done');
+  });
+
+  it('interpolates localized strings', () => {
+    expect(translate('de', 'user.defaultName', { postfix: 'AAAAAA' })).toBe('Spieler AAAAAA');
+  });
+});
+
+describe('i18n storage', () => {
+  it('loads a supported stored locale', async () => {
+    mockedAsyncStorage.getItem.mockResolvedValueOnce('uk');
+
+    await expect(loadStoredLocale()).resolves.toBe('uk');
+    expect(mockedAsyncStorage.getItem).toHaveBeenCalledWith(LANGUAGE_STORAGE_KEY);
+  });
+
+  it('ignores unsupported stored locales', async () => {
+    mockedAsyncStorage.getItem.mockResolvedValueOnce('es');
+
+    await expect(loadStoredLocale()).resolves.toBeNull();
+  });
+
+  it('saves the selected locale locally', async () => {
+    mockedAsyncStorage.setItem.mockResolvedValueOnce(undefined);
+
+    await saveStoredLocale('lt');
+
+    expect(mockedAsyncStorage.setItem).toHaveBeenCalledWith(LANGUAGE_STORAGE_KEY, 'lt');
+  });
+});
+
+function LocaleConsumer() {
+  const { locale, setLocale, t } = useLocalization();
+
+  return (
+    <div>
+      <p data-testid="locale">{locale}</p>
+      <p data-testid="language-label">{t('settings.language')}</p>
+      <button type="button" onClick={() => { void setLocale('lt'); }}>Set Lithuanian</button>
+    </div>
+  );
+}
+
+describe('LocalizationProvider', () => {
+  it('loads a saved locale and applies manual language changes', async () => {
+    mockedAsyncStorage.getItem.mockResolvedValueOnce('fr');
+    mockedAsyncStorage.setItem.mockResolvedValueOnce(undefined);
+
+    render(
+      <LocalizationProvider>
+        <LocaleConsumer />
+      </LocalizationProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale').textContent).toBe('fr');
+    });
+    expect(screen.getByTestId('language-label').textContent).toBe('Langue');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Set Lithuanian'));
+    });
+
+    expect(screen.getByTestId('locale').textContent).toBe('lt');
+    expect(screen.getByTestId('language-label').textContent).toBe('Kalba');
+    expect(mockedAsyncStorage.setItem).toHaveBeenCalledWith(LANGUAGE_STORAGE_KEY, 'lt');
+  });
+});

--- a/frontend/i18n/index.ts
+++ b/frontend/i18n/index.ts
@@ -1,0 +1,6 @@
+export { LocalizationProvider, useLocalization } from '@/i18n/LocalizationContext';
+export { DEFAULT_LOCALE, LOCALE_INFOS, SUPPORTED_LOCALES } from '@/i18n/locales';
+export type { LocaleInfo, SupportedLocale } from '@/i18n/locales';
+export { normalizeLocale } from '@/i18n/locales';
+export { translate } from '@/i18n/translate';
+export type { TranslationKey, TranslationValues } from '@/i18n/translate';

--- a/frontend/i18n/locales.ts
+++ b/frontend/i18n/locales.ts
@@ -1,0 +1,60 @@
+export const DEFAULT_LOCALE = 'en';
+
+export const SUPPORTED_LOCALES = [
+  'en',
+  'pl',
+  'de',
+  'fr',
+  'lt',
+  'lv',
+  'et',
+  'ru',
+  'be',
+  'uk',
+] as const;
+
+export type SupportedLocale = typeof SUPPORTED_LOCALES[number];
+
+export type LocaleInfo = {
+  code: SupportedLocale;
+  englishName: string;
+  nativeName: string;
+};
+
+export const LOCALE_INFOS: LocaleInfo[] = [
+  { code: 'en', englishName: 'English', nativeName: 'English' },
+  { code: 'pl', englishName: 'Polish', nativeName: 'Polski' },
+  { code: 'de', englishName: 'German', nativeName: 'Deutsch' },
+  { code: 'fr', englishName: 'French', nativeName: 'Français' },
+  { code: 'lt', englishName: 'Lithuanian', nativeName: 'Lietuvių' },
+  { code: 'lv', englishName: 'Latvian', nativeName: 'Latviešu' },
+  { code: 'et', englishName: 'Estonian', nativeName: 'Eesti' },
+  { code: 'ru', englishName: 'Russian', nativeName: 'Русский' },
+  { code: 'be', englishName: 'Belarusian', nativeName: 'Беларуская' },
+  { code: 'uk', englishName: 'Ukrainian', nativeName: 'Українська' },
+];
+
+const SUPPORTED_LOCALE_SET = new Set<string>(SUPPORTED_LOCALES);
+
+export function isSupportedLocale(value: string | null | undefined): value is SupportedLocale {
+  return typeof value === 'string' && SUPPORTED_LOCALE_SET.has(value);
+}
+
+export function normalizeLocale(value: string | null | undefined): SupportedLocale | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase().replace('_', '-');
+  if (!normalized) {
+    return null;
+  }
+
+  const exact = normalized.split('.')[0];
+  if (isSupportedLocale(exact)) {
+    return exact;
+  }
+
+  const [language] = exact.split('-');
+  return isSupportedLocale(language) ? language : null;
+}

--- a/frontend/i18n/storage.ts
+++ b/frontend/i18n/storage.ts
@@ -1,0 +1,14 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { isSupportedLocale, SupportedLocale } from '@/i18n/locales';
+
+export const LANGUAGE_STORAGE_KEY = 'language';
+
+export async function loadStoredLocale(): Promise<SupportedLocale | null> {
+  const storedLocale = await AsyncStorage.getItem(LANGUAGE_STORAGE_KEY);
+  return isSupportedLocale(storedLocale) ? storedLocale : null;
+}
+
+export async function saveStoredLocale(locale: SupportedLocale): Promise<void> {
+  await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, locale);
+}

--- a/frontend/i18n/translate.ts
+++ b/frontend/i18n/translate.ts
@@ -1,0 +1,37 @@
+import { en, Messages } from '@/i18n/en';
+import { SupportedLocale } from '@/i18n/locales';
+import { translations } from '@/i18n/translations';
+
+type LeafPaths<T, Prefix extends string = ''> = {
+  [K in keyof T & string]: T[K] extends string
+    ? `${Prefix}${K}`
+    : T[K] extends Record<string, unknown>
+      ? LeafPaths<T[K], `${Prefix}${K}.`>
+      : never;
+}[keyof T & string];
+
+export type TranslationKey = LeafPaths<Messages>;
+export type TranslationValues = Record<string, string | number>;
+
+function readPath(source: unknown, key: string): string | undefined {
+  const value = key.split('.').reduce<unknown>((current, part) => {
+    if (current && typeof current === 'object' && part in current) {
+      return (current as Record<string, unknown>)[part];
+    }
+    return undefined;
+  }, source);
+
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function interpolate(template: string, values: TranslationValues = {}): string {
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, name: string) => (
+    Object.prototype.hasOwnProperty.call(values, name) ? String(values[name]) : match
+  ));
+}
+
+export function translate(locale: SupportedLocale, key: TranslationKey, values?: TranslationValues): string {
+  const localized = readPath(translations[locale], key);
+  const fallback = readPath(en, key);
+  return interpolate(localized || fallback || key, values);
+}

--- a/frontend/i18n/translations.ts
+++ b/frontend/i18n/translations.ts
@@ -1,0 +1,106 @@
+import { en, Messages } from '@/i18n/en';
+import { SupportedLocale } from '@/i18n/locales';
+
+type Primitive = string | number | boolean | null;
+type PartialDeep<T> = {
+  [K in keyof T]?: T[K] extends Primitive ? T[K] : PartialDeep<T[K]>;
+};
+
+const pl: PartialDeep<Messages> = {
+  common: { cancel: 'Anuluj', save: 'Zapisz', saving: 'Zapisywanie', select: '<Wybierz>' },
+  settings: { language: 'Język' },
+  profile: { changeAvatar: 'Zmień awatar', nickname: 'Pseudonim:', nicknamePlaceholder: 'Wpisz pseudonim' },
+  user: { defaultName: 'Gracz {{postfix}}' },
+};
+
+const de: PartialDeep<Messages> = {
+  common: { cancel: 'Abbrechen', save: 'Speichern', saving: 'Speichern', select: '<Auswählen>' },
+  settings: { language: 'Sprache' },
+  profile: { changeAvatar: 'Avatar ändern', nickname: 'Spitzname:', nicknamePlaceholder: 'Spitznamen eingeben' },
+  user: { defaultName: 'Spieler {{postfix}}' },
+};
+
+const fr: PartialDeep<Messages> = {
+  common: { cancel: 'Annuler', save: 'Enregistrer', saving: 'Enregistrement', select: '<Sélectionner>' },
+  settings: { language: 'Langue' },
+  profile: { changeAvatar: 'Changer avatar', nickname: 'Pseudo :', nicknamePlaceholder: 'Saisir un pseudo' },
+  user: { defaultName: 'Joueur {{postfix}}' },
+};
+
+const lt: PartialDeep<Messages> = {
+  common: { cancel: 'Atšaukti', save: 'Išsaugoti', saving: 'Saugoma', select: '<Pasirinkti>' },
+  settings: { language: 'Kalba' },
+  profile: { changeAvatar: 'Keisti avatarą', nickname: 'Slapyvardis:', nicknamePlaceholder: 'Įveskite slapyvardį' },
+  rooms: {
+    battle: 'Mūšis',
+    log: 'Žurnalas',
+    copy: 'Kopijuoti',
+    copied: 'Nukopijuota ✓',
+    changeProfile: 'Keisti',
+  },
+  battle: {
+    playersWin: 'Žaidėjai laimi',
+    monstersWin: 'Monstrai laimi',
+    monsterWins: 'Monstras laimi',
+    playerSide: 'Žaidėjų pusė',
+    monsterSide: 'Monstrų pusė',
+  },
+  history: {
+    created: 'sukurtas',
+    removed: 'pašalintas',
+    started: 'pradėtas',
+    concluded: 'Užbaigtas',
+    discarded: 'atmestas',
+    battleAccessibility: '{{prefix}}{{name}}, {{status}}, {{relativeTime}}.{{suffix}}',
+    openBattleRecordHint: ' Dukart bakstelėkite, kad atidarytumėte mūšio įrašą.',
+  },
+  user: { defaultName: 'Žaidėjas {{postfix}}' },
+};
+
+const lv: PartialDeep<Messages> = {
+  common: { cancel: 'Atcelt', save: 'Saglabāt', saving: 'Saglabā', select: '<Izvēlēties>' },
+  settings: { language: 'Valoda' },
+  profile: { changeAvatar: 'Mainīt avataru', nickname: 'Segvārds:', nicknamePlaceholder: 'Ievadi segvārdu' },
+  user: { defaultName: 'Spēlētājs {{postfix}}' },
+};
+
+const et: PartialDeep<Messages> = {
+  common: { cancel: 'Tühista', save: 'Salvesta', saving: 'Salvestamine', select: '<Vali>' },
+  settings: { language: 'Keel' },
+  profile: { changeAvatar: 'Muuda avatari', nickname: 'Hüüdnimi:', nicknamePlaceholder: 'Sisesta hüüdnimi' },
+  user: { defaultName: 'Mängija {{postfix}}' },
+};
+
+const ru: PartialDeep<Messages> = {
+  common: { cancel: 'Отмена', save: 'Сохранить', saving: 'Сохранение', select: '<Выбрать>' },
+  settings: { language: 'Язык' },
+  profile: { changeAvatar: 'Сменить аватар', nickname: 'Никнейм:', nicknamePlaceholder: 'Введите никнейм' },
+  user: { defaultName: 'Игрок {{postfix}}' },
+};
+
+const be: PartialDeep<Messages> = {
+  common: { cancel: 'Скасаваць', save: 'Захаваць', saving: 'Захаванне', select: '<Выбраць>' },
+  settings: { language: 'Мова' },
+  profile: { changeAvatar: 'Змяніць аватар', nickname: 'Нікнэйм:', nicknamePlaceholder: 'Увядзіце нікнэйм' },
+  user: { defaultName: 'Гулец {{postfix}}' },
+};
+
+const uk: PartialDeep<Messages> = {
+  common: { cancel: 'Скасувати', save: 'Зберегти', saving: 'Збереження', select: '<Вибрати>' },
+  settings: { language: 'Мова' },
+  profile: { changeAvatar: 'Змінити аватар', nickname: 'Нікнейм:', nicknamePlaceholder: 'Введіть нікнейм' },
+  user: { defaultName: 'Гравець {{postfix}}' },
+};
+
+export const translations: Record<SupportedLocale, PartialDeep<Messages>> = {
+  en,
+  pl,
+  de,
+  fr,
+  lt,
+  lv,
+  et,
+  ru,
+  be,
+  uk,
+};

--- a/openspec/changes/add-localization/.openspec.yaml
+++ b/openspec/changes/add-localization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/add-localization/design.md
+++ b/openspec/changes/add-localization/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The frontend is an Expo Router app with many hardcoded English strings across screens, components, hooks, accessibility labels, placeholders, tests, and long-form privacy/support content. There is no existing i18n layer. Backend APIs store and return language-neutral identifiers and user-generated room/game data, but log entries also include English summary strings that should become fallback display text instead of the primary localized source.
+
+The first supported locale set is English, Polish, German, French, Lithuanian, Latvian, Estonian, Russian, Belarusian, and Ukrainian. English remains the default and fallback.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a single frontend localization layer for UI strings, navigation titles, accessibility labels, placeholders, errors, and game-domain labels.
+- Detect the device/browser language on first launch and choose a supported locale when available.
+- Let users manually choose a language from the profile/change-user UI and persist that choice locally.
+- Apply language changes immediately without backend synchronization.
+- Keep translation lookup type-safe enough to catch missing English keys during development.
+- Prefer structured room history and battle payloads for localized rendering, using backend summary strings only as fallback.
+
+**Non-Goals:**
+
+- Translating user-generated names, room codes, typed monster names, backend ids, or internal enum values at rest.
+- Adding per-room or account-level language settings.
+- Changing backend APIs or database schema for the initial implementation.
+- Building a full settings screen before the app has more settings to host.
+- Guaranteeing legal-quality translations for privacy text without later human review.
+
+## Decisions
+
+### Use a small internal translation layer
+
+Create `frontend/i18n` with supported locale metadata, English source strings, locale dictionaries, a translation function, interpolation support, and a React provider/hook. This avoids introducing a large i18n framework for the app's current needs while keeping the public API straightforward.
+
+Alternative considered: add `i18next` or another full framework. That would provide mature pluralization and ecosystem features, but it is heavier than needed for a compact Expo app and would make the first extraction more complex.
+
+### Add locale detection through Expo/browser platform APIs
+
+Use a locale detection helper that supports native and web. If an Expo locale helper dependency is added, keep it isolated behind this helper so the rest of the app depends only on local `i18n` APIs. Match full locale tags to base language codes, for example `fr-CA` to `fr`.
+
+Alternative considered: rely only on JavaScript `navigator.language`. That works on web but is insufficient for native.
+
+### Store only the user override
+
+Persist the selected locale in AsyncStorage under a dedicated key. On startup, load the stored locale first; if absent or invalid, detect the device/browser locale; if unsupported, use English. Changing the language writes the override locally and updates the provider state immediately.
+
+Alternative considered: store the language in the user profile/backend. This would make language follow users across devices but introduces account/profile coupling for a preference that should be local and does not need multiplayer synchronization.
+
+### Put the first language picker in the profile UI
+
+Add a language picker to the existing change-user/profile modal, near nickname and avatar controls. This keeps the preference reachable without creating a mostly empty settings surface.
+
+Alternative considered: create a new settings screen. That is likely premature until there are more preferences.
+
+### Localize room history from structured payloads
+
+Update log and battle history presentation to render known event types from structured payload fields. Use the backend-provided `summary` as a fallback when payload data is incomplete or the event type is unknown. This lets different users in the same room view the same event in different languages without changing stored history.
+
+Alternative considered: have the backend store localized summaries. That would duplicate content per language, require selecting one language at event-write time, and fail for rooms with users in different languages.
+
+### Keep English complete and fallback-based
+
+English is the canonical translation resource. Other locales may fall back per key to English so the app remains usable if a translated key is missing. Development tests should verify all locale dictionaries conform to the English key shape or explicitly rely on fallback behavior.
+
+Alternative considered: fail hard on missing non-English keys. That improves translation completeness but makes partial rollout and iterative review painful.
+
+## Risks / Trade-offs
+
+- Long labels can break compact mobile layouts in German, French, Polish, Lithuanian, Latvian, Estonian, Russian, Belarusian, and Ukrainian -> review key screens on small widths and prefer flexible layout constraints where labels appear in buttons or headers.
+- Legal/privacy translations can carry compliance risk -> keep English as source of truth and flag translated privacy/support prose for human review before release.
+- Existing tests assert literal English strings -> centralize English test defaults and update assertions to render through the provider where localization affects UI.
+- Missing structured log payload details can limit localization -> keep summary fallback and add localized rendering only where payloads are sufficient.
+- Adding device locale detection may require a new Expo dependency -> isolate it behind a helper and keep the rest of the localization layer independent.
+
+## Migration Plan
+
+1. Add localization infrastructure with English-only strings and tests for fallback behavior.
+2. Wrap the app root in the localization provider.
+3. Extract strings screen-by-screen, keeping English behavior stable.
+4. Add the profile language picker and local persistence.
+5. Add non-English locale dictionaries for the first language set.
+6. Update log/history rendering to prefer structured localized labels with summary fallback.
+7. Run unit tests, type checks, and targeted UI checks for the most text-dense screens.
+
+Rollback is straightforward: keep English translations intact and remove or hide the language picker if non-English rollout needs to pause.
+
+## Open Questions
+
+- Should privacy policy translations ship with the first localized UI release, or should the app keep legal text in English until human-reviewed translations are available?
+- Should language names be displayed in their native form, English form, or both?

--- a/openspec/changes/add-localization/proposal.md
+++ b/openspec/changes/add-localization/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Munch Helper currently presents its user interface, accessibility labels, legal/support content, default generated names, and game history text in English only. Adding localization makes the app usable for a broader set of players while keeping English as the reliable default and fallback.
+
+## What Changes
+
+- Add app localization with English as the default and fallback language.
+- Support the first language set: Polish, German, French, Lithuanian, Latvian, Estonian, Russian, Belarusian, and Ukrainian.
+- Detect the device or browser locale on first launch and choose the best supported language when possible.
+- Allow users to manually change the app language from the profile/user preferences UI.
+- Persist the selected language locally on the device and apply it without backend synchronization.
+- Extract user-visible app strings, navigation titles, accessibility labels, placeholders, error fallbacks, and game-domain labels into translation resources.
+- Render room history and battle summaries from structured event data where possible so they can be localized per user.
+- Keep user-generated data, room codes, backend identifiers, and internal enums language-neutral.
+
+## Capabilities
+
+### New Capabilities
+
+- `localization`: Covers language detection, manual language selection, local persistence, translation fallback behavior, and localized rendering of app UI and game-domain text.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Frontend app localization infrastructure, context/hooks, and translation resources.
+- Profile/change-user UI where language selection will live initially.
+- React Native and Expo navigation titles, accessibility labels, placeholders, and error fallbacks.
+- Munchkin room, battle, character, log, support, and privacy screens.
+- Frontend tests that currently assert exact English strings.
+- No backend API or data model changes are expected, though frontend log rendering should prefer structured payload fields over backend summary strings when localizing history entries.

--- a/openspec/changes/add-localization/specs/localization/spec.md
+++ b/openspec/changes/add-localization/specs/localization/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Supported app languages
+The system SHALL support English as the default and fallback app language, and SHALL support Polish, German, French, Lithuanian, Latvian, Estonian, Russian, Belarusian, and Ukrainian as selectable app languages.
+
+#### Scenario: Supported language list is available
+- **WHEN** the app presents language choices to the user
+- **THEN** it lists English, Polish, German, French, Lithuanian, Latvian, Estonian, Russian, Belarusian, and Ukrainian as available choices
+
+#### Scenario: English fallback is available
+- **WHEN** a localized string is missing for the active non-English language
+- **THEN** the app displays the English string for that key
+
+### Requirement: Initial language selection
+The system SHALL choose the initial app language from a previously saved user selection when present; otherwise it SHALL choose the best supported device or browser language; otherwise it SHALL use English.
+
+#### Scenario: Saved language exists
+- **WHEN** the app starts and a valid saved language exists locally
+- **THEN** the app uses the saved language regardless of the device or browser locale
+
+#### Scenario: Device language is supported
+- **WHEN** the app starts without a saved language and the device or browser locale maps to a supported language
+- **THEN** the app uses the mapped supported language
+
+#### Scenario: Device language is unsupported
+- **WHEN** the app starts without a saved language and the device or browser locale does not map to a supported language
+- **THEN** the app uses English
+
+### Requirement: Manual language selection
+The system SHALL allow users to manually change the app language from the profile or user preferences UI and SHALL persist that selection locally on the device.
+
+#### Scenario: User changes language
+- **WHEN** the user selects a different supported language in the profile or user preferences UI
+- **THEN** the app stores the selected language locally
+- **AND** visible app UI updates to the selected language without requiring backend synchronization
+
+#### Scenario: User restarts app after language change
+- **WHEN** the user has selected a supported language and restarts the app
+- **THEN** the app uses the previously selected language
+
+### Requirement: Localized user interface text
+The system SHALL render user-visible static app text through localization resources, including navigation titles, buttons, form labels, placeholders, accessibility labels, error fallback messages, support text, privacy text, and game-domain labels.
+
+#### Scenario: UI renders in active language
+- **WHEN** the active language is changed to a supported non-English language
+- **THEN** localized static UI text displays in that active language where translations exist
+
+#### Scenario: User-generated content remains unchanged
+- **WHEN** user-generated names, room codes, typed monster names, or backend identifiers are displayed
+- **THEN** the app displays those values exactly as stored or entered
+
+### Requirement: Localized game history rendering
+The system SHALL render known room history and battle history events from structured event data in the active app language when enough structured data is available, and SHALL use backend-provided summary text as fallback when structured localization is not possible.
+
+#### Scenario: Structured event can be localized
+- **WHEN** a known history event includes enough structured payload data to render a localized message
+- **THEN** the app displays the event message in the active app language
+
+#### Scenario: Structured event cannot be localized
+- **WHEN** a history event is unknown or lacks required structured payload data
+- **THEN** the app displays the backend-provided summary text
+
+### Requirement: Language preference remains local
+The system SHALL treat the selected language as a local app preference and SHALL NOT require account creation, profile synchronization, room synchronization, or backend API changes to apply it.
+
+#### Scenario: Language changes do not alter shared state
+- **WHEN** a user changes the app language while in a room with other users
+- **THEN** only that user's local app UI language changes
+- **AND** shared room, character, battle, and log state remains unchanged

--- a/openspec/changes/add-localization/tasks.md
+++ b/openspec/changes/add-localization/tasks.md
@@ -1,0 +1,40 @@
+## 1. Localization Infrastructure
+
+- [x] 1.1 Create `frontend/i18n` locale metadata for `en`, `pl`, `de`, `fr`, `lt`, `lv`, `et`, `ru`, `be`, and `uk`.
+- [x] 1.2 Implement a typed English translation resource and per-locale dictionary loading with English fallback for missing keys.
+- [x] 1.3 Implement translation lookup with interpolation for dynamic values such as names, room codes, counts, and timestamps.
+- [x] 1.4 Implement locale normalization so full locale tags such as `fr-CA` map to supported base languages such as `fr`.
+- [x] 1.5 Implement native/web locale detection behind a local helper, adding an Expo locale dependency only if required.
+- [x] 1.6 Implement an AsyncStorage-backed language preference loader and saver.
+- [x] 1.7 Add a localization provider and hook, then wrap the app root so screens can read and update the active language.
+
+## 2. Language Selection UI
+
+- [x] 2.1 Add a language field to the profile/change-user modal using the supported language list.
+- [x] 2.2 Persist language changes locally and update the active UI language immediately after selection.
+- [x] 2.3 Ensure language selection does not update backend user profile data or shared room state.
+- [x] 2.4 Add tests for saved language loading, unsupported locale fallback, and manual language changes.
+
+## 3. UI String Extraction
+
+- [x] 3.1 Extract landing, rooms, support, privacy, shop, profile, room join, room create, avatar, and character modal strings into translation resources.
+- [x] 3.2 Extract Munchkin room, character card, quick edit, reconnecting banner, active battle banner, battle action, and battle editor strings into translation resources.
+- [x] 3.3 Extract navigation titles, accessibility labels, placeholders, button labels, confirmation dialog text, and error fallback messages.
+- [x] 3.4 Keep user-generated names, room codes, typed monster names, backend identifiers, and internal enum values unmodified.
+- [x] 3.5 Add translations for Polish, German, French, Lithuanian, Latvian, Estonian, Russian, Belarusian, and Ukrainian.
+
+## 4. Localized Game History
+
+- [x] 4.1 Update log entry rendering to use structured event payload data for known character and battle events.
+- [x] 4.2 Update battle history modal labels, statuses, result names, and accessibility text to use localization resources.
+- [x] 4.3 Preserve backend-provided summary text as fallback when an event is unknown or lacks required structured payload data.
+- [x] 4.4 Add tests proving the same structured event can render in at least English and one non-English locale while fallback summaries still display.
+
+## 5. Verification
+
+- [x] 5.1 Add tests that verify supported locale metadata includes all first-launch languages.
+- [x] 5.2 Add tests that verify missing non-English translation keys fall back to English.
+- [x] 5.3 Update existing frontend tests that asserted literal English UI strings to render through the localization provider.
+- [x] 5.4 Run frontend unit tests and room-route tests.
+- [x] 5.5 Run TypeScript checking and linting for the frontend.
+- [x] 5.6 Perform targeted UI review on small mobile widths for text-heavy screens and long translated labels.


### PR DESCRIPTION
## Summary
- Introduce an i18n layer with locale detection, persistence, translation helpers, and context wiring
- Localize core app screens, modals, battle views, banners, and shared Munchkin UI components
- Add localization coverage for log entry rendering and related translation behavior

## Testing
- Added and updated localization-focused unit tests
- Performed local UI validation of translated flows and screen-level text rendering