### PR TITLE
docs: OpenSpec change to refresh store screenshots (game-story, on-brand caption bands)

### DIFF
--- a/openspec/changes/refresh-store-screenshots/.openspec.yaml
+++ b/openspec/changes/refresh-store-screenshots/.openspec.yaml
@@ -1,0 +1,6 @@
+schema: spec-driven
+created: 2026-07-07
+goal: Rewrite the store screenshot pipeline to tell the 4-beat game story (room,
+  power/class, battle, history) with a solid brand caption band above a clean
+  device shot, using the app's own palette, for iPhone 6.9 (1320x2868) and
+  Android 1080x2400.

--- a/openspec/changes/refresh-store-screenshots/design.md
+++ b/openspec/changes/refresh-store-screenshots/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The store screenshots are produced by a local pipeline (not committed — `screenshots/` is gitignored):
+
+1. `seed-app-store-room.mjs` seeds a room + cast of characters in the local backend.
+2. `capture-app-store-screenshots.mjs` / `capture-google-play-screenshots.mjs` build the release app, run Maestro flows to reach each screen, and capture PNGs.
+3. `generate-app-store-preview-redesign.py` composites marketing captions onto the iPhone PNGs.
+
+Three problems motivate this change (see proposal): the captured story no longer matches gameplay, the caption compositor floats text over a *dimmed* screenshot using an off-brand hardcoded palette, and Android gets no captions at all. The app already contains the two screens the new story needs — the battle screen (`frontend/app/munchkin/[roomNumber]/(battle)/index.tsx`) and the history log (`frontend/app/munchkin/[roomNumber]/log.tsx`) — but neither is captured today.
+
+Constraints locked during exploration:
+- **Exactly 4 slides**, one per story beat.
+- **Bare device screenshot** (rounded corners + soft shadow), not a hardware bezel.
+- **English captions**, stored as locale-keyed data so other languages are a later data-only addition.
+- **Fixed canvases**: App Store 6.9″ only (1320×2868); Google Play 1080×2400 only. Both already approved sizes.
+- Palette must come from `frontend/constants/theme.ts`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Tell the 4-beat game story (room → power/class → battle → history) on both stores.
+- Caption text on a solid, on-brand contrast band **above** a clean, full-brightness device shot.
+- Reuse the app's real palette so marketing frames read as the same app users open.
+- Make the compositor store-agnostic across the two fixed canvases and run it for Android too.
+- Keep the copy pipeline localizable without a rewrite.
+
+**Non-Goals:**
+- Localizing caption text now (only the data structure must support it).
+- iPad, 6.3″, or 6.1″ App Store screenshot sets, and any tablet sets.
+- The Google Play feature graphic (1024×500) — handled in a separate change; `create-google-play-feature-graphic.swift` is untouched here.
+- Hardware device bezels / frames.
+- Changing any app or backend code — screens and endpoints already exist.
+- Animated App Preview videos (a separate `preview_video` flow already exists and is untouched).
+
+## Decisions
+
+### D1: Populate battle + history by performing real actions, not fabricating data
+The log service exposes only `GET /logs` — log events are side effects of battle/character actions. So the seed script will *perform* actions: create characters (already done), start a battle via `POST /battles` and leave it **active** (for the battle screenshot), and `POST /battles/:id/conclude` on at least one battle (to fill the history log). This keeps seeded data internally consistent with what the app would actually produce.
+- *Alternative considered*: inserting log rows directly — rejected; no write endpoint and it would drift from real event shapes.
+
+### D2: One compositor, two fixed base canvases
+Rather than deriving band geometry from arbitrary device resolutions, the compositor hardcodes two bases — `IPHONE = 1320×2868` and `ANDROID = 1080×2400` — each with its own band height and type scale tuned once. The compositor detects which base a source directory belongs to (`iphone69` vs `android1080x2400`) and applies that base's constants.
+- *Alternative considered*: keep the current `min(scale_x, scale_y)` dynamic scaling from a single base — rejected; unnecessary now that both sizes are fixed, and it was the source of the "variable Android resolution" risk.
+
+### D3: Band-above-clean-shot composition
+Each output = solid brand-background canvas with two regions:
+- **Top band**: occupies roughly the top **20–30%** of the canvas height. Holds eyebrow (accent color), headline (textPrimary/white), sub (muted/cream), left-aligned or centered per a per-slide flag.
+- **Device region**: the raw screenshot, **undimmed**, placed in the remaining ~70–80%, rounded corners, soft drop shadow, optional accent glow behind it.
+No full-image dim, no top-chrome retouch, no scrim gradient over the screenshot (all present in the current script) — the band provides contrast instead.
+- *Alternative considered*: refine the existing dim+overlay — rejected by product decision (want a true solid band).
+
+### D3a: Bottom-crop the device shot to fit
+The device screenshot is placed at its native width (scaled to the region width) and, if taller than the remaining region, **cropped from the bottom** rather than shrunk to fit. This keeps the screenshot at a legible scale and preserves the top of the screen — where the most identifiable in-app content and headings live — so the on-band caption and the screenshot together stay visually recognizable. The band ratio (within 20–30%) is tuned per slide/base so the crop never removes the content the caption refers to.
+- *Alternative considered*: scale the whole screenshot down to fit the region — rejected; shrinking makes in-app text illegible at store thumbnail sizes, defeating the point of the band.
+
+### D4: Palette sourced from theme.ts, mirrored in the compositor
+The Python compositor can't import the TS theme, so it holds a small palette dict that mirrors `frontend/constants/theme.ts` verbatim (`background #3C3636`, `accent #D4C26E`, `actionSecondary #6E6BD4`, `danger #922525`, `parchmentText #CEB464`, `surfaceWarm #8A6150`, `textPrimary #FFFFFF`). A comment ties it to the source file so the two stay in sync.
+- *Alternative considered*: generate a JSON palette from theme.ts at build time — deferred; low churn, not worth the tooling now, but noted as a future option.
+
+### D5: Locale-keyed caption data
+Caption copy becomes a nested structure `CAPTIONS[locale][slide] = {eyebrow, headline[], sub, accent}` with `en` populated. The compositor reads a `LOCALE` (default `en`) and writes output into a locale-scoped path so future locales don't collide. Only `en` renders today.
+- *Alternative considered*: inline per-slide English strings (status quo) — rejected; makes future localization a code change.
+
+### D6: Slide → screen → accent mapping
+| # | Screen  | Eyebrow          | Headline                       | Accent (theme token)      |
+|---|---------|------------------|--------------------------------|---------------------------|
+| 1 | rooms-home | GATHER THE TABLE | One room for the whole party   | `accent` #D4C26E          |
+| 2 | room-view  | LIVE TABLE       | Watch everyone level up        | `actionSecondary` #6E6BD4 |
+| 3 | battle     | INTO BATTLE      | Take on the monster together   | `danger` #922525          |
+| 4 | log        | GAME HISTORY     | Replay every twist             | `parchmentText` #CEB464   |
+
+## Risks / Trade-offs
+
+- **Seed timing / battle state** → An active battle must survive until the battle flow captures it. Mitigation: seed the active battle last (or make the battle flow independent of the concluded ones) and assert on stable text in the Maestro flow.
+- **Android emulator not 1080×2400** → capture would land in the wrong `android<W>x<H>` dir. Mitigation: pin capture to a Pixel 6a (native 1080×2400) and target the `android1080x2400` dir explicitly; fail fast if `wm size` ≠ 1080×2400.
+- **Palette drift** between `theme.ts` and the compositor's mirror dict → colors silently diverge over time. Mitigation: comment linking to the source; future option (D4 alternative) to generate it.
+- **Battle/log flows brittle to i18n text** → Maestro asserts on visible strings. Mitigation: assert on stable, non-localized identifiers (seeded character/monster names, room id) where possible.
+- **iPad listing** → dropping the iPad set breaks an iPad listing if one exists. Mitigation: flagged in proposal as an out-of-scope check before shipping the listing.
+
+## Migration Plan
+
+No runtime deploy — this is local tooling producing store assets. Rollout is procedural:
+1. Land script/flow changes.
+2. Run `npm run screenshots:app-store` and `npm run screenshots:google-play`, then the compositor, and eyeball all 8 outputs.
+3. Upload to App Store Connect (6.9″) and Play Console (1080×2400).
+Rollback = re-upload the previously approved screenshots; the old script revision remains in git history.
+
+## Open Questions
+
+- Exact band height within the 20–30% range, per-slide crop offset, and type sizes — to be tuned visually against the first render so each caption still matches the visible (post-crop) screenshot content; not blocking.

