### PR TITLE
docs: OpenSpec change — cross-platform E2E tests (add-e2e-testing)

### DIFF
--- a/openspec/changes/add-e2e-testing/.openspec.yaml
+++ b/openspec/changes/add-e2e-testing/.openspec.yaml
@@ -1,0 +1,6 @@
+schema: spec-driven
+created: 2026-07-07
+goal: Establish Maestro-driven end-to-end tests running the same flows on iOS,
+  Android, and web against the local backend stack, covering room + character
+  lifecycle and cross-user character updates (real-time WebSocket fanout), all
+  gated on every PR in CI.

--- a/openspec/changes/add-e2e-testing/design.md
+++ b/openspec/changes/add-e2e-testing/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The frontend is a single Expo/React Native app rendered to iOS, Android, and web (react-native-web ~0.21). The backend is six services (`user`, `room`, `character`, `battle`, `room-notifications`, `log`) plus Redis and Mongo, orchestrated for local dev by `backend/docker-compose.local.yml` behind an nginx gateway on `:8080`. The app's signature behavior is real-time cross-user updates: a character write flows `character-service → Redis (room-character-events) → room-notifications-service → WebSocket → app`, where the app's `RoomWebSocketClient` ([frontend/api/webSocket.ts](frontend/api/webSocket.ts)) invalidates the react-query cache and the list re-renders.
+
+Crucially, the local stack runs a **real** `ws` WebSocketServer ([room-notifications-service/src/index.ts](backend/room-notifications-service/src/index.ts)) that nginx proxies at `/ws` with upgrade headers — not the AWS API-Gateway path. The app derives its WebSocket URL from `API_BASE_URL` (default `http://localhost:8080` → `ws://localhost:8080/ws`, [frontend/config/runtime.ts](frontend/config/runtime.ts)). So the full cross-user path is reproducible with `docker compose up` and zero cloud dependency.
+
+Existing test assets: vitest unit/component tests; Maestro 2.4.0 flows built for store screenshots (`maestro/*.yaml`), which already demonstrate `${ROOM_ID}` parameterization, `clearState`, and `extendedWaitUntil`. There is no E2E suite for crucial paths and no E2E job in CI (only platform CD workflows exist).
+
+## Goals / Non-Goals
+
+**Goals:**
+- One test-authoring tool (Maestro) driving the same flows across iOS, Android, and web.
+- Genuine end-to-end coverage of room + character lifecycle against the running local stack.
+- Genuine cross-user coverage: an external actor's character write results in the app-under-test's UI updating via the real WebSocket fanout.
+- Deterministic, isolated runs (unique room/user per test; no shared mutable state between tests).
+- Every PR gated by the suite on all three platforms.
+
+**Non-Goals:**
+- Battle, shop, and log flows (later changes).
+- Two live driven clients in one test (Maestro can't; and it isn't needed for the inbound-event assertion).
+- Cross-browser web (Maestro Web is Chromium-only).
+- Visual-regression or localization assertions.
+- Testing against deployed/cloud environments.
+
+## Decisions
+
+### D1 — Maestro as the single cross-platform driver (over Maestro-mobile + Playwright-web)
+Maestro 2.4.0 supports web flows and drives iOS/Android natively. react-native-web maps `testID` → `data-testid` (verified in [ButtonLabel.test.tsx](frontend/components/ButtonLabel.test.tsx)), so the app's 64 existing `testID`s are valid selectors on all three platforms. Writing flows once and running them everywhere minimizes maintenance — the stated priority.
+- *Alternative considered:* Maestro (mobile) + Playwright (web). Best-in-class web fidelity and cross-browser, but two flow languages and duplicated flows. Rejected in favor of single-tool maintenance.
+- *Consequence:* accept Chromium-only web and a younger web driver (see R1).
+
+### D2 — Run against the local docker stack, not mocks
+The cross-user requirement is only meaningful if the real Redis→notifications→WebSocket path is exercised. `docker-compose.local.yml` provides exactly that. A harness script (`scripts/e2e/*` or `frontend/scripts/e2e/*`) boots the stack, polls `GET :8080/health` (and per-service health) until ready, runs flows, then tears down.
+- *Alternative:* mock the WebSocket / stub the backend. Rejected — it would test the mock, not the fanout.
+
+### D3 — API-injected "actor B" for cross-user scenarios
+Cross-user flows use a small HTTP helper that performs the other user's writes directly against the backend (`POST/PATCH/DELETE /characters` with actor B's `userId` + the shared `roomId`). Because Maestro flows can shell out (`runScript`/`runFlow` with a JS step), the flow triggers actor B's write and then asserts actor A's list changes.
+- *Rationale:* the system under test is actor A's inbound-event handling; actor B's write UI is already covered by A's own create/edit flows. Maestro also cannot drive two devices in one test.
+- *Alternative:* a second Maestro instance driving actor B's UI. Higher fidelity, 2× flake and orchestration; deferred as a later fidelity upgrade.
+
+### D4 — Test isolation via unique room + user ids
+Each test generates a unique `roomId` and `userId` (e.g., timestamp/uuid suffix) so parallel or repeated runs don't collide. The app-under-test is launched with `clearState` and pointed at the shared `roomId`; actor B uses the same `roomId` with a distinct `userId`. Ephemeral stack state (fresh compose volumes in CI) plus unique ids removes the need for per-test cleanup endpoints.
+
+### D5 — Per-platform runtime wiring
+- **iOS sim**: dev client build; `EXPO_PUBLIC_API_URL=http://localhost:8080`; localhost reaches the host stack.
+- **Android emulator**: host is reachable at **`10.0.2.2`**, so `EXPO_PUBLIC_API_URL=http://10.0.2.2:8080` (and the derived `ws://10.0.2.2:8080/ws`). This is the known gotcha to bake into the harness.
+- **Web**: `expo export --platform web`, serve the static output, run `maestro test --url http://localhost:<port>`; the app uses the default `http://localhost:8080`.
+
+### D6 — CI shape: one workflow, three jobs, all required on PR
+`.github/workflows/e2e.yml` with a reusable "boot backend stack" step and three matrixed jobs: `web` (Linux + Chromium), `android` (Linux + KVM emulator), `ios` (macOS + simulator). All three are required checks on pull requests. iOS macOS-runner cost is accepted now and re-evaluated later.
+
+## Risks / Trade-offs
+
+- **R1 — Maestro Web is younger/Chromium-only** → Keep web assertions tolerant: rely on `extendedWaitUntil` with generous timeouts (the WebSocket update is async), select by stable `data-testid`, avoid pixel/layout assertions. Treat cross-browser as out of scope.
+- **R2 — WebSocket timing flake in cross-user tests** → Assert with `extendedWaitUntil` on the post-update state (not fixed sleeps); give the fanout a generous window; ensure actor A is confirmed connected (the app invalidates the query `onOpen`) before actor B writes.
+- **R3 — iOS CI is slow/expensive (sim boot + dev-client build)** → Cache the dev-client build and Maestro; accept cost for now per decision; documented escape hatch is moving iOS to nightly/pre-release later.
+- **R4 — Android emulator flakiness in CI** → Use a known-good emulator action with KVM, headless, and a warm snapshot; retry the emulator boot, not the assertions.
+- **R5 — Local-echo suppression regressions** ([useCharacters.ts](frontend/hooks/useCharacters.ts)) → Include an explicit cross-user case where actor A edits its own character and must see exactly one applied change (no double-apply from the echoed event).
+- **R6 — Missing/unstable testIDs on some crucial-path elements** → Audit the room + character-lifecycle screens during implementation; add `testID`s where needed (prop-only, no behavior change) rather than selecting by translated text (i18n makes text brittle).
+
+## Migration Plan
+
+Additive only — no runtime/app behavior changes. Land the harness + flows + docs, then add `e2e.yml` as a required PR check once green on all three platforms. Rollback = remove/de-require the workflow; no production surface is touched.
+
+## Open Questions
+
+- Where do harness scripts and flows live — top-level `maestro/` + `scripts/e2e/`, or under `frontend/`? (Existing flows are top-level `maestro/`; lean that way for consistency.)
+- Should the `roomId`/`userId` generation and actor-B helper be a small Node module invoked via Maestro `runScript`, or standalone shell used in `before` hooks? (Design leans `runScript` JS for portability across the three CI OSes.)
+- Do any first-cut screens require new `testID`s (resolved during the R6 audit)?