--- a/openspec/changes/refresh-store-screenshots/proposal.md
+++ b/openspec/changes/refresh-store-screenshots/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The current App Store / Google Play screenshots tell an onboarding-funnel story ("start fast", "join in seconds", "track updates", "edit stats") that no longer matches how the app plays, and the marketing overlay uses an off-brand hardcoded palette with text floated over a dimmed screenshot. We want screenshots that tell the actual game story — gather your table, gain power and swap classes, fight the monster, replay the history — with captions on a solid, on-brand contrast band above a clean, undimmed device shot.
+
+## What Changes
+
+- **New 4-beat story** replacing the 4 onboarding slides. Each slide maps to one beat and one screen:
+  1. `rooms-home` — gather the whole table in one room
+  2. `room-view` — everyone gains power and changes class in real time
+  3. `battle` *(newly captured)* — team up to fight the monster
+  4. `log` *(newly captured)* — replay every twist in the game history
+- **Capture the battle and log screens**, which exist in the app but were never captured. Add `app_store_battle.yaml` and `app_store_log.yaml` Maestro flows and wire them into the shared capture flow list.
+- **Extend the seed** so the battle screen and history log are populated: start a battle and leave it active, and conclude at least one battle so the shared log fills via the services' side effects (the log service has no write endpoint — events are produced by battle/character actions).
+- **New compositor layout**: a solid brand caption band (eyebrow + headline + sub) occupying roughly the top 20–30% of the canvas, above a clean, full-brightness device screenshot with rounded corners and a soft shadow/glow — replacing the current dim-and-overlay style. To keep the on-band text visually recognizable, the device screenshot may be cropped from the bottom to fit the remaining region.
+- **On-brand palette**: caption band colors are drawn from `frontend/constants/theme.ts` (`background`, `accent`, `actionSecondary`, `danger`, `parchmentText`, `surfaceWarm`) instead of the script's hardcoded hexes.
+- **Locale-keyed caption copy**: captions ship in English now, but are stored as data keyed by locale (default `en`) so the other store languages can be added later as data, not code.
+- **Fixed canvas sizes, both stores**: iOS captures **only the 6.9″ iPhone (1320×2868)** — App Store scales it to all iPhone models — and Android captures **only 1080×2400** (Pixel 6a), matching sizes already approved for the store. The App Store script drops the 6.3″, 6.1″, and iPad profiles.
+- **Cross-store parity**: the caption-band compositor becomes store-agnostic with two fixed base canvases (1320×2868 and 1080×2400) and runs over both the iPhone and Android outputs; today only iPhone gets a text overlay and Android gets none.
+- Update `scripts/README-screenshots.md` to describe the new story, screens, canvases, and compositor.
+
+## Capabilities
+
+### New Capabilities
+- `store-screenshots`: Defines the store screenshot deliverable — the 4-beat story and its screen mapping, the seed data required to render each screen, the caption-band visual layout and on-brand palette, the locale-keyed caption model, and the fixed per-store canvas dimensions for App Store (1320×2868) and Google Play (1080×2400).
+
+### Modified Capabilities
+<!-- No existing spec captures the screenshot pipeline; this is net-new. -->
+
+## Impact
+
+- **Scripts**: `scripts/seed-app-store-room.mjs` (add battle + concluded-battle seeding), `scripts/capture-app-store-screenshots.mjs` (6.9″ only; add battle/log flows), `scripts/capture-google-play-screenshots.mjs` (pin 1080×2400; add flows; invoke compositor), `scripts/generate-app-store-preview-redesign.py` (new band layout, theme palette, locale-keyed copy, two fixed bases, run over android1080x2400), `scripts/README-screenshots.md`.
+- **Maestro**: new `maestro/app_store_battle.yaml`, `maestro/app_store_log.yaml`.
+- **Backend/API**: no code changes — uses existing `POST /battles`, `PATCH /battles/:id`, `POST /battles/:id/conclude`, and existing log side effects.
+- **App code**: none — screens already exist (`(battle)/index.tsx`, `log.tsx`).
+- **Output artifacts** (gitignored): `screenshots/iphone69/*`, `screenshots/android1080x2400/*`, and the redesigned caption-band previews.
+- **Out of scope (separate change)**: iPad and tablet screenshot sets, and the Google Play feature graphic (`scripts/create-google-play-feature-graphic.swift` / `screenshots/google-play/feature-graphic.png`) — these differ significantly from phone images and will be handled on their own. If the app is still offered on iPad in App Store Connect, an iPad set remains separately required.

--- a/openspec/changes/refresh-store-screenshots/specs/store-screenshots/spec.md
+++ b/openspec/changes/refresh-store-screenshots/specs/store-screenshots/spec.md
@@ -1,0 +1,123 @@
+## ADDED Requirements
+
+### Requirement: Four-beat game story
+
+The store screenshot set SHALL consist of exactly four slides, in order, each mapping to one game-story beat and one app screen:
+
+1. `rooms-home` — gather the whole table in one room
+2. `room-view` — everyone gains power and changes class in real time
+3. `battle` — team up to fight the monster
+4. `log` — replay every twist in the game history
+
+The set SHALL NOT include the previous onboarding-funnel slides (`join-room`, `character-details`) in the published hero set.
+
+#### Scenario: Slides are produced in story order
+
+- **WHEN** the screenshot pipeline runs to completion for a store
+- **THEN** exactly four captioned slides are produced
+- **AND** they appear in the order rooms-home, room-view, battle, log
+
+#### Scenario: Battle and log screens are captured
+
+- **WHEN** the capture flows run
+- **THEN** the battle screen and the history log screen are each captured as source screenshots
+
+### Requirement: Seeded data renders every story screen
+
+The seed step SHALL create data such that every captured screen shows meaningful, non-empty content, using only existing backend endpoints and log side effects.
+
+#### Scenario: Battle screen has an active battle
+
+- **WHEN** the battle screen is captured
+- **THEN** an active battle (created via `POST /battles`) is visible with at least one monster and player participation
+
+#### Scenario: History log is populated
+
+- **WHEN** the history log screen is captured
+- **THEN** it shows log events produced as side effects of seeded actions, including at least one concluded battle (via `POST /battles/:id/conclude`)
+
+#### Scenario: No direct log writes
+
+- **WHEN** the seed populates history
+- **THEN** it does so by performing battle/character actions, not by writing log rows directly
+
+### Requirement: Caption band above a clean device shot
+
+Each slide SHALL render the caption text on a solid contrast band positioned above the device screenshot. The band SHALL occupy approximately the top 20–30% of the canvas height. The device screenshot SHALL be shown at full brightness (undimmed), with rounded corners and a soft shadow, and SHALL NOT be covered by a dimming overlay, scrim gradient, or top-chrome retouch. To keep both the caption and the screenshot recognizable, the device screenshot MAY be cropped from the bottom to fit the remaining region rather than scaled down to fit.
+
+#### Scenario: Text sits on a solid band, not over the screenshot
+
+- **WHEN** a slide is composited
+- **THEN** the eyebrow, headline, and sub text render on a solid brand-colored band above the device screenshot
+- **AND** the band occupies roughly the top 20–30% of the canvas height
+- **AND** the device screenshot region contains no dimming overlay or text
+
+#### Scenario: Device shot styling
+
+- **WHEN** the device screenshot is placed
+- **THEN** it has rounded corners and a soft shadow
+- **AND** it is not wrapped in a hardware device bezel
+
+#### Scenario: Bottom-crop to preserve legibility
+
+- **WHEN** the device screenshot is taller than the region left below the band
+- **THEN** it is cropped from the bottom rather than shrunk to fit
+- **AND** the top of the screenshot (the content the caption refers to) remains visible
+
+### Requirement: On-brand palette
+
+Caption band and accent colors SHALL be drawn from the app theme defined in `frontend/constants/theme.ts`. The compositor SHALL NOT introduce marketing-only colors that do not exist in that theme.
+
+#### Scenario: Colors match the app theme
+
+- **WHEN** a slide is composited
+- **THEN** the band background, text, and accent colors are values present in `frontend/constants/theme.ts` (e.g. `background`, `accent`, `actionSecondary`, `danger`, `parchmentText`, `textPrimary`)
+
+#### Scenario: Per-slide accent
+
+- **WHEN** each of the four slides is composited
+- **THEN** its accent color matches the mapping: rooms-home→`accent`, room-view→`actionSecondary`, battle→`danger`, log→`parchmentText`
+
+### Requirement: Localizable caption copy
+
+Caption copy SHALL be stored as data keyed by locale, with `en` populated. The compositor SHALL render a single configurable locale (default `en`) and SHALL allow additional locales to be added as data without code changes.
+
+#### Scenario: English renders by default
+
+- **WHEN** the compositor runs with no locale override
+- **THEN** it renders English caption copy
+
+#### Scenario: Adding a locale requires only data
+
+- **WHEN** a new locale's caption strings are added to the caption data
+- **THEN** that locale can be rendered without modifying compositor logic
+
+### Requirement: Fixed per-store canvas dimensions
+
+The App Store output SHALL be produced only at the 6.9″ iPhone size of 1320×2868. The Google Play output SHALL be produced only at 1080×2400. The App Store pipeline SHALL NOT produce 6.3″, 6.1″, or iPad sets.
+
+#### Scenario: App Store canvas
+
+- **WHEN** App Store slides are produced
+- **THEN** each output image is exactly 1320×2868
+- **AND** no 6.3″, 6.1″, or iPad images are produced
+
+#### Scenario: Google Play canvas
+
+- **WHEN** Google Play slides are produced
+- **THEN** each output image is exactly 1080×2400
+
+### Requirement: Cross-store parity
+
+The caption-band compositor SHALL apply to both the App Store and Google Play outputs using two fixed base canvases (1320×2868 and 1080×2400). Both stores SHALL receive the same four-beat captioned story; Google Play SHALL no longer ship uncaptioned screenshots.
+
+#### Scenario: Both stores get captioned slides
+
+- **WHEN** the pipeline completes for both stores
+- **THEN** the App Store and Google Play each have four captioned slides telling the same story
+- **AND** neither store ships an uncaptioned screenshot in the hero set
+
+#### Scenario: Compositor selects the base by canvas
+
+- **WHEN** the compositor processes a source directory
+- **THEN** it applies the 1320×2868 base for the iPhone output and the 1080×2400 base for the Android output