--- a/openspec/changes/add-e2e-testing/proposal.md
+++ b/openspec/changes/add-e2e-testing/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The app is one Expo codebase shipped to three platforms (iOS, Android, web via react-native-web) backed by six microservices, and its defining feature is real-time cross-user updates over WebSocket — yet there is no end-to-end test that exercises a crucial user path against the running stack, and nothing that verifies "another user changed their character and my screen updated." Unit/component tests (vitest) and the existing Maestro flows (built for store screenshots) do not cover these journeys, so regressions in navigation, the room/character lifecycle, or the WebSocket fanout can reach production unnoticed. This change establishes a single-tool E2E suite that runs the same flows on all three platforms and gates every PR.
+
+## What Changes
+
+- **One tool, three platforms**: adopt **Maestro** (already at 2.4.0, already used for screenshots) as the single E2E driver for iOS simulator, Android emulator, and web (Chromium). Flows are written once in Maestro YAML, parameterized by `${ROOM_ID}` / `${USER_ID}`, and selected via the app's existing `testID`s — which react-native-web maps to `data-testid`, so the same ids work on web.
+- **Local full-stack harness**: E2E runs against `backend/docker-compose.local.yml` (all six services + Redis + Mongo + nginx gateway on `:8080`), which already exposes a real WebSocket server at `/ws`. No AWS/cloud dependency. A harness script boots the stack, waits for health, and tears it down.
+- **Test isolation**: each test derives a unique `roomId` + `userId` so runs don't contaminate each other, and cleans up (or relies on ephemeral stack state) between runs.
+- **API-injected "actor B"**: cross-user scenarios are driven by a small HTTP helper that performs the *other user's* character writes directly against the backend (`POST/PATCH/DELETE /characters`). This triggers the real Redis → notifications → WebSocket → app path, so actor A's UI update is genuinely end-to-end. (Rationale: what's under test is actor A's inbound-event handling; Maestro also cannot yet drive two devices in one test.)
+- **Crucial-path coverage (first cut)**:
+  - Room lifecycle: create a room, join a room by id, land in the character list.
+  - Character lifecycle: create, edit/quick-edit, change (name/avatar), delete a character.
+  - Cross-user character updates: actor B **creates / updates / deletes** a character while actor A is on the room screen → actor A's list reflects the change (WebSocket-driven), including that actor A's own edits are not double-applied (local-echo suppression).
+- **CI on every PR**: a new `.github/workflows/e2e.yml` runs the suite on all three platforms (web + Android on Linux runners, iOS on a macOS runner) as a required check on pull requests. iOS runner cost is accepted for now and will be re-evaluated later.
+- **Documentation**: a testing guide covering how to run the suite locally per platform (including the Android emulator host `10.0.2.2` gotcha and web `--url` against the exported web build) and how to add new flows.
+
+## Capabilities
+
+### New Capabilities
+- `e2e-testing`: Defines the end-to-end test deliverable — the single-tool (Maestro) cross-platform strategy, the local full-stack harness and test isolation model, the API-injected actor-B mechanism for cross-user scenarios, the first-cut crucial-path flow coverage (room + character lifecycle + cross-user character updates), and the CI gating requirement across iOS/Android/web on every PR.
+
+### Modified Capabilities
+<!-- No existing spec covers testing or CI; this is net-new. -->
+
+## Impact
+
+- **New**: `.github/workflows/e2e.yml`; E2E harness scripts (boot/wait/teardown of the local stack, `roomId`/`userId` generation, actor-B HTTP helper); new Maestro flow files under `maestro/` for room + character lifecycle and cross-user updates; a testing guide doc (e.g. `docs/development-guide-e2e.md` / update `docs/index.md`).
+- **Backend/API**: no code changes — uses the existing local stack (`docker-compose.local.yml`, nginx `/ws`) and existing endpoints (`/rooms`, `/characters`).
+- **App code**: none for the first cut, unless a specific crucial-path element lacks a stable `testID` — any additions are limited to `testID` props (no behavior change). To be confirmed during design/implementation.
+- **Frontend build (web)**: E2E web job runs `expo export --platform web` and serves the static output for Maestro to drive.
+- **CI cost**: adds an iOS macOS-runner job to every PR; cost accepted now, re-evaluated later (possible move to nightly/pre-release if it proves expensive).
+- **Out of scope (separate changes)**: battle flow, shop, log view, and other paths; two-live-client cross-user tests (second driven device); cross-browser web (Maestro Web is Chromium-only); localization/visual-regression assertions.

--- a/openspec/changes/add-e2e-testing/specs/e2e-testing/spec.md
+++ b/openspec/changes/add-e2e-testing/specs/e2e-testing/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Single cross-platform E2E tool
+
+The E2E suite SHALL use Maestro as the single test-authoring tool, with each crucial-path flow defined once and executable on iOS, Android, and web. Flows SHALL select elements by the app's `testID`s (mapped to `data-testid` on web) rather than translated text where a stable `testID` exists, and SHALL be parameterized by `roomId` and `userId`.
+
+#### Scenario: One flow runs on all three platforms
+
+- **WHEN** a crucial-path flow file is executed on the iOS simulator, the Android emulator, and the exported web build
+- **THEN** the same flow definition SHALL drive the app on each platform without a platform-specific copy of the flow
+
+#### Scenario: Stable selectors over translated text
+
+- **WHEN** a flow interacts with an element that has a `testID`
+- **THEN** the flow SHALL select it by that id so the flow is resilient to the app's localization
+
+### Requirement: E2E runs against the local full-stack backend
+
+The E2E suite SHALL run against the local backend stack defined by `backend/docker-compose.local.yml` (all services, Redis, Mongo, and the nginx gateway on port 8080), including the real WebSocket endpoint at `/ws`. A harness SHALL start the stack, wait until it is healthy, and tear it down after the run. The suite SHALL NOT depend on any deployed or cloud environment.
+
+#### Scenario: Stack is ready before flows run
+
+- **WHEN** the harness starts the local stack
+- **THEN** it SHALL wait until the gateway and required services report healthy before executing any flow
+
+#### Scenario: Real WebSocket path is exercised
+
+- **WHEN** a character write occurs against the running stack
+- **THEN** the resulting notification SHALL be delivered to the app over the real `/ws` WebSocket fanout (Redis → room-notifications-service → WebSocket), not a mock
+
+### Requirement: Test isolation via unique room and user identifiers
+
+Each E2E test SHALL derive a unique `roomId` and use distinct `userId`s for the app-under-test and any injected actor, so that concurrent or repeated runs do not interfere with one another. The app-under-test SHALL be launched with cleared state.
+
+#### Scenario: Repeated runs do not collide
+
+- **WHEN** the same test runs twice against the same stack instance
+- **THEN** each run SHALL operate on a distinct room and SHALL NOT observe state produced by the other run
+
+### Requirement: Room lifecycle coverage
+
+The suite SHALL cover creating a room, joining a room by its identifier, and arriving at that room's character list.
+
+#### Scenario: Create a room
+
+- **WHEN** the user creates a new room from the Rooms screen
+- **THEN** the app SHALL navigate into the room and present the character list for that room
+
+#### Scenario: Join a room by id
+
+- **WHEN** the user joins an existing room using its identifier
+- **THEN** the app SHALL navigate into that room and present its character list
+
+### Requirement: Character lifecycle coverage
+
+The suite SHALL cover creating, editing, changing (name and/or avatar), and deleting a character within a room, asserting the resulting list state after each operation.
+
+#### Scenario: Create a character
+
+- **WHEN** the user creates a character in a room
+- **THEN** the new character SHALL appear in that room's character list
+
+#### Scenario: Edit a character
+
+- **WHEN** the user edits a character's editable attributes
+- **THEN** the character's displayed values SHALL reflect the edit
+
+#### Scenario: Delete a character
+
+- **WHEN** the user deletes a character and confirms the deletion
+- **THEN** the character SHALL no longer appear in the room's character list
+
+### Requirement: Cross-user character update coverage
+
+The suite SHALL cover an external actor ("actor B"), injected via direct HTTP calls to the backend as a different user in the same room, whose character writes cause the app-under-test's ("actor A") screen to update over the WebSocket path. Assertions SHALL wait for the update rather than asserting on a fixed delay.
+
+#### Scenario: Actor B creates a character
+
+- **WHEN** actor A is viewing a room's character list and actor B creates a character in that room via the backend
+- **THEN** actor A's list SHALL show actor B's new character without a manual refresh
+
+#### Scenario: Actor B updates a character
+
+- **WHEN** actor A is viewing the room and actor B updates a character in that room via the backend
+- **THEN** actor A's view SHALL reflect the updated character values without a manual refresh
+
+#### Scenario: Actor B deletes a character
+
+- **WHEN** actor A is viewing the room and actor B deletes a character in that room via the backend
+- **THEN** the deleted character SHALL disappear from actor A's list without a manual refresh
+
+#### Scenario: Actor A's own edit is applied exactly once
+
+- **WHEN** actor A edits its own character and the backend echoes the corresponding update event back over the WebSocket
+- **THEN** actor A's list SHALL reflect the edit exactly once, with no duplicated or reverted state from the echoed event
+
+### Requirement: CI gating on every pull request across all platforms
+
+The E2E suite SHALL run in CI as a required check on every pull request, executing on iOS, Android, and web. The suite SHALL also be runnable locally on each platform, with documented setup including the Android emulator host address and the web export/serve steps.
+
+#### Scenario: PR is gated by all three platforms
+
+- **WHEN** a pull request is opened or updated
+- **THEN** the E2E suite SHALL run on iOS, Android, and web, and all three SHALL be required to pass before merge
+
+#### Scenario: Suite is runnable locally
+
+- **WHEN** a developer follows the testing guide for a given platform
+- **THEN** they SHALL be able to boot the stack and run the same flows locally on that platform