--- a/openspec/changes/refresh-store-screenshots/tasks.md
+++ b/openspec/changes/refresh-store-screenshots/tasks.md
@@ -1,0 +1,42 @@
+## 1. Seed battle and history data
+
+- [ ] 1.1 Extend `scripts/seed-app-store-room.mjs` to start a battle via `POST /battles` with at least one monster and player participation, and leave it **active** for the battle screenshot
+- [ ] 1.2 In the same seed, create and `POST /battles/:id/conclude` at least one battle so the shared history log is populated via side effects
+- [ ] 1.3 Verify the seeded battle and log render non-empty by hitting `GET /battles?roomId=...&status=active` and `GET /logs?roomId=...`
+- [ ] 1.4 Ensure the active battle used for the screenshot is not the one that gets concluded (seed order / separate battles)
+
+## 2. Maestro flows for the new screens
+
+- [ ] 2.1 Add `maestro/app_store_battle.yaml` that navigates from the room to the active battle screen and asserts on stable seeded text
+- [ ] 2.2 Add `maestro/app_store_log.yaml` that navigates to the history log screen and asserts a log entry is visible
+- [ ] 2.3 Prefer assertions on non-localized identifiers (seeded names, room id) to keep flows i18n-robust
+
+## 3. Capture pipeline — App Store (6.9″ only)
+
+- [ ] 3.1 In `scripts/capture-app-store-screenshots.mjs`, reduce `deviceProfiles` to the single 6.9″ profile (iPhone 17 Pro Max → `iphone69`); remove the 6.3″, 6.1″, and iPad profiles
+- [ ] 3.2 Replace the `flows` array with the four story flows: rooms-home, room-view, battle, log
+- [ ] 3.3 Confirm captured PNGs land in `screenshots/iphone69` at 1320×2868
+
+## 4. Capture pipeline — Google Play (1080×2400 only)
+
+- [ ] 4.1 In `scripts/capture-google-play-screenshots.mjs`, use the same four story `flows`
+- [ ] 4.2 Pin capture to a 1080×2400 device (Pixel 6a); fail fast if `wm size` ≠ 1080×2400 and write output to `screenshots/android1080x2400`
+- [ ] 4.3 Invoke the caption compositor over the Android output after capture
+
+## 5. Caption-band compositor rewrite
+
+- [ ] 5.1 In `scripts/generate-app-store-preview-redesign.py`, remove the dim overlay, scrim gradient, and top-chrome retouch
+- [ ] 5.2 Implement the band-above-clean-shot layout: solid brand band (eyebrow/headline/sub) occupying ~20–30% of canvas height, above an undimmed, rounded-corner device shot with a soft shadow
+- [ ] 5.2a Bottom-crop the device screenshot to fit the region below the band (keep top content visible) instead of scaling it down; make the band ratio / crop offset tunable per slide and base
+- [ ] 5.3 Replace the hardcoded palette with values mirrored from `frontend/constants/theme.ts`, with a comment linking to the source
+- [ ] 5.4 Define two fixed base canvases (iPhone 1320×2868, Android 1080×2400) with per-base band height and type scale; select the base by source directory
+- [ ] 5.5 Move caption copy into a locale-keyed structure `CAPTIONS[locale][slide]` with `en` populated and a default `LOCALE=en`; write output to a locale-scoped path
+- [ ] 5.6 Apply the four-slide accent mapping: rooms-home→`accent`, room-view→`actionSecondary`, battle→`danger`, log→`parchmentText`
+- [ ] 5.7 Run the compositor over both `iphone69` and `android1080x2400` sources
+
+## 6. Docs and verification
+
+- [ ] 6.1 Update `scripts/README-screenshots.md`: new 4-beat story, battle/log flows, 6.9″-only iOS, 1080×2400-only Android, new compositor + palette + locale model, and the ~20–30% band + bottom-crop behavior
+- [ ] 6.2 Run the full pipeline end to end for both stores and visually verify all 8 slides (caption matches the post-crop screenshot content)
+- [ ] 6.3 Confirm final dimensions: iPhone outputs 1320×2868, Android outputs 1080×2400
+- [ ] 6.4 Flag (outside this change) that iPad/tablet sets and the Google Play feature graphic are handled separately