--- a/openspec/changes/add-e2e-testing/tasks.md
+++ b/openspec/changes/add-e2e-testing/tasks.md
@@ -1,0 +1,48 @@
+## 1. Local backend harness
+
+- [ ] 1.1 Add a script to boot `backend/docker-compose.local.yml` and wait for readiness (poll `GET :8080/health` and required service health) before returning
+- [ ] 1.2 Add a matching teardown that stops the stack and, in CI, uses fresh volumes so each run starts clean
+- [ ] 1.3 Add a `roomId`/`userId` generator that produces unique ids per test run
+- [ ] 1.4 Add the actor-B HTTP helper (create/update/delete a character as a given `userId` in a given `roomId` against `:8080`), reusable from Maestro `runScript`
+
+## 2. testID audit for first-cut screens
+
+- [ ] 2.1 Walk the room lifecycle (Rooms → create/join → character list) and confirm every element a flow must select has a stable `testID`; add `testID` props where missing (prop-only, no behavior change)
+- [ ] 2.2 Walk the character lifecycle (create, edit/quick-edit, change name/avatar, delete + confirm) and do the same audit/additions
+- [ ] 2.3 Verify `testID`s render as `data-testid` in the web export for the audited screens
+
+## 3. Room + character lifecycle flows
+
+- [ ] 3.1 Author the room lifecycle flow(s): create a room and land in its character list; join a room by id and land in its list — parameterized by `${ROOM_ID}`/`${USER_ID}`, launched with `clearState`
+- [ ] 3.2 Author the character create flow and assert the character appears in the list
+- [ ] 3.3 Author the character edit/quick-edit flow and assert updated values
+- [ ] 3.4 Author the character change (name/avatar) flow and assert the change
+- [ ] 3.5 Author the character delete flow (with confirm) and assert removal
+
+## 4. Cross-user character update flows
+
+- [ ] 4.1 Actor B creates a character (via helper) while actor A views the room → assert it appears in A's list (use `extendedWaitUntil`, no fixed sleep)
+- [ ] 4.2 Actor B updates a character → assert A's view reflects the new values
+- [ ] 4.3 Actor B deletes a character → assert it disappears from A's list
+- [ ] 4.4 Actor A edits its own character and the event echoes back → assert the edit is applied exactly once (local-echo suppression)
+- [ ] 4.5 Ensure flows wait for actor A's WebSocket connection to be established before actor B writes
+
+## 5. Per-platform runtime wiring
+
+- [ ] 5.1 iOS: build/run the dev client on a simulator with `EXPO_PUBLIC_API_URL=http://localhost:8080`; confirm flows pass locally
+- [ ] 5.2 Android: run on an emulator with `EXPO_PUBLIC_API_URL=http://10.0.2.2:8080` (host gotcha); confirm flows pass locally
+- [ ] 5.3 Web: `expo export --platform web`, serve the static output, run `maestro test --url …`; confirm flows pass locally
+
+## 6. CI workflow
+
+- [ ] 6.1 Add `.github/workflows/e2e.yml` with a reusable "boot backend stack" step
+- [ ] 6.2 Web job on a Linux runner (export + serve + Chromium)
+- [ ] 6.3 Android job on a Linux runner (KVM emulator, warm snapshot, boot retry)
+- [ ] 6.4 iOS job on a macOS runner (simulator + dev-client build, with build/Maestro caching)
+- [ ] 6.5 Make all three jobs required checks on pull requests
+- [ ] 6.6 Stabilize: run the workflow until green on all three platforms without retry-on-assertion flakiness
+
+## 7. Documentation
+
+- [ ] 7.1 Add an E2E testing guide (how to boot the stack and run flows per platform, the Android `10.0.2.2` gotcha, the web export/serve steps, and how to add a new flow)
+- [ ] 7.2 Link the guide from `docs/index.md`


### PR DESCRIPTION
## What

Adds an OpenSpec change proposal (`add-e2e-testing`) — planning artifacts only, no implementation code. It captures the agreed plan for an end-to-end test suite covering crucial user paths on **iOS, Android, and web**, including **cross-user character updates** delivered over the app's real-time WebSocket fanout.

Files:
- `proposal.md` — why + what changes
- `design.md` — 6 decisions (with alternatives), 6 risks (with mitigations), migration/rollback, open questions
- `specs/e2e-testing/spec.md` — 7 requirements / 17 testable scenarios
- `tasks.md` — 7 groups, 28 dependency-ordered tasks

## Why

The app is one Expo codebase shipped to three platforms with a real-time cross-user feature at its core, but there's no E2E coverage of crucial paths and nothing verifying "another user changed their character and my screen updated." This proposal establishes that suite and gates it on every PR.

## Key decisions captured

- **Maestro as the single tool** for all three platforms — react-native-web maps `testID` → `data-testid`, so the app's existing testIDs work on web and flows are authored once.
- **Run against the local docker-compose stack** — the local `room-notifications-service` runs a real `ws` server behind nginx `/ws`, so the Redis → notifications → WebSocket → app path is genuinely end-to-end with no cloud dependency. Harness boots/waits/tears down the stack; unique room/user ids per test for isolation.
- **API-injected "actor B"** for cross-user scenarios (Maestro can't drive two devices in one test, and the system under test is actor A's inbound-event handling). Includes the local-echo "applied exactly once" case.
- **First-cut scope**: room + character lifecycle + cross-user character updates. Battle/shop/log deferred to later changes.
- **CI**: all three platforms are required checks on every PR; iOS macOS-runner cost accepted for now, revisit later.

## Reviewer notes

- This PR is **spec/docs only** — no app or backend code changes. Implementation follows via `/opsx:apply add-e2e-testing`.
- Two items are intentionally parked as tasks/open-questions rather than decided here: a **testID audit** (a few first-cut screens may need prop-only `testID` additions) and **file layout** (leaning top-level `maestro/` + `scripts/e2e/` to match existing flows).
- `openspec validate add-e2e-testing` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)