### PR DESCRIPTION
## Why

The current App Store / Google Play screenshots tell an onboarding-funnel story ("start fast", "join in seconds"…) that no longer matches how the app plays, the caption compositor floats text over a *dimmed* screenshot using an off-brand hardcoded palette, and Android ships no captions at all. This adds an OpenSpec change that plans a rework so screenshots tell the actual game story on a solid, on-brand contrast band above a clean device shot.

**Planning artifacts only — no implementation.** Nothing under `scripts/`, `maestro/`, or app code is touched.

## What's in the change

A new `refresh-store-screenshots` OpenSpec change (proposal + design + specs + tasks) capturing:

- **4-beat game story** → `rooms-home` (gather the table) · `room-view` (gain power / change class) · **`battle`** (fight the monster) · **`log`** (replay the history). The battle and log screens exist in the app but were never captured.
- **Seed by real actions** — start an active battle and conclude one, so the history log fills via the log service's side effects (no direct log writes; it has no write endpoint).
- **Band-above-clean-shot layout** — solid brand caption band (~20–30% of height) above an undimmed, rounded-corner device shot; the shot is **bottom-cropped** to fit so caption + screenshot stay legible.
- **On-brand palette** sourced from `frontend/constants/theme.ts` (retiring the script's hardcoded hexes).
- **Locale-keyed caption copy** — English now, structured so other listing languages are a data-only add later.
- **Fixed per-store canvases** — App Store 6.9″ only (1320×2868, scales to all iPhones); Google Play 1080×2400 only (Pixel 6a). Both are already-approved sizes.
- **Cross-store parity** — the compositor becomes store-agnostic (two fixed bases) and runs for Android too.

## Out of scope (separate change)

iPad / tablet screenshot sets and the Google Play feature graphic — they differ significantly from phone images and will be handled on their own. If the app is still offered on iPad in App Store Connect, an iPad set remains separately required (flagged in the change).

## Reviewer notes

- `openspec validate refresh-store-screenshots` passes; all four artifacts report complete.
- No runtime/deploy impact — this is local asset-generation tooling. Implementation will follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